### PR TITLE
No need to specify yaml_tag for derived config classes

### DIFF
--- a/sockeye/attention.py
+++ b/sockeye/attention.py
@@ -38,8 +38,6 @@ class AttentionConfig(config.Config):
     :param layer_normalization: Apply layer normalization to MLP attention.
     :param config_coverage: Optional coverage configuration.
     """
-    yaml_tag = "!AttentionConfig"
-
     def __init__(self,
                  type: str,
                  num_hidden: int,

--- a/sockeye/config.py
+++ b/sockeye/config.py
@@ -16,13 +16,17 @@ import copy
 import yaml
 
 
-class Config(yaml.YAMLObject):
+class TaggedYamlObjectMetaclass(yaml.YAMLObjectMetaclass):
+    def __init__(cls, name, bases, kwds):
+        cls.yaml_tag = "!" + name
+        super().__init__(name, bases, {**kwds, **{'yaml_tag': "!" + name}})
+
+
+class Config(yaml.YAMLObject, metaclass=TaggedYamlObjectMetaclass):
     """
     Base configuration object that supports freezing of members and YAML (de-)serialization.
     Actual Configuration should subclass this object.
     """
-    yaml_tag = '!Config'
-
     def __init__(self):
         self.__add_frozen()
 

--- a/sockeye/coverage.py
+++ b/sockeye/coverage.py
@@ -36,8 +36,6 @@ class CoverageConfig(config.Config):
     :param num_hidden: Number of hidden units for coverage networks.
     :param layer_normalization: Apply layer normalization to coverage networks.
     """
-    yaml_tag = "!AttentionConfig"
-
     def __init__(self,
                  type: str,
                  num_hidden: int,

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -190,8 +190,6 @@ class DataConfig(config.Config):
     """
     Stores data paths from training.
     """
-    yaml_tag = "!DataConfig"
-
     def __init__(self,
                  source: str,
                  target: str,

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -41,8 +41,6 @@ class RecurrentDecoderConfig(Config):
     :param context_gating: Whether to use context gating.
     :param layer_normalization: Apply layer normalization.
     """
-    yaml_tag = "!RecurrentDecoderConfig"
-
     def __init__(self,
                  vocab_size: int,
                  num_embed: int,

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -37,8 +37,6 @@ class RecurrentEncoderConfig(Config):
     :param num_embed: Size of embedding layer.
     :param rnn_config: RNN configuration.
     """
-    yaml_tag = "!RecurrentEncoderConfig"
-
     def __init__(self,
                  vocab_size: int,
                  num_embed: int,
@@ -463,8 +461,6 @@ class ConvolutionalEmbeddingConfig(Config):
     :param num_highway_layers: Number of highway layers for segment embeddings.
     :param dropout: Dropout probability.
     """
-    yaml_tag = "!ConvolutionalEmbeddingConfig"
-
     def __init__(self,
                  num_embed: int,
                  max_filter_width: int = 8,

--- a/sockeye/loss.py
+++ b/sockeye/loss.py
@@ -32,8 +32,6 @@ class LossConfig(config.Config):
     :param normalize: Whether to normalize loss value.
     :param smoothed_cross_entropy_alpha: Smoothing value for smoothed-cross-entropy loss.
     """
-    yaml_tag = '!LossConfig'
-
     def __init__(self,
                  type: str,
                  vocab_size: int,

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -46,8 +46,6 @@ class ModelConfig(Config):
     :param lexical_bias: Use lexical biases.
     :param learn_lexical_bias: Learn lexical biases during training.
     """
-    yaml_tag = "!ModelConfig"
-
     def __init__(self,
                  config_data: data_io.DataConfig,
                  max_seq_len: int,

--- a/sockeye/rnn.py
+++ b/sockeye/rnn.py
@@ -32,8 +32,6 @@ class RNNConfig(Config):
     :param residual: Whether to add residual connections between multi-layered RNNs.
     :param forget_bias: Initial value of forget biases.
     """
-    yaml_tag = '!RNNConfig'
-
     def __init__(self,
                  cell_type: str,
                  num_hidden: int,


### PR DESCRIPTION
**Pros:** convenience, less error prone
**Contra:** _slight_ dependence on actual PyYAML implementation