### PR TITLE
Start from best parameters (and optimizer states) after updating learning rates if not improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 For each item we will potentially have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
 ## [1.8.3]
-### Changed
- - Training procedure: start from best parameters after updating learning rates if not improved for x checkpoints.
+### Added
+ - Optional smart rollback of parameters and optimizer states after updating the learning rate 
+ if not improved for x checkpoints. New flags: ``--learning-rate-decay-param-reset``,
+ ``--learning-rate-decay-optimizer-states-reset``
 
 ## [1.8.2]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ Any bump in the second digit indicates potential backwards incompatibilities, e.
 simply modifying weight names.
 Note that Sockeye has checks in place to not translate with an old model that was trained with an incompatible version.
 
-For each item we will potentially have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_ and _Fixed_.
+For each item we will potentially have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
+
+## [1.8.3]
+### Changed
+ - Training procedure: start from best parameters after updating learning rates if not improved for x checkpoints.
 
 ## [1.8.2]
 ### Fixed
  - The RNN variational dropout mask is now independent of the input
  (previously any zero initial state led to the first state being canceled).
+ - Correctly pass `self.dropout_inputs` float to `mx.sym.Dropout` in `VariationalDropoutCell`.
 
 ## [1.8.1]
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.8.2'
+__version__ = '1.8.3'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -659,6 +659,16 @@ def add_training_args(params):
                               default=0,
                               help="Number of warmup steps. If set to x, linearly increases learning rate from 10%% "
                                    "to 100%% of the initial learning rate. Default: %(default)s.")
+    train_params.add_argument('--learning-rate-decay-param-reset',
+                              action='store_true',
+                              help='Resets model parameters to current best when learning rate is reduced due to the '
+                                   'value of --learning-rate-reduce-num-not-improved. Default: %(default)s.')
+    train_params.add_argument('--learning-rate-decay-optimizer-states-reset',
+                              choices=C.LR_DECAY_OPT_STATES_RESET_CHOICES,
+                              default=C.LR_DECAY_OPT_STATES_RESET_OFF,
+                              help="Action to take on optimizer states (e.g. Adam states) when learning rate is "
+                                   "reduced due to the value of --learning-rate-reduce-num-not-improved. "
+                                   "Default: %(default)s.")
 
     train_params.add_argument('--use-fused-rnn',
                               default=False,

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -181,7 +181,9 @@ TENSORBOARD_NAME = "tensorboard"
 TRAINING_STATE_DIRNAME = "training_state"
 TRAINING_STATE_TEMP_DIRNAME = "tmp.training_state"
 TRAINING_STATE_TEMP_DELETENAME = "delete.training_state"
-MODULE_OPT_STATE_NAME = "mx_optimizer.pkl"
+OPT_STATES_LAST = "mx_optimizer_last.pkl"
+OPT_STATES_BEST = "mx_optimizer_best.pkl"
+OPT_STATES_INITIAL = "mx_optimizer_initial.pkl"
 BUCKET_ITER_STATE_NAME = "bucket.pkl"
 RNG_STATE_NAME = "rng.pkl"
 MONITOR_STATE_NAME = "monitor.pkl"
@@ -225,6 +227,13 @@ LR_SCHEDULERS = [LR_SCHEDULER_FIXED_RATE_INV_SQRT_T,
                  LR_SCHEDULER_FIXED_RATE_INV_T,
                  LR_SCHEDULER_FIXED_STEP,
                  LR_SCHEDULER_PLATEAU_REDUCE]
+
+LR_DECAY_OPT_STATES_RESET_OFF = 'off'
+LR_DECAY_OPT_STATES_RESET_INITIAL = 'initial'
+LR_DECAY_OPT_STATES_RESET_BEST = 'best'
+LR_DECAY_OPT_STATES_RESET_CHOICES = [LR_DECAY_OPT_STATES_RESET_OFF,
+                                     LR_DECAY_OPT_STATES_RESET_INITIAL,
+                                     LR_DECAY_OPT_STATES_RESET_BEST]
 
 OUTPUT_HANDLER_TRANSLATION = "translation"
 OUTPUT_HANDLER_TRANSLATION_WITH_ALIGNMENTS = "translation_with_alignments"

--- a/sockeye/lr_scheduler.py
+++ b/sockeye/lr_scheduler.py
@@ -31,7 +31,10 @@ class LearningRateScheduler:
 
     def new_evaluation_result(self, has_improved: bool) -> bool:
         """
-        Returns true if learning rate was adjusted.
+        Returns true if the parameters should be reset to the ones with the best validation score.
+
+        :param has_improved: Whether the model improved on held-out validation data.
+        :return: True if parameters should be reset to the ones with best validation score.
         """
         return False
 
@@ -75,6 +78,12 @@ class LearningRateSchedulerFixedStep(LearningRateScheduler):
         self._update_rate(self.current_step)
 
     def new_evaluation_result(self, has_improved: bool) -> bool:
+        """
+        Returns true if the parameters should be reset to the ones with the best validation score.
+
+        :param has_improved: Whether the model improved on held-out validation data.
+        :return: True if parameters should be reset to the ones with best validation score.
+        """
         logger.info("Checkpoint learning rate: %1.2e (%d/%d updates)",
                     self.current_rate,
                     self.latest_t - self.current_step_started_at,
@@ -195,6 +204,12 @@ class LearningRateSchedulerPlateauReduce(LearningRateScheduler):
                     reduce_factor, reduce_num_not_improved)
 
     def new_evaluation_result(self, has_improved: bool) -> bool:
+        """
+        Returns true if the parameters should be reset to the ones with the best validation score.
+
+        :param has_improved: Whether the model improved on held-out validation data.
+        :return: True if parameters should be reset to the ones with best validation score.
+        """
         if self.lr is None:
             assert self.base_lr is not None
             self.lr = self.base_lr

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -659,7 +659,9 @@ def main():
                            monitor_bleu=monitor_bleu,
                            use_tensorboard=args.use_tensorboard,
                            mxmonitor_pattern=args.monitor_pattern,
-                           mxmonitor_stat_func=args.monitor_stat_func)
+                           mxmonitor_stat_func=args.monitor_stat_func,
+                           lr_decay_param_reset=args.learning_rate_decay_param_reset,
+                           lr_decay_opt_states_reset=args.learning_rate_decay_optimizer_states_reset)
 
 
 if __name__ == "__main__":

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -37,7 +37,8 @@ _LINE_MAX_LENGTH = 9
      "--loss smoothed-cross-entropy --smoothed-cross-entropy-alpha 0.1 --normalize-loss --optimized-metric perplexity"
      " --max-updates 10 --checkpoint-frequency 10 --optimizer adam --initial-learning-rate 0.01"
      " --rnn-dropout-inputs 0.5:0.1 --rnn-dropout-states 0.5:0.1 --embed-dropout 0.1 --rnn-decoder-hidden-dropout 0.01"
