### PR TITLE
Basic Travis CI enabled with pylint and unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: required
+language: python
+
+services:
+  - docker
+
+before_install:
+  - docker pull ubuntu:16.04
+
+python:
+  - "3.5"
+  - "3.6"
+
+install:
+  - pip install -r requirements.txt
+  - pip install pylint
+
+script:
+  - python3 setup.py test
+  - pyline --version
+  - pylint --rcfile=sockeye.pylintrc sockeye -E
+  - pylint --rcfile=sockeye.pylintrc test -E

--- a/sockeye/callback.py
+++ b/sockeye/callback.py
@@ -63,7 +63,7 @@ class TrainingMonitor(object):
         self.start_tic = time.time()
         self.summary_writer = None
         if use_tensorboard:
-            import tensorboard
+            import tensorboard  # pylint: disable=import-error
             log_dir = os.path.join(output_folder, C.TENSORBOARD_NAME)
             if os.path.exists(log_dir):
                 logger.info("Deleting existing tensorboard log dir %s", log_dir)


### PR DESCRIPTION
I've enabled some basic tests and checks to be run with Travis.  After pulling in this PR we'll still have to enable Travis builds, and verify builds are working properly.  Then of course comes the most important step of updating our README with a travis badge.

Small note that the pylint run picked up a missing dep (tensorboard). It's been added in this PR.