### PR TITLE
bugfix when counting vocab coverage

### DIFF
--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -352,7 +352,7 @@ class ParallelBucketSentenceIter(mx.io.DataIter):
             tokens_source += len(source)
             tokens_target += len(target)
             num_of_unks_source += source.count(self.unk_id)
-            num_of_unks_source += target.count(self.unk_id)
+            num_of_unks_target += target.count(self.unk_id)
 
             buck_idx, buck = self._get_bucket(self.buckets, len(source), len(target))
             if buck is None:


### PR DESCRIPTION
Small bug in the I/O that would add unks from the target sentence to the source counts. This seems to only affect logging though.