### PR TITLE
Benchmark translation output handler

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -587,7 +587,11 @@ def add_inference_args(params):
 
     decode_params.add_argument('--output-type',
                                default='translation',
-                               choices=["translation", "translation_with_alignments", "align_plot", "align_text"],
+                               choices=["translation",
+                                        "translation_with_alignments",
+                                        "benchmark",
+                                        "align_plot",
+                                        "align_text"],
                                help='Output type. Choices: [translation, translation_with_alignments, '
                                     'align_plot, align_text]. Default: %(default)s.')
     decode_params.add_argument('--sure-align-threshold',

--- a/sockeye/output_handler.py
+++ b/sockeye/output_handler.py
@@ -35,6 +35,8 @@ def get_output_handler(output_type: str,
         return StringOutputHandler(output_stream)
     elif output_type == "translation_with_alignments":
         return StringWithAlignmentsOutputHandler(output_stream, sure_align_threshold)
+    elif output_type == "benchmark":
+        return BenchmarkOutputHandler(output_stream)
     elif output_type == "align_plot":
         return AlignPlotHandler(plot_prefix="align" if output_fname is None else output_fname)
     elif output_type == "align_text":
@@ -48,11 +50,15 @@ class OutputHandler:
     Abstract output handler interface
     """
 
-    def handle(self, t_input: sockeye.inference.TranslatorInput, t_output: sockeye.inference.TranslatorOutput):
+    def handle(self,
+               t_input: sockeye.inference.TranslatorInput,
+               t_output: sockeye.inference.TranslatorOutput,
+               t_walltime: float = 0.):
         """
         :raises: NotImplementedError
         :param t_input: Translator input.
         :param t_output: Translator output.
+        :param t_walltime: Total wall-clock time for translation.
         """
         raise NotImplementedError()
 
@@ -67,10 +73,14 @@ class StringOutputHandler(OutputHandler):
     def __init__(self, stream):
         self.stream = stream
 
-    def handle(self, t_input: sockeye.inference.TranslatorInput, t_output: sockeye.inference.TranslatorOutput):
+    def handle(self,
+               t_input: sockeye.inference.TranslatorInput,
+               t_output: sockeye.inference.TranslatorOutput,
+               t_walltime: float = 0.):
         """
         :param t_input: Translator input.
         :param t_output: Translator output.
+        :param t_walltime: Total walltime for translation.
         """
         self.stream.write("%s\n" % t_output.translation)
         self.stream.flush()
@@ -92,14 +102,43 @@ class StringWithAlignmentsOutputHandler(StringOutputHandler):
         super().__init__(stream)
         self.threshold = threshold
 
-    def handle(self, t_input: sockeye.inference.TranslatorInput, t_output: sockeye.inference.TranslatorOutput):
+    def handle(self,
+               t_input: sockeye.inference.TranslatorInput,
+               t_output: sockeye.inference.TranslatorOutput,
+               t_walltime: float = 0.):
         """
         :param t_input: Translator input.
         :param t_output: Translator output.
+        :param t_walltime: Total wall-clock time for translation.
         """
         alignments = " ".join(
             ["%d-%d" % (s, t) for s, t in get_alignments(t_output.attention_matrix, threshold=self.threshold)])
         self.stream.write("%s\t%s\n" % (t_output.translation, alignments))
+        self.stream.flush()
+
+
+class BenchmarkOutputHandler(StringOutputHandler):
+    """
+    Output handler to write detailed benchmark information to a stream.
+
+    :param stream: Stream to write translations to (e.g. sys.stdout).
+    """
+
+    def handle(self,
+               t_input: sockeye.inference.TranslatorInput,
+               t_output: sockeye.inference.TranslatorOutput,
+               t_walltime: float = 0.):
+        """
+        :param t_input: Translator input.
+        :param t_output: Translator output.
+        :param t_walltime: Total walltime for translation.
+        """
+        self.stream.write("input=%s\toutput=%s\tinput_tokens=%d\toutput_tokens=%d\ttranslation_time=%0.4f\n" %
+                          (t_input.sentence,
+                           t_output.translation,
+                           len(t_input.tokens),
+                           len(t_output.tokens),
+                           t_walltime))
         self.stream.flush()
 
 
@@ -113,10 +152,15 @@ class AlignPlotHandler(OutputHandler):
     def __init__(self, plot_prefix: str) -> None:
         self.plot_prefix = plot_prefix
 
-    def handle(self, t_input: sockeye.inference.TranslatorInput, t_output: sockeye.inference.TranslatorOutput):
+    def handle(self,
+               t_input: sockeye.inference.TranslatorInput,
+               t_output: sockeye.inference.TranslatorOutput,
+               t_walltime: float = 0.):
         """
+        :raises: NotImplementedError
         :param t_input: Translator input.
         :param t_output: Translator output.
+        :param t_walltime: Total wall-clock time for translation.
         """
         plot_attention(t_output.attention_matrix,
                        t_input.tokens,
@@ -134,10 +178,15 @@ class AlignTextHandler(OutputHandler):
     def __init__(self, threshold: float) -> None:
         self.threshold = threshold
 
-    def handle(self, t_input: sockeye.inference.TranslatorInput, t_output: sockeye.inference.TranslatorOutput):
+    def handle(self,
+               t_input: sockeye.inference.TranslatorInput,
+               t_output: sockeye.inference.TranslatorOutput,
+               t_walltime: float = 0.):
         """
+        :raises: NotImplementedError
         :param t_input: Translator input.
         :param t_output: Translator output.
+        :param t_walltime: Total wall-clock time for translation.
         """
         print_attention_text(t_output.attention_matrix,
                              t_input.tokens,

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -115,7 +115,7 @@ def translate_lines(output_handler: sockeye.output_handler.OutputHandler, source
         total_time += trans_wall_time
         logger.debug("OUT: %s", trans_output)
         logger.debug("OUT: time=%.2f", trans_wall_time)
-        output_handler.handle(trans_input, trans_output)
+        output_handler.handle(trans_input, trans_output, trans_wall_time)
     return i, total_time
 
 


### PR DESCRIPTION
This adds an output handler for detailed benchmarking.  It records inputs/outputs/wall-clock time for each sentence using the standard tab-delimited format.

    [INFO:__main__] Translating...
    1 2 3 4 5
    input=1 2 3 4 5	output=1 2 3 4 5	input_tokens=5	output_tokens=6	translation_time=0.0856