### PR TITLE
Distinguish num-checkpoint-not-improved for stopping training and reducing learning rate in logger.info

### DIFF
--- a/sockeye/lr_scheduler.py
+++ b/sockeye/lr_scheduler.py
@@ -117,7 +117,7 @@ class LearningRateSchedulerPlateauReduce(LearningRateScheduler):
             self.num_not_improved += 1
             if self.num_not_improved >= self.reduce_num_not_improved:
                 self.lr *= self.reduce_factor
-                logger.info("Validation score hasn't improved for %d checkpoints, "
+                logger.info("%d checkpoints since validation score improvement or rate scaling, "
                                  "lowering learning rate to %1.2e", self.num_not_improved, self.lr)
                 self.num_not_improved = 0
 

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -315,6 +315,7 @@ class TrainingModel(sockeye.model.SockeyeModel):
                         shutil.rmtree(final_training_state_dirname)
                     break
                 else:
+                    logger.info("Model has not improved for %d checkpoints.", training_state.num_not_improved)
                     self._checkpoint(training_state, output_folder, train_iter)
 
     def _save_params(self, output_folder: str, checkpoint: int):


### PR DESCRIPTION
Two different actions would be activated after certain number of checkpoints without improvements.
1) Stop training, controlled by --max-num-checkpoint-not-improved
2) Reducing learning rate, controlled by --learning-rate-reduce-num-not-improved
The modified logger info makes it easier for users to distinguish between them.