### PR TITLE
Refactored beam search to use only MX NDArray operations (except topk). Achieves ~13% speedup on GPU.

### DIFF
--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -21,20 +21,18 @@ from typing import Dict, List, NamedTuple, Optional, Tuple
 import mxnet as mx
 import numpy as np
 
-import sockeye.bleu
-import sockeye.constants as C
-import sockeye.data_io
-import sockeye.model
-import sockeye.utils
-import sockeye.vocab
-from sockeye.attention import AttentionState
-from sockeye.decoder import DecoderState
-from sockeye.utils import check_condition
+from . import attention
+from . import constants as C
+from . import data_io
+from . import decoder
+from . import model
+from . import utils
+from . import vocab
 
 logger = logging.getLogger(__name__)
 
 
-class InferenceModel(sockeye.model.SockeyeModel):
+class InferenceModel(model.SockeyeModel):
     """
     InferenceModel is a SockeyeModel that supports three operations used for inference/decoding:
 
@@ -60,7 +58,7 @@ class InferenceModel(sockeye.model.SockeyeModel):
                  checkpoint: Optional[int] = None,
                  softmax_temperature: Optional[float] = None):
         # load config & determine parameter file
-        super().__init__(sockeye.model.SockeyeModel.load_config(os.path.join(model_folder, C.CONFIG_NAME)))
+        super().__init__(model.SockeyeModel.load_config(os.path.join(model_folder, C.CONFIG_NAME)))
         fname_params = os.path.join(model_folder, C.PARAMS_NAME % checkpoint if checkpoint else C.PARAMS_BEST_NAME)
 
         if max_input_len is None:
@@ -71,8 +69,8 @@ class InferenceModel(sockeye.model.SockeyeModel):
                                self.config.max_seq_len, max_input_len)
         self.max_input_len = max_input_len
 
-        check_condition(beam_size < self.config.vocab_target_size,
-                        'The beam size must be smaller than the target vocabulary size.')
+        utils.check_condition(beam_size < self.config.vocab_target_size,
+                              'The beam size must be smaller than the target vocabulary size.')
 
         self.beam_size = beam_size
         self.softmax_temperature = softmax_temperature
@@ -126,8 +124,8 @@ class InferenceModel(sockeye.model.SockeyeModel):
         word_id_prev = mx.sym.Variable(C.TARGET_PREVIOUS_NAME)
         hidden_prev = mx.sym.Variable(C.HIDDEN_PREVIOUS_NAME)
         layer_states, self.layer_shapes, layer_names = self.decoder.create_layer_input_variables(self.beam_size)
-        state = DecoderState(hidden_prev, layer_states)
-        attention_state = AttentionState(context=None, probs=None, dynamic_source=dynamic_source_prev)
+        state = decoder.DecoderState(hidden_prev, layer_states)
+        attention_state = attention.AttentionState(context=None, probs=None, dynamic_source=dynamic_source_prev)
 
         def decoder_sym_gen(source_seq_len: int):
             data_names = [C.SOURCE_ENCODED_NAME,
@@ -253,7 +251,6 @@ class InferenceModel(sockeye.model.SockeyeModel):
         decoder_hidden_init = mx.nd.tile(decoder_hidden_init, reps=(self.beam_size, 1))
         decoder_states = [mx.nd.tile(state, reps=(self.beam_size, 1)) for state in decoder_states]
         source_length = mx.nd.tile(source_length, reps=(self.beam_size,))
-
         return encoded_source, source_dynamic_init, source_length, decoder_hidden_init, decoder_states
 
     def run_decoder(self,
@@ -320,9 +317,8 @@ def load_models(context: mx.context.Context,
     if checkpoints is None:
         checkpoints = [None] * len(model_folders)
     for model_folder, checkpoint in zip(model_folders, checkpoints):
-
-        source_vocabs.append(sockeye.vocab.vocab_from_json_or_pickle(os.path.join(model_folder, C.VOCAB_SRC_NAME)))
-        target_vocabs.append(sockeye.vocab.vocab_from_json_or_pickle(os.path.join(model_folder, C.VOCAB_TRG_NAME)))
+        source_vocabs.append(vocab.vocab_from_json_or_pickle(os.path.join(model_folder, C.VOCAB_SRC_NAME)))
+        target_vocabs.append(vocab.vocab_from_json_or_pickle(os.path.join(model_folder, C.VOCAB_TRG_NAME)))
         model = InferenceModel(model_folder=model_folder,
                                context=context,
                                fused=False,
@@ -372,6 +368,37 @@ Output structure from Translator.
 """
 
 
