### PR TITLE
Add pyyaml to docs building requirements.

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -3,3 +3,4 @@ sphinx_rtd_theme
 sphinx-autodoc-typehints
 recommonmark
 pypandoc
+pyyaml


### PR DESCRIPTION
Readthedocs build fails with:
```
ImportError: No module named 'yaml'
```