### PR TITLE
dump vocab in utf-8

### DIFF
--- a/sockeye/vocab.py
+++ b/sockeye/vocab.py
@@ -95,7 +95,7 @@ def vocab_to_json(vocab: Mapping, path: str):
     :param path: Output file path.
     """
     with open(path, "w") as out:
-        json.dump(vocab, out, indent=4)
+        json.dump(vocab, out, indent=4, ensure_ascii=False)
         logger.info('Vocabulary saved to "%s"', path)
 
 


### PR DESCRIPTION
The current code dumps to ASCII, encoding all UTF-8 characters, like so:

    [snip]
    "\u2581,": 6,
    "\u2581.": 7,
    "\u2581de": 8,
    [snip]

This makes the file a bit hard to read. This change dumps the file directly to UTF-8. I have tested that loading the dictionary dumped this way produces an identical dictionary to one loaded from the ASCII version.