### PR TITLE
Word batching update

### DIFF
--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -575,12 +575,14 @@ class ParallelBucketSentenceIter(mx.io.DataIter):
             # Track largest batch size by total elements
             largest_total_batch_size = max(largest_total_batch_size, batch_size_seq * max(*bucket_shape))
         # Final step: guarantee that largest bucket by sequence length also has largest total batch size.
-        padded_seq_len = max(*self.buckets[-1])
-        average_seq_len = self.data_label_average_len[-1]
-        while self.bucket_batch_sizes[-1][0] * padded_seq_len < largest_total_batch_size:
-            batch_size_seq, batch_size_word = self.bucket_batch_sizes[-1]
-            self.bucket_batch_sizes[-1] = (batch_size_seq + self.batch_num_devices,
-                                           batch_size_word + self.batch_num_devices * average_seq_len)
+        # When batching by sentences, this will already be the case.
+        if self.batch_by_words:
+            padded_seq_len = max(*self.buckets[-1])
+            average_seq_len = self.data_label_average_len[-1]
+            while self.bucket_batch_sizes[-1][0] * padded_seq_len < largest_total_batch_size:
+                batch_size_seq, batch_size_word = self.bucket_batch_sizes[-1]
+                self.bucket_batch_sizes[-1] = (batch_size_seq + self.batch_num_devices,
+                                               batch_size_word + self.batch_num_devices * average_seq_len)
 
     def _convert_to_array(self):
         for i in range(len(self.data_source)):

--- a/test/system/test_seq_copy_sys.py
+++ b/test/system/test_seq_copy_sys.py
@@ -88,7 +88,7 @@ def test_seq_copy(train_params, translate_params, perplexity_thresh, bleu_thresh
                                                train_target_path,
                                                dev_source_path,
                                                dev_target_path,
-                                               max_seq_len=_LINE_MAX_LENGTH + 10,
+                                               max_seq_len=_LINE_MAX_LENGTH + 1,
                                                work_dir=work_dir)
         assert perplexity <= perplexity_thresh
         assert bleu >= bleu_thresh


### PR DESCRIPTION
This update simplifies memory handling for bucket-specific batch sizes by guaranteeing that the default bucket (largest by sequence length) will also have the largest number of total elements of any batch.  If any other batch has more elements than the default, we bump the default batch size up by the number of devices.  We can then just use the default bucket keys and batch size for `provide_data` and MXNet should do the right thing.  This change resolves the re-bucketing warnings and overall GPU memory usage is lower.

The price for this is that the batch size for the largest bucket gets bumped up slightly, but the effect is relatively minor with reasonable batch sizes.  On an example data set with a requested batch size of 4000, other buckets range from 3800-4200 while the largest is about 4300.