+class ModelState:
+    """
+    A ModelState encapsulates information about the decoder state of an InferenceModel.
+    """
+
+    def __init__(self,
+                 bucket_key: int,
+                 prev_target_word_id: mx.nd.NDArray,
+                 source_encoded: mx.nd.NDArray,
+                 source_dynamic: mx.nd.NDArray,
+                 source_length: mx.nd.NDArray,
+                 decoder_hidden: mx.nd.NDArray,
+                 decoder_states: List[mx.nd.NDArray]):
+        self.bucket_key = bucket_key
+        self.prev_target_word_id = prev_target_word_id
+        self.source_encoded = source_encoded
+        self.source_dynamic = source_dynamic
+        self.source_length = source_length
+        self.decoder_states = decoder_states
+        self.decoder_hidden = decoder_hidden
+
+    def sort_state(self, best_hyp_indices: mx.nd.NDArray, best_word_indices: mx.nd.NDArray):
+        """
+        Sorts states according to k-best order from last step in beam search.
+        """
+        self.prev_target_word_id = best_word_indices
+        self.source_dynamic = mx.nd.take(self.source_dynamic, best_hyp_indices)
+        self.decoder_hidden = mx.nd.take(self.decoder_hidden, best_hyp_indices)
+        self.decoder_states = [mx.nd.take(ds, best_hyp_indices) for ds in self.decoder_states]
+
+
 class Translator:
     """
     Translator uses one or several models to translate input.
@@ -394,13 +421,14 @@ class Translator:
         self.context = context
         self.vocab_source = vocab_source
         self.vocab_target = vocab_target
-        self.vocab_target_inv = sockeye.vocab.reverse_vocab(self.vocab_target)
+        self.vocab_target_inv = vocab.reverse_vocab(self.vocab_target)
         self.start_id = self.vocab_target[C.BOS_SYMBOL]
         self.stop_ids = {self.vocab_target[C.EOS_SYMBOL], C.PAD_ID}
         self.models = models
         self.interpolation_func = self._get_interpolation_func(ensemble_mode)
         self.beam_size = self.models[0].beam_size
-        self.buckets = sockeye.data_io.define_buckets(self.models[0].max_input_len)
+        self.buckets = data_io.define_buckets(self.models[0].max_input_len)
+        self.pad_dist = mx.nd.zeros((self.beam_size, len(self.vocab_target)), ctx=self.context) + np.inf
         logger.info("Translator (%d model(s) beam_size=%d ensemble_mode=%s)",
                     len(self.models), self.beam_size, "None" if len(self.models) == 1 else ensemble_mode)
 
@@ -415,14 +443,14 @@ class Translator:
 
     @staticmethod
     def _linear_interpolation(predictions):
-        return -mx.nd.log(sockeye.utils.average_arrays(predictions))
+        return -mx.nd.log(utils.average_arrays(predictions))
 
     @staticmethod
     def _log_linear_interpolation(predictions):
         """
         Returns averaged and re-normalized log probabilities
         """
-        log_probs = sockeye.utils.average_arrays([mx.nd.log(p) for p in predictions])
+        log_probs = utils.average_arrays([mx.nd.log(p) for p in predictions])
         return -mx.nd.log(mx.nd.softmax(log_probs))
 
     @staticmethod
@@ -434,7 +462,7 @@ class Translator:
         :param sentence: Input sentence.
         :return: Input for translate method.
         """
