### PR TITLE
Split the _beam_search() method into two parts to enable access to the full beam

### DIFF
--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -510,7 +510,7 @@ class Translator:
         # TODO: max_output_length adaptive to source_length
         max_output_length = bucket_key * 2
 
-        return self._beam_search(source, source_length, bucket_key, max_output_length)
+        return self._get_best_from_beam(*self._beam_search(source, source_length, bucket_key, max_output_length))
 
     def _combine_predictions(self,
                              predictions: List[mx.nd.NDArray],
@@ -532,9 +532,15 @@ class Translator:
                      source: mx.nd.NDArray,
                      source_length: mx.nd.NDArray,
                      bucket_key: int,
-                     max_output_length: int) -> Tuple[List[int], np.ndarray, float]:
+                     max_output_length: int) -> Tuple[List[List[int]], List[np.ndarray], mx.nd.NDArray]:
         """
-        Translates a single sentence using beam search.
+            Translates a single sentence using beam search.
+            :param source: Source array.
+            :param source_length: Length of source.
+            :param bucket_key: Bucket key.
+            :param max_output_length: Cap the output at this maximum length.
+            :return List of lists of word ids, list of attentions, array of accumulated length-normalized
+            negative log-probs.
         """
 
         # encode source and initialize decoder states for each model
@@ -638,7 +644,20 @@ class Translator:
                                     next_dynamic_source in model_next_dynamic_source]
             model_decoder_states = [[mx.nd.take(state, prev_hyp_indices_nd) for state in decoder_states] for
                                     decoder_states in model_next_decoder_states]
+        
+        return sequences, attention_lists, accumulated_scores
 
+    def _get_best_from_beam(self,
+                            sequences: List[List[int]], 
+                            attention_lists: List[np.ndarray],
+                            accumulated_scores: mx.nd.NDArray) -> Tuple[List[int], np.ndarray, float]:
+        """
+            Return the best (aka top) entry from the n-best list.
+            :param sequences: List of lists of word ids.
+            :param attention_lists: List of attention.
+            :param accumulated_scores: Array of length-normalized negative log-probs.
+            :return: Top sequence, top attention matrix, top accumulated score (length-normalized negative log-probs).
+        """
         # sequences & accumulated scores are in latest 'k-best order', thus 0th element is best
         best = 0
         # attention_matrix: (target_seq_len, source_seq_len)

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -649,8 +649,7 @@ class Translator:
         return sequences, attention_lists, accumulated_scores
 
     @staticmethod
-    def _get_best_from_beam(self,
-                            sequences: List[List[int]], 
+    def _get_best_from_beam(sequences: List[List[int]], 
                             attention_lists: List[np.ndarray],
                             accumulated_scores: mx.nd.NDArray) -> Tuple[List[int], np.ndarray, float]:
         """

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -534,13 +534,14 @@ class Translator:
                      bucket_key: int,
                      max_output_length: int) -> Tuple[List[List[int]], List[np.ndarray], mx.nd.NDArray]:
         """
-            Translates a single sentence using beam search.
-            :param source: Source array.
-            :param source_length: Length of source.
-            :param bucket_key: Bucket key.
-            :param max_output_length: Cap the output at this maximum length.
-            :return List of lists of word ids, list of attentions, array of accumulated length-normalized
-            negative log-probs.
+        Translates a single sentence using beam search.
+
+        :param source: Source array.
+        :param source_length: Length of source.
+        :param bucket_key: Bucket key.
+        :param max_output_length: Cap the output at this maximum length.
+        :return List of lists of word ids, list of attentions, array of accumulated length-normalized
+        negative log-probs.
         """
 
         # encode source and initialize decoder states for each model
@@ -647,16 +648,18 @@ class Translator:
         
         return sequences, attention_lists, accumulated_scores
 
+    @staticmethod
     def _get_best_from_beam(self,
                             sequences: List[List[int]], 
                             attention_lists: List[np.ndarray],
                             accumulated_scores: mx.nd.NDArray) -> Tuple[List[int], np.ndarray, float]:
         """
-            Return the best (aka top) entry from the n-best list.
-            :param sequences: List of lists of word ids.
-            :param attention_lists: List of attention.
-            :param accumulated_scores: Array of length-normalized negative log-probs.
-            :return: Top sequence, top attention matrix, top accumulated score (length-normalized negative log-probs).
+        Return the best (aka top) entry from the n-best list.
+
+        :param sequences: List of lists of word ids.
+        :param attention_lists: List of attention.
+        :param accumulated_scores: Array of length-normalized negative log-probs.
+        :return: Top sequence, top attention matrix, top accumulated score (length-normalized negative log-probs).
         """
         # sequences & accumulated scores are in latest 'k-best order', thus 0th element is best
         best = 0


### PR DESCRIPTION
Might be useful if some external code needs full beams, not just the best hypothesis.