### PR TITLE
Support for continuation of aborted training

### DIFF
--- a/docs/user_documentation.md
+++ b/docs/user_documentation.md
@@ -48,8 +48,17 @@ BLEU results reported or with results corresponding to older checkpoints. This
 is expected behaviour and sockeye internally keeps track of the results in the
 correct order.
 
-Note that evaluation metrics for training data and held-out validation data are written in a 
-tab-separated file called `metrics`.
+Note that evaluation metrics for training data and held-out validation data are
+written in a tab-separated file called `metrics`.
+
+At each checkpoint, the internal state of the training process is stored to
+disk. If the training is interrupted (e.g. due to a hardware failure), you can
+start sockeye again, with the same parameters as for the initial call, and
+training will resume from the last checkpoint. Note that this is different to
+using the `--params` argument. This argument is used only to initialize the
+training with pre-computed values for the parameters of the model, but the
+parameters of the optimizer and other parts of the system are initialized from
+scratch.
 
 ### Monitoring training progress with tensorboard
 

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -59,7 +59,7 @@ def add_io_args(params):
                              help='Folder where model & training results are written to.')
     data_params.add_argument('--overwrite-output',
                              action='store_true',
-                             help='Overwrite output folder if it exists')
+                             help='Overwrite output folder if it exists.')
 
     data_params.add_argument('--source-vocab',
                              required=False,

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -57,6 +57,9 @@ def add_io_args(params):
     data_params.add_argument('--output', '-o',
                              required=True,
                              help='Folder where model & training results are written to.')
+    data_params.add_argument('--overwrite-output',
+                             action='store_true',
+                             help='Overwrite output folder if it exists')
 
     data_params.add_argument('--source-vocab',
                              required=False,

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -320,6 +320,7 @@ def add_training_args(params):
                               type=int,
                               default=13,
                               help='Random seed. Default: %(default)s.')
+
     return params
 
 

--- a/sockeye/callback.py
+++ b/sockeye/callback.py
@@ -18,6 +18,7 @@ early-stopping.
 import logging
 import multiprocessing as mp
 import os
+import pickle
 import shutil
 import time
 from typing import Optional, Tuple, Dict
@@ -243,6 +244,21 @@ class TrainingMonitor(object):
         self._empty_decoder_metric_queue()
         self._write_scores()
 
+    def save_state(self, fname):
+        """
+        Save the state: current metrics and best checkpoint
+        """
+        with open(fname, "wb") as fp:
+            pickle.dump(self.metrics, fp)
+            pickle.dump(self.best_checkpoint, fp)
+
+    def load_state(self, fname):
+        """
+        Load the state: current metrics and best checkpoint
+        """
+        with open(fname, "rb") as fp:
+            self.metrics = pickle.load(fp)
+            self.best_checkpoint = pickle.load(fp)
 
 def _decode_and_evaluate(checkpoint_decoder: sockeye.checkpoint_decoder.CheckpointDecoder,
                          checkpoint: int,

--- a/sockeye/callback.py
+++ b/sockeye/callback.py
@@ -244,17 +244,21 @@ class TrainingMonitor(object):
         self._empty_decoder_metric_queue()
         self._write_scores()
 
-    def save_state(self, fname):
+    def save_state(self, fname: str):
         """
-        Save the state: current metrics and best checkpoint
+        Saves the state: current metrics and best checkpoint.
+
+        :param fname: Name of the file to save the state to.
         """
         with open(fname, "wb") as fp:
             pickle.dump(self.metrics, fp)
             pickle.dump(self.best_checkpoint, fp)
 
-    def load_state(self, fname):
+    def load_state(self, fname: str):
         """
-        Load the state: current metrics and best checkpoint
+        Loads the state: current metrics and best checkpoint.
+
+        :param fname: Name of the file to load the state from.
         """
         with open(fname, "rb") as fp:
             self.metrics = pickle.load(fp)

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -93,6 +93,9 @@ SCHEDULER_STATE_NAME = "scheduler.pkl"
 TRAINING_STATE_PARAMS_NAME = "params"
 ARGS_STATE_NAME = "args.json"
 
+# Arguments that may differ and still resume training
+ARGS_MAY_DIFFER = ["overwrite_output", "use-tensorboard", "quiet", "align_plot_prefix", "sure_align_threshold"]
+
 # data layout strings
 BATCH_MAJOR = "NTC"
 TIME_MAJOR = "TNC"

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -80,6 +80,7 @@ SYMBOL_NAME = "symbol" + JSON_SUFFIX
 METRICS_NAME = "metrics"
 TENSORBOARD_NAME = "tensorboard"
 
+# training resumption constants
 TRAINING_STATE_DIRNAME= "training_state"
 TRAINING_STATE_TEMP_DIRNAME = "tmp.training_state"
 TRAINING_STATE_TEMP_DELETENAME = "delete.training_state"

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -80,6 +80,17 @@ SYMBOL_NAME = "symbol" + JSON_SUFFIX
 METRICS_NAME = "metrics"
 TENSORBOARD_NAME = "tensorboard"
 
+TRAINING_STATE_DIRNAME= "training_state"
+TRAINING_STATE_TEMP_DIRNAME = "tmp.training_state"
+TRAINING_STATE_TEMP_DELETENAME = "delete.training_state"
+MODULE_OPT_STATE_NAME = "mx_optimizer.pkl"
+BUCKET_ITER_STATE_NAME = "bucket.pkl"
+RNG_STATE_NAME = "rng.pkl"
+MONITOR_STATE_NAME = "monitor.pkl"
+TRAINING_STATE_NAME = "training.pkl"
+SCHEDULER_STATE_NAME = "scheduler.pkl"
+TRAINING_STATE_PARAMS_NAME = "params"
+
 # data layout strings
 BATCH_MAJOR = "NTC"
 TIME_MAJOR = "TNC"

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -91,6 +91,7 @@ MONITOR_STATE_NAME = "monitor.pkl"
 TRAINING_STATE_NAME = "training.pkl"
 SCHEDULER_STATE_NAME = "scheduler.pkl"
 TRAINING_STATE_PARAMS_NAME = "params"
+ARGS_STATE_NAME = "args.json"
 
 # data layout strings
 BATCH_MAJOR = "NTC"

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -439,8 +439,8 @@ class ParallelBucketSentenceIter(mx.io.DataIter):
         Appends the actual data, selected by the given indices, to the NDArrays
         of the appropriate bucket. Use when reshuffling the data.
 
-        :param bucket: Current bucket
-        :param shuffled_indices: Indices indicating which data to select
+        :param bucket: Current bucket.
+        :param shuffled_indices: Indices indicating which data to select.
         """
         self.nd_source.append(mx.nd.array(self.data_source[bucket].take(shuffled_indices, axis=0), dtype=self.dtype))
         self.nd_length.append(mx.nd.array(self.data_length[bucket].take(shuffled_indices, axis=0), dtype=self.dtype))

--- a/sockeye/lr_scheduler.py
+++ b/sockeye/lr_scheduler.py
@@ -100,7 +100,6 @@ class LearningRateSchedulerPlateauReduce(LearningRateScheduler):
         self.reduce_factor = reduce_factor
         self.reduce_num_not_improved = reduce_num_not_improved
         self.num_not_improved = 0
-        self.logger = logging.getLogger("LearningRateSchedulerPlateauReduce")
         # Note: will be overwritten by optimizer in mxnet
         self.base_lr = None  # type: float
         self.lr = None  # type: float
@@ -118,7 +117,7 @@ class LearningRateSchedulerPlateauReduce(LearningRateScheduler):
             self.num_not_improved += 1
             if self.num_not_improved >= self.reduce_num_not_improved:
                 self.lr *= self.reduce_factor
-                self.logger.info("Validation score hasn't improved for %d checkpoints, "
+                logger.info("Validation score hasn't improved for %d checkpoints, "
                                  "lowering learning rate to %1.2e", self.num_not_improved, self.lr)
                 self.num_not_improved = 0
 

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -319,9 +319,9 @@ class TrainingModel(sockeye.model.SockeyeModel):
 
     def _save_params(self, output_folder: str, checkpoint: int):
         """
-        Save the parameters to disk.
+        Saves the parameters to disk.
         """
-        arg_params, aux_params = self.module.get_params() # sync aux params across devices
+        arg_params, aux_params = self.module.get_params()  # sync aux params across devices
         self.module.set_params(arg_params, aux_params)
         self.params = arg_params
         params_base_fname = C.PARAMS_NAME % checkpoint
@@ -403,14 +403,18 @@ class TrainingModel(sockeye.model.SockeyeModel):
 
     def save_state(self, training_state: _TrainingState, fname: str):
         """
-        Saves the state (of the TrainingModel class) to disk
+        Saves the state (of the TrainingModel class) to disk.
+
+        :param fname: file name to save the state to.
         """
         with open(fname, "wb") as fp:
             pickle.dump(training_state, fp)
 
     def load_state(self, fname: str) -> _TrainingState:
         """
-        Loads the training state (of the TrainingModel class) from disk
+        Loads the training state (of the TrainingModel class) from disk.
+
+        :param fname: file name to load the state from.
         """
         training_state = None
         with open(fname, "rb") as fp:

--- a/test/test_checkpoint.py
+++ b/test/test_checkpoint.py
@@ -1,0 +1,83 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+# 
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from math import isclose
+import mxnet as mx
+import random
+import tempfile
+
+import sockeye.data_io
+
+def generate_random_sentence(vocab_size, max_len):
+    length = random.randint(1, max_len)
+    sentence = []
+    for _ in range(length):
+        sentence.append(random.randint(3, vocab_size + 2))
+    return sentence
+
+def create_ParallelBucketSentenceIter(source_sentences, target_sentences, max_len):
+    buckets = sockeye.data_io.define_parallel_buckets(max_len, 10)
+    batch_size = 50
+    eos = 0
+    pad = 1
+    unk = 2
+    bucket_iterator = sockeye.data_io.ParallelBucketSentenceIter(source_sentences,
+                                                         target_sentences,
+                                                         buckets,
+                                                         batch_size,
+                                                         eos, pad, unk)
+    return bucket_iterator
+
+def data_batches_equal(db1, db2):
+    # We just compare the data, should probably be enough
+    equal = True
+    for data1, data2 in zip(db1.data, db2.data):
+        equal = equal \
+                and (data1.shape == data2.shape) \
+                and isclose(mx.nd.prod(data1.reshape((-1,)) == data2.reshape((-1,))).asnumpy()[0], 1.0)
+    return equal
+
+def test_ParallelBucketSentenceIter():
+    # Create random sentences
+    vocab_size = 100
+    max_len = 100
+    source_sentences = []
+    target_sentences = []
+    for _ in range(1000):
+        source_sentences.append(generate_random_sentence(vocab_size, max_len))
+        target_sentences.append(generate_random_sentence(vocab_size, max_len))
+
+    ori_iterator = create_ParallelBucketSentenceIter(source_sentences, target_sentences, max_len)
+    ori_iterator.reset() # Random order
+    # Simulate some iterations
+    ori_iterator.next()
+    ori_iterator.next()
+    ori_iterator.next()
+    ori_iterator.next()
+    expected_output = ori_iterator.next()
+    # expected_output because the user is expected to call next() after loading
+
+    # Save the state to disk
+    tmp_file = tempfile.NamedTemporaryFile()
+    ori_iterator.save_state(tmp_file.name)
+
+    # Load the state in a new iterator
+    load_iterator = create_ParallelBucketSentenceIter(source_sentences, target_sentences, max_len)
+    load_iterator.reset() # Random order
+    load_iterator.load_state(tmp_file.name)
+
+    # Compare the outputs
+    loaded_output = load_iterator.next()
+    assert data_batches_equal(expected_output, loaded_output)
+
+

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -75,7 +75,7 @@ def generate_random_sentence(vocab_size, max_len):
     :param vocab_size: Number of words in the "vocabulary". Note that due to
                        the inclusion of special words (BOS, EOS, UNK) this does *not*
                        correspond to the maximum possible value.
-    :param max_len: maximum sentence lenght
+    :param max_len: maximum sentence length.
     """
     length = random.randint(1, max_len)
     # Due to the special words, the actual words start at index 3 and go up to vocab_size+2

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -15,6 +15,7 @@ import sockeye.utils
 import numpy as np
 import mxnet as mx
 import numpy as np
+import random
 
 
 def test_get_alignments():
@@ -66,3 +67,16 @@ def uniform_vector(shape, min_value=0, max_value=1, return_symbol=False):
     """
     return mx.sym.random_uniform(low=min_value, high=max_value, shape=shape) if return_symbol \
         else np.random.uniform(low=min_value, high=max_value, size=shape)
+
+def generate_random_sentence(vocab_size, max_len):
+    """
+    Generates a random "sentence" as a list of integers.
+
+    :param vocab_size: Number of words in the "vocabulary". Note that due to
+                       the inclusion of special words (BOS, EOS, UNK) this does *not*
+                       correspond to the maximum possible value.
+    :param max_len: maximum sentence lenght
+    """
+    length = random.randint(1, max_len)
+    # Due to the special words, the actual words start at index 3 and go up to vocab_size+2
+    return [random.randint(3, vocab_size + 2) for _ in range(length)]


### PR DESCRIPTION
Transparently continue a training if it was aborted. **Important:** Start sockeye with exactly the same arguments.

Because of the asynchronous decoding for BLEU evaluation, some BLEU scores may get lost in the continuation, but this should not have a big effect on the final result.

Results are not yet 100% equal in the continuation, but are certainly in the same range. There must be still some part of the "traning state" missing, put it is surely usable, especially if dealing with long trainings.