-        tokens = list(sockeye.data_io.get_tokens(sentence))
+        tokens = list(data_io.get_tokens(sentence))
         return TranslatorInput(id=sentence_id, sentence=sentence.rstrip(), tokens=tokens)
 
     def translate(self, trans_input: TranslatorInput) -> TranslatorOutput:
@@ -455,18 +483,20 @@ class Translator:
 
     def _get_inference_input(self, tokens: List[str]) -> Tuple[mx.nd.NDArray, mx.nd.NDArray, Optional[int]]:
         """
-        Returns NDArray of source ids, NDArray of sentence length, and corresponding bucket_key
+        Returns NDArray of source ids (shape=(1, bucket_key)),
+        NDArray of sentence length (shape=(1,)), and corresponding bucket_key.
 
         :param tokens: List of input tokens.
+        :return NDArray of source ids, NDArray of sentence length, and bucket key.
         """
-        bucket_key = sockeye.data_io.get_bucket(len(tokens), self.buckets)
+        bucket_key = data_io.get_bucket(len(tokens), self.buckets)
         if bucket_key is None:
             logger.warning("Input (%d) exceeds max bucket size (%d). Stripping", len(tokens), self.buckets[-1])
             bucket_key = self.buckets[-1]
             tokens = tokens[:bucket_key]
 
         source = mx.nd.zeros((1, bucket_key))
-        ids = sockeye.data_io.tokens2ids(tokens, self.vocab_source)
+        ids = data_io.tokens2ids(tokens, self.vocab_source)
         for i, wid in enumerate(ids):
             source[0, i] = wid
         length = mx.nd.array([len(ids)])
@@ -491,19 +521,22 @@ class Translator:
             target_token for target_id, target_token in zip(target_ids, target_tokens) if
             target_id not in self.stop_ids)
         attention_matrix = attention_matrix[:, :len(trans_input.tokens)]
+
         return TranslatorOutput(id=trans_input.id,
                                 translation=target_string,
                                 tokens=target_tokens,
                                 attention_matrix=attention_matrix,
                                 score=neg_logprob)
 
-    def translate_nd(self, source: mx.nd.NDArray, source_length: mx.nd.NDArray, bucket_key: int) \
-            -> Tuple[List[int], np.ndarray, float]:
+    def translate_nd(self,
+                     source: mx.nd.NDArray,
+                     source_length: mx.nd.NDArray,
+                     bucket_key: int) -> Tuple[np.ndarray, np.ndarray, float]:
         """
         Translates source of source_length, given a bucket_key.
 
-        :param source: Source.
-        :param source_length: Source length.
+        :param source: Source ids. Shape: (1, bucket_key).
+        :param source_length: Source length. Shape: (1,).
         :param bucket_key: Bucket key.
 
         :return: Sequence of translated ids, attention matrix, length-normalized negative log probability.
@@ -514,156 +547,165 @@ class Translator:
 
         return self._get_best_from_beam(*self._beam_search(source, source_length, bucket_key, max_output_length))
 
-    def _combine_predictions(self,
-                             predictions: List[mx.nd.NDArray],
-                             attention_prob_scores: List[mx.nd.NDArray]) -> Tuple[mx.nd.NDArray, np.ndarray]:
+    def _encode(self, source: mx.nd.NDArray, source_length: mx.nd.NDArray, bucket_key: int) -> List[ModelState]:
         """
