### PR TITLE
Training resumption with non-empty model dir.

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -150,7 +150,7 @@ def add_io_args(params):
                              help='Folder where model & training results are written to.')
     data_params.add_argument('--overwrite-output',
                              action='store_true',
-                             help='Overwrite output folder if it exists.')
+                             help='Delete all contents of the model directory if it already exists.')
 
     data_params.add_argument('--source-vocab',
                              required=False,

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -142,6 +142,10 @@ class SockeyeModel:
         :param fname: Path to load parameters from.
         """
         assert self.built
+        utils.check_condition(os.path.exists(fname), "No model parameter file found under %s. "
+                                                     "This is either not a model directory or the first training "
+                                                     "checkpoint has not happened yet." % fname)
+
         self.params, _ = utils.load_params(fname)
         # pack rnn cell weights
         for cell in self.rnn_cells:

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -123,9 +123,12 @@ def main():
                 logger.error("Mismatch in arguments for training continuation.")
                 logger.error("Differing arguments: %s.", ", ".join(arg_diffs))
                 sys.exit(1)
-        else:
-            logger.error("Refusing to overwrite existing output folder %s.", output_folder)
+        elif os.path.exists(os.path.join(output_folder, C.PARAMS_BEST_NAME)):
+            logger.error("Refusing to overwrite model folder %s as it seems to contain a trained model.", output_folder)
             sys.exit(1)
+        else:
+            logger.info("The output folder %s already exists, but no training state or parameter file was found. "
+                        "Will start training from scratch.", output_folder)
     else:
         os.makedirs(output_folder)
 


### PR DESCRIPTION
Do not refuse training when no model state is found. So far the training
just died if the model directory already existed but did not contain
a training state. I do not see any good reason to not just start training
from scratch from the existing directory.

Additionally this commit adds a nicer error message for decoding when no
parameter file is found in the model directory.