### PR TITLE
Allow for dropout in all decoder layers and fix resetting of rnn layers in decoder.decode().

### DIFF
--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -363,6 +363,8 @@ class StackedRNNDecoder(Decoder):
         lexical_biases = []
 
         self.rnn.reset()
+        for cell in self.rnn._cells:
+            cell.reset()
 
         for seq_idx in range(target_seq_len):
             # hidden: (batch_size, rnn_num_hidden)

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -363,6 +363,7 @@ class StackedRNNDecoder(Decoder):
         lexical_biases = []
 
         self.rnn.reset()
+        # TODO remove this once mxnet.rnn.SequentialRNNCell.reset() invokes recursive calls on layer cells
         for cell in self.rnn._cells:
             cell.reset()
 

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -70,7 +70,7 @@ def get_encoder(num_embed: int,
     if num_layers > 1:
         encoders.append(EncoderClass(num_hidden=rnn_num_hidden,
                                      num_layers=num_layers - 1,
-                                     dropout=0.,
+                                     dropout=dropout,
                                      layout=C.TIME_MAJOR,
                                      cell_type=cell_type,
                                      residual=residual,


### PR DESCRIPTION
Before the layers in layer._counter for each rnn layer would grow indefinitely.