### PR TITLE
Allow automatic acquisition of n GPUs through --device-ids -n

### DIFF
--- a/docs/user_documentation.md
+++ b/docs/user_documentation.md
@@ -78,20 +78,22 @@ Then start tensorboard and point it to the model directory (or any parent direct
 ### CPU/GPU training
 
 By default, training is carried out on the first GPU device of your machine.
-You can specify alternative devices with the `--device-ids` option, with
+You can specify alternative GPU devices with the `--device-ids` option, with
 which you can also activate multi-GPU training (see below). If
 `--device-ids -1`, sockeye will try to find a free GPU on your machine and block
-until one is available. The locking mechanism is based on files and therefore assumes all processes are running
+until all of them are available. The locking mechanism is based on files and therefore assumes all processes are running
 on the same machine with the same file system.
 If this is not the case there is a chance that two processes will be using the same GPU and you run out of GPU memory.
 If you do not have or do not want to use a GPU, specify `--use-cpu`.
 In this case a drop in performance is expected.
 
-Training can be carried out on multiple GPUs using the `--device-ids` flag and specifying multiple GPU device ids:
-`--device-ids 0 1 2 3`.
+##### Multi-GPU training
+Training can be carried out on multiple GPUs by either specifying multiple GPU device ids:
+`--device-ids 0 1 2 3`, or specifying the number GPUs required: `--device-ids -n` attempts to acquire `n` GPUs through
+the locking mechanism described above.
 This will train using [Data Parallelism](https://github.com/dmlc/mxnet/blob/master/docs/how_to/multi_devices.md).
 MXNet will divide the data in each batch and send it to the different devices.
-Note that you should increase the batch size, for k GPUs use ``--batch-size k*<original_batch_size>``.
+Note that you should increase the batch size: for `k` GPUs use ``--batch-size k*<original_batch_size>``.
 Also note that this will likely linearly increase your throughput in terms of sentences/second, but not necessarily
 increase the model's convergence speed.
 

--- a/docs/user_documentation.md
+++ b/docs/user_documentation.md
@@ -81,7 +81,7 @@ By default, training is carried out on the first GPU device of your machine.
 You can specify alternative GPU devices with the `--device-ids` option, with
 which you can also activate multi-GPU training (see below). If
 `--device-ids -1`, sockeye will try to find a free GPU on your machine and block
-until all of them are available. The locking mechanism is based on files and therefore assumes all processes are running
+until one is available. The locking mechanism is based on files and therefore assumes all processes are running
 on the same machine with the same file system.
 If this is not the case there is a chance that two processes will be using the same GPU and you run out of GPU memory.
 If you do not have or do not want to use a GPU, specify `--use-cpu`.

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -86,7 +86,7 @@ def add_device_args(params):
 
     device_params.add_argument('--device-ids', default=[-1],
                                help='List or number of GPUs ids to use. Default: %(default)s. '
-                                    'Use -x to automatically acquire x GPUs through a file locking mechanism. '
+                                    'Use -x to automatically acquire x GPUs. '
                                     'Use x [x] to use a specific GPU id on this host. '
                                     '(Note that automatic acquisition of GPUs assumes that all GPU processes on '
                                     'this host are using automatic sockeye GPU acquisition).',

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -85,9 +85,11 @@ def add_device_args(params):
     device_params = params.add_argument_group("Device parameters")
 
     device_params.add_argument('--device-ids', default=[-1],
-                               help='List of GPU ids to use. Default: %(default)s. '
-                                    'Use -1 to automatically acquire a GPU through a file locking mechanism. '
-                                    '(Note that this assumes GPU processes are using automatic sockeye GPU ids).',
+                               help='List or number of GPUs ids to use. Default: %(default)s. '
+                                    'Use -x to automatically acquire x GPUs through a file locking mechanism. '
+                                    'Use x [x] to use a specific GPU id on this host. '
+                                    '(Note that automatic acquisition of GPUs assumes that all GPU processes on '
+                                    'this host are using automatic sockeye GPU acquisition).',
                                nargs='+', type=int)
     device_params.add_argument('--use-cpu',
                                action='store_true',

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -273,7 +273,7 @@ def get_num_gpus() -> int:
 @contextmanager
 def acquire_gpu(lock_dir: str = "/var/lock", retry_wait: int = 10):
     """
-    Acquires a gpu by locking a file (therefore this assumes that everyone using gpus calls this method and shares the
+    Acquires a GPU by locking a file (therefore this assumes that everyone using GPUs calls this method and shares the
     lock directory).
 
     :param lock_dir: The directory for storing the lock file.
@@ -281,7 +281,7 @@ def acquire_gpu(lock_dir: str = "/var/lock", retry_wait: int = 10):
     """
     num_gpus = get_num_gpus()
 
-    logger.info("Trying to acquire one of the %d gpus", num_gpus)
+    logger.info("Trying to acquire one of %d available GPUs.", num_gpus)
 
     # try to acquire a GPU lock
     while True:
@@ -307,7 +307,7 @@ def acquire_gpu(lock_dir: str = "/var/lock", retry_wait: int = 10):
                 except IOError as e:
                     # raise on unrelated IOErrors
                     if e.errno != errno.EAGAIN:
-                        logger.error("Failed acquiring gpu lock.", exc_info=True)
+                        logger.error("Failed acquiring GPU lock.", exc_info=True)
                         raise
                     else:
                         logger.info("GPU %d is currently locked." % gpu_id,


### PR DESCRIPTION
More flexible way of automatically acquiring multiple GPUs.

```--device-ids -4``` is equivalent to ```--device-ids -1 -2 -1```