-     " --rnn-decoder-state-init avg --rnn-encoder-reverse-input --rnn-dropout-recurrent 0.1:0.0",
+     " --rnn-decoder-state-init avg --rnn-encoder-reverse-input --rnn-dropout-recurrent 0.1:0.0"
+     " --learning-rate-decay-param-reset",
      "--beam-size 2"),
     # Convolutional embedding encoder + LSTM encoder-decoder with attention
     ("--encoder rnn-with-conv-embed --conv-embed-max-filter-width 3 --conv-embed-num-filters 4:4:8"

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -146,6 +146,8 @@ def test_model_parameters(test_params, expected_params):
               learning_rate_half_life=10,
               learning_rate_warmup=0,
               learning_rate_schedule=None,
+              learning_rate_decay_param_reset=False,
+              learning_rate_decay_optimizer_states_reset='off',
               use_fused_rnn=False,
               weight_init='xavier',
               weight_init_scale=0.04,


### PR DESCRIPTION
This is a small change but potentially quite useful. With this PR we reset the model parameters during training back to the current best params when adjusting the learning rate. That means we will continue from the currently best known point with a lower learning rate. Before we did (by default) 3000 updates with the larger learning rate and potentially moved away from the current best before continuing with a smaller learning rate.

I tested this on a small dataset and final validation perplexity was a bit lower (-0.3) than the baseline.
With the change, the model was trained longer (more checkpoints) and train perplexity was overall higher, suggesting less overfitting to train.

Open question: Should we also reset the optimizer states (e.g. for Adam) in these cases? Might not be as easy to do since we only keep one copy of them (they tend to be fairly large). In any case, that should be another PR.