-        Returns combined predictions of models as negative log probabilities, as well as averaged attention prob scores.
+        Returns a ModelState for each model representing the state of the model after encoding the source.
+
+        :param source: Source ids. Shape: (1, bucket_key).
+        :param source_length: Source length. Shape: (1,).
+        :param bucket_key: Bucket key.
+        :return: List of ModelStates.
+        """
+        prev_target_word_id = mx.nd.zeros((self.beam_size,), ctx=self.context)
+        prev_target_word_id[:] = self.start_id
+        model_states = [ModelState(bucket_key,
+                                   prev_target_word_id,
+                                   *m.run_encoder(source, source_length, bucket_key))
+                        for m in self.models]
+        return model_states
+
+    def _decode_step(self, states: List[ModelState]) -> Tuple[mx.nd.NDArray, mx.nd.NDArray, List[ModelState]]:
+        """
+        Returns decoder predictions (combined from all models), attention scores, and updated states.
+
+        :param: List of model states.
+        :return: (probs, attention scores, list of model states)
+        """
+        model_probs, model_attention_scores = [], []
+        for m, s in zip(self.models, states):
+            probs, attention_scores, s.source_dynamic, s.decoder_hidden, s.decoder_states = m.run_decoder(
+                s.source_encoded,
+                s.source_dynamic,
+                s.source_length,
+                s.prev_target_word_id,
+                s.decoder_hidden,
+                s.decoder_states,
+                s.bucket_key)
+            model_probs.append(probs)
+            model_attention_scores.append(attention_scores)
+        probs, attention_scores = self._combine_predictions(model_probs, model_attention_scores)
+        return probs, attention_scores, states
+
+    def _combine_predictions(self,
+                             probs: List[mx.nd.NDArray],
+                             attention_probs: List[mx.nd.NDArray]) -> Tuple[mx.nd.NDArray, mx.nd.NDArray]:
+        """
+        Returns combined predictions of models as negative log probabilities and averaged attention prob scores.
+
+        :param probs: List of Shape(beam_size, target_vocab_size).
+        :param attention_probs: List of Shape(beam_size, bucket_key).
+        :return: Combined probabilities, averaged attention scores.
         """
         # average attention prob scores. TODO: is there a smarter way to do this?
-        attention_prob_score = sockeye.utils.average_arrays(attention_prob_scores).asnumpy()
+        attention_prob_score = utils.average_arrays(attention_probs)
 
         # combine model predictions and convert to neg log probs
         if len(self.models) == 1:
-            neg_logprobs = -mx.nd.log(predictions[0])
+            neg_logprobs = -mx.nd.log(probs[0])
         else:
-            neg_logprobs = self.interpolation_func(predictions)
+            neg_logprobs = self.interpolation_func(probs)
         return neg_logprobs, attention_prob_score
 
     def _beam_search(self,
                      source: mx.nd.NDArray,
                      source_length: mx.nd.NDArray,
                      bucket_key: int,
-                     max_output_length: int) -> Tuple[List[List[int]], List[np.ndarray], mx.nd.NDArray]:
+                     max_output_length: int) -> Tuple[mx.nd.NDArray, mx.nd.NDArray, mx.nd.NDArray, mx.nd.NDArray]:
         """
         Translates a single sentence using beam search.
 
-        :param source: Source array.
-        :param source_length: Length of source.
+        :param source: Source ids. Shape: (1, bucket_key).
+        :param source_length: Source length. Shape: (1,).
         :param bucket_key: Bucket key.
         :param max_output_length: Cap the output at this maximum length.
         :return List of lists of word ids, list of attentions, array of accumulated length-normalized
-        negative log-probs.
+                negative log-probs.
         """
+        lengths = mx.nd.zeros((self.beam_size, 1), ctx=self.context)
+        finished = mx.nd.zeros((self.beam_size,), dtype='int32', ctx=self.context)
+        # sequences: (beam_size, output_length)
+        sequences = mx.nd.array(np.full((self.beam_size, max_output_length), C.PAD_ID), dtype='int32', ctx=self.context)
+        # attentions: (beam_size, output_length, bucket_key/source_length)
+        attentions = mx.nd.zeros((self.beam_size, max_output_length, bucket_key), ctx=self.context)
 
-        # encode source and initialize decoder states for each model
-        model_encoded_source, model_dynamic_source, model_source_length, model_decoder_states = [], [], [], []
-        model_prev_hidden = []
+        # best_hyp_indices: row indices of smallest scores (ascending).
+        best_hyp_indices = mx.nd.zeros((self.beam_size,), ctx=self.context)
+        # best_word_indices: column indices of smallest scores (ascending).
+        best_word_indices = mx.nd.zeros((self.beam_size,), ctx=self.context, dtype='int32')
+        # scores_accumulated: chosen smallest scores in scores (ascending).
+        scores_accumulated = mx.nd.zeros((self.beam_size, 1), ctx=self.context)
 
-        for model in self.models:
-            # encode input sentence and initialize decoder states
-            # encoded_source: (self.beam_size, bucket_key, rnn_num_hidden)
-            # decoder_states: [(self.beam_size, rnn_num_hidden),...]
-            encoded_source, source_dynamic_init, source_length, prev_hidden, decoder_states = \
-                model.run_encoder(source,
-                                  source_length,
-                                  bucket_key)
-            model_encoded_source.append(encoded_source)
-            model_dynamic_source.append(source_dynamic_init)
-            model_source_length.append(source_length)
-            model_decoder_states.append(decoder_states)
-            model_prev_hidden.append(prev_hidden)
+        self.pad_dist += np.inf
 
-        # prev_target_word_id(s): (beam_size,)
-        prev_target_word_id = mx.nd.zeros((self.beam_size,), ctx=self.context)
-        prev_target_word_id[:] = self.start_id
-
-        accumulated_scores = mx.nd.zeros((self.beam_size,), ctx=self.context)
-        lengths = mx.nd.zeros((self.beam_size,), ctx=self.context)
-        finished = [False] * self.beam_size
-        sequences = [[] for _ in range(self.beam_size)]
-        # one list of source word attention vectors per hypothesis
-        attention_lists = [[] for _ in range(self.beam_size)]
-        prev_hyp_indices = None
+        # (0) encode source sentence
+        model_states = self._encode(source, source_length, bucket_key)
 
         for t in range(0, max_output_length):
 
-            # decode one step for each model
-            model_probs, model_attention_prob_score, model_next_hidden = [], [], []
-            model_next_dynamic_source, model_next_decoder_states = [], []
-            for model_index, model in enumerate(self.models):
-                probs, attention_prob_score, next_dynamic_source, next_hidden, next_decoder_states = model.run_decoder(
-                    model_encoded_source[model_index],
-                    model_dynamic_source[model_index],
-                    model_source_length[model_index],
-                    prev_target_word_id,
-                    model_prev_hidden[model_index],
-                    model_decoder_states[model_index],
-                    bucket_key)
-                model_probs.append(probs)
-                model_attention_prob_score.append(attention_prob_score)
-                model_next_hidden.append(next_hidden)
-                model_next_dynamic_source.append(next_dynamic_source)
-                model_next_decoder_states.append(next_decoder_states)
+            # (1) obtain next predictions and advance models' state
+            # scores: (beam_size, target_vocab_size)
+            # attention_scores: (beam_size, bucket_key)
+            scores, attention_scores, model_states = self._decode_step(model_states)
 
-            # combine predictions
-            hyp_scores, attention_prob_score = self._combine_predictions(model_probs, model_attention_prob_score)
+            # (2) compute length-normalized accumulated scores in place
+            if t == 0:  # only one hypothesis at t==0
+                scores = scores[:1]
+            else:
+                # renormalize scores by length+1, but not for finished hyps;
+                # their predicted distribution is set to one-hot at C.PAD_ID.
+                scores = (scores + scores_accumulated * lengths) / (lengths + 1)
+                self.pad_dist[:, C.PAD_ID] = scores_accumulated
+                scores = mx.nd.where(finished, self.pad_dist, scores)
+                self.pad_dist += np.inf
 
-            for hyp_idx in range(self.beam_size):
-                if not finished[hyp_idx]:
-                    # re-normalize hypothesis score by length
-                    hyp_scores[hyp_idx] = (hyp_scores[hyp_idx] + accumulated_scores[hyp_idx] * lengths[hyp_idx]) / (
-                        lengths[hyp_idx] + 1)
-                else:
-                    hyp_scores[hyp_idx][:] = np.inf
-                    hyp_scores[hyp_idx][C.PAD_ID] = accumulated_scores[hyp_idx]
+            # (3) get beam_size winning hypotheses
+            # TODO(fhieber): once mx.nd.topk is sped-up no numpy conversion necessary anymore.
+            (best_hyp_indices[:], best_word_indices_np), scores_accumulated_np = utils.smallest_k(scores.asnumpy(),
+                                                                                                  self.beam_size)
+            scores_accumulated[:] = np.expand_dims(scores_accumulated_np, axis=1)
+            best_word_indices[:] = best_word_indices_np
 
-            # get self.beam_size smallest hypotheses
-            # prev_hyp_indices: row indices in hyp_scores.
-            # next_word_ids: column indices in hyp_scores
-            # accumulated_scores: chosen smallest scores in hyp_scores
-            (prev_hyp_indices, next_word_ids), accumulated_scores = sockeye.utils.smallest_k(hyp_scores.asnumpy(),
-                                                                                             self.beam_size, t == 0)
+            # (4) get hypotheses and their properties for beam_size winning hypotheses (ascending)
+            mx.nd.take(sequences, best_hyp_indices, out=sequences)
+            mx.nd.take(lengths, best_hyp_indices, out=lengths)
+            mx.nd.take(finished, best_hyp_indices, out=finished)
+            mx.nd.take(attention_scores, best_hyp_indices, out=attention_scores)
+            mx.nd.take(attentions, best_hyp_indices, out=attentions)
 
-            # select attention according to hypothesis
-            attention_prob_score = attention_prob_score[prev_hyp_indices, :]
+            # (5) update best hypotheses, their attention lists and lengths (only for non-finished hyps)
+            sequences[:, t] = mx.nd.expand_dims(best_word_indices, axis=1)
+            attentions[:, t, :] = mx.nd.expand_dims(attention_scores, axis=1)
+            lengths += mx.nd.cast(1 - mx.nd.expand_dims(finished, axis=1), dtype='float32')
 
-            # list of new hypothesis that are now finished
-            new_hyp_finished = [word_id in self.stop_ids for word_id in next_word_ids]
-            new_sequences = [None for _ in range(self.beam_size)]
-            new_attention_lists = [None for _ in range(self.beam_size)]
-            for new_hyp_idx, prev_hyp_idx in enumerate(prev_hyp_indices):
-                if not finished[prev_hyp_idx]:
-                    new_sequences[new_hyp_idx] = sequences[prev_hyp_idx] + [next_word_ids[new_hyp_idx]]
-                    new_attention_lists[new_hyp_idx] = attention_lists[prev_hyp_idx] + [
-                        attention_prob_score[new_hyp_idx, :]]
-                else:
-                    new_sequences[new_hyp_idx] = sequences[prev_hyp_idx]
-                    new_attention_lists[new_hyp_idx] = attention_lists[prev_hyp_idx]
-                lengths[new_hyp_idx] = len(new_sequences[new_hyp_idx])
-
-            finished = new_hyp_finished
-            sequences = new_sequences
-            attention_lists = new_attention_lists
-
-            if all(new_hyp_finished):
+            # (6) determine which hypotheses in the beam are now finished
+            finished = ((best_word_indices == C.PAD_ID) + (best_word_indices == self.vocab_target[C.EOS_SYMBOL]))
+            if mx.nd.sum(finished).asscalar() == self.beam_size:  # all finished
                 break
 
-            # prepare new batch
-            prev_hyp_indices_nd = mx.nd.array(prev_hyp_indices, ctx=self.context)
-            prev_target_word_id = mx.nd.array(next_word_ids, ctx=self.context)
-            model_prev_hidden = [mx.nd.take(next_hidden, prev_hyp_indices_nd) for next_hidden in model_next_hidden]
-            model_dynamic_source = [mx.nd.take(next_dynamic_source, prev_hyp_indices_nd) for
-                                    next_dynamic_source in model_next_dynamic_source]
-            model_decoder_states = [[mx.nd.take(state, prev_hyp_indices_nd) for state in decoder_states] for
-                                    decoder_states in model_next_decoder_states]
+            # (7) update models' state with winning hypotheses (ascending)
+            for ms in model_states:
+                ms.sort_state(best_hyp_indices, best_word_indices)
 
-        return sequences, attention_lists, accumulated_scores
+        return sequences, attentions, scores_accumulated, lengths
 
     @staticmethod
-    def _get_best_from_beam(sequences: List[List[int]],
-                            attention_lists: List[np.ndarray],
-                            accumulated_scores: mx.nd.NDArray) -> Tuple[List[int], np.ndarray, float]:
+    def _get_best_from_beam(sequences: mx.nd.NDArray,
+                            attention_lists: mx.nd.NDArray,
+                            accumulated_scores: mx.nd.NDArray,
+                            lengths: mx.nd.NDArray) -> Tuple[np.ndarray, np.ndarray, float]:
         """
         Return the best (aka top) entry from the n-best list.
 
-        :param sequences: List of lists of word ids.
-        :param attention_lists: List of attention.
+        :param sequences: Array of word ids. Shape: (beam_size, bucket_key).
+        :param attention_lists: Array of attentions over source words. Shape: (length, bucket_key).
         :param accumulated_scores: Array of length-normalized negative log-probs.
         :return: Top sequence, top attention matrix, top accumulated score (length-normalized negative log-probs).
         """
         # sequences & accumulated scores are in latest 'k-best order', thus 0th element is best
         best = 0
+        length = int(lengths[best].asscalar())
+        sequence = sequences[best][:length].asnumpy().tolist()
         # attention_matrix: (target_seq_len, source_seq_len)
-        attention_matrix = np.stack(attention_lists[best], axis=0)
-        return sequences[best], attention_matrix, accumulated_scores[best]
+        attention_matrix = np.stack(attention_lists[best].asnumpy()[:length, :], axis=0)
+        score = accumulated_scores[best].asscalar()
+        return sequence, attention_matrix, score

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -428,7 +428,7 @@ class Translator:
         self.interpolation_func = self._get_interpolation_func(ensemble_mode)
         self.beam_size = self.models[0].beam_size
         self.buckets = data_io.define_buckets(self.models[0].max_input_len)
-        self.pad_dist = mx.nd.zeros((self.beam_size, len(self.vocab_target)), ctx=self.context) + np.inf
+        self.pad_dist = mx.nd.full((self.beam_size, len(self.vocab_target)), val=np.inf, ctx=self.context)
         logger.info("Translator (%d model(s) beam_size=%d ensemble_mode=%s)",
                     len(self.models), self.beam_size, "None" if len(self.models) == 1 else ensemble_mode)
 
@@ -556,8 +556,7 @@ class Translator:
         :param bucket_key: Bucket key.
         :return: List of ModelStates.
         """
-        prev_target_word_id = mx.nd.zeros((self.beam_size,), ctx=self.context)
-        prev_target_word_id[:] = self.start_id
+        prev_target_word_id = mx.nd.full((self.beam_size,), val=self.start_id, ctx=self.context)
         model_states = [ModelState(bucket_key,
                                    prev_target_word_id,
                                    *m.run_encoder(source, source_length, bucket_key))

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -256,7 +256,7 @@ def get_alignments(attention_matrix: np.ndarray, threshold: float = .9) -> Itera
                 yield (src_idx, trg_idx)
 
 
-def average_arrays(arrays: List[mx.sym.NDArray]) -> mx.sym.NDArray:
+def average_arrays(arrays: List[mx.nd.NDArray]) -> mx.nd.NDArray:
     """
     Take a list of arrays of the same shape and take the element wise average.
 


### PR DESCRIPTION
This gets rid of most of the numpy operations during beam search. Only thing missing is an efficient topk & unravel_index implementation in MXNet

