### PR TITLE
Batch decoding for better speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 For each item we will potentially have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.9.0]
+### Added
+ - Batch decoding. New options for the translate CLI: ``--batch-size`` and ``--chunk-size``. Translator.translate()  
+ now accepts and returns lists of inputs and outputs.
+
 ## [1.8.4]
 ### Added
  - Exposing the MXNet KVStore through the ``--kvstore`` argument, potentially enabling distributed training.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.8.4'
+__version__ = '1.9.0'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -754,6 +754,15 @@ def add_inference_args(params):
                                type=int_greater_or_equal(1),
                                default=5,
                                help='Size of the beam. Default: %(default)s.')
+    decode_params.add_argument('--batch-size',
+                               type=int_greater_or_equal(1),
+                               default=16,
+                               help='Batch size during decoding. Determines how many sentences are translated simultaneously.'
+                                    'Default: %(default)s.')
+    decode_params.add_argument('--chunk-size',
+                               type=int_greater_or_equal(1),
+                               default=10000,
+                               help='Size of the chunks to be read from input at once. Default: %(default)s.')
     decode_params.add_argument('--ensemble-mode',
                                type=str,
                                default='linear',

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -242,6 +242,10 @@ LR_DECAY_OPT_STATES_RESET_CHOICES = [LR_DECAY_OPT_STATES_RESET_OFF,
                                      LR_DECAY_OPT_STATES_RESET_INITIAL,
                                      LR_DECAY_OPT_STATES_RESET_BEST]
 
+# id of an empty translation input; used to mark them while chunking during decoding
+EMPTY_TRANSLATION_INPUT_ID = -999999999
+
+# output handler
 OUTPUT_HANDLER_TRANSLATION = "translation"
 OUTPUT_HANDLER_TRANSLATION_WITH_SCORE = "translation_with_score"
 OUTPUT_HANDLER_TRANSLATION_WITH_ALIGNMENTS = "translation_with_alignments"
@@ -262,7 +266,7 @@ ACCURACY = 'accuracy'
 PERPLEXITY = 'perplexity'
 BLEU = 'bleu'
 BLEU_VAL = BLEU + "-val"
-SPEED_PCT = "p%d-sec-per-sent-val"
+AVG_TIME = "avg-sec-per-sent-val"
 METRICS = [PERPLEXITY, ACCURACY, BLEU]
 METRIC_MAXIMIZE = {ACCURACY: True, BLEU: True, PERPLEXITY: False}
 METRIC_WORST = {ACCURACY: 0.0, BLEU: 0.0, PERPLEXITY: np.inf}

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -14,9 +14,11 @@
 """
 Translation CLI.
 """
+import itertools
 import argparse
 import sys
 import time
+from math import ceil
 from contextlib import ExitStack
 from typing import Optional, Iterable, Tuple
 
@@ -67,60 +69,75 @@ def main():
                                                   *sockeye.inference.load_models(context,
                                                                                  args.max_input_len,
                                                                                  args.beam_size,
+                                                                                 args.batch_size,
                                                                                  args.models,
                                                                                  args.checkpoints,
                                                                                  args.softmax_temperature,
                                                                                  args.max_output_length_num_stds))
-        read_and_translate(translator, output_handler, args.input)
+
+        logger.info("Using batches of size %d", args.batch_size)
+        read_and_translate(translator, output_handler, args.chunk_size, args.input)
 
 
 def read_and_translate(translator: sockeye.inference.Translator, output_handler: sockeye.output_handler.OutputHandler,
-                       source: Optional[str] = None) -> None:
+                       chunk_size: int, source: Optional[str] = None) -> None:
     """
     Reads from either a file or stdin and translates each line, calling the output_handler with the result.
 
     :param output_handler: Handler that will write output to a stream.
     :param translator: Translator that will translate each line of input.
+    :param chunk_size: The size of the portion to read at a time from the input.
     :param source: Path to file which will be translated line-by-line if included, if none use stdin.
     """
+    def grouper(iterable: Iterable, size: int) -> Iterable:
+        """
+        Collect data into fixed-length chunks or blocks
+        without either dicarding underfilled chunks or padding them
+        """
+        it = iter(iterable)
+        while True:
+            chunk = list(itertools.islice(it, size))
+            if not chunk:
+                return
+            yield chunk
 
     source_data = sys.stdin if source is None else sockeye.data_io.smart_open(source)
 
     logger.info("Translating...")
 
-    i, total_time = translate_lines(output_handler, source_data, translator)
+    total_time, total_lines = 0.0, 0
+    for chunk in grouper(source_data, chunk_size):
+        chunk_time = translate(output_handler, chunk, translator)
+        total_lines += len(chunk) 
+        total_time += chunk_time
 
-    if i != 0:
-        logger.info("Processed %d lines. Total time: %.4f sec/sent: %.4f sent/sec: %.4f", i, total_time,
-                    total_time / i, i / total_time)
+    if total_lines != 0:
+        logger.info("Processed %d lines in %d batches. Total time: %.4f, sec/sent: %.4f, sent/sec: %.4f",
+                    total_lines, ceil(total_lines / translator.batch_size), total_time,
+                    total_time / total_lines, total_lines / total_time)
     else:
         logger.info("Processed 0 lines.")
 
 
-def translate_lines(output_handler: sockeye.output_handler.OutputHandler, source_data: Iterable[str],
-                    translator: sockeye.inference.Translator) -> Tuple[int, float]:
+def translate(output_handler: sockeye.output_handler.OutputHandler, source_data: Iterable[str],
+                    translator: sockeye.inference.Translator) -> float:
     """
-    Translates each line from source_data, calling output handler for each result.
+    Translates each line from source_data, calling output handler after translating a batch.
 
     :param output_handler: A handler that will be called once with the output of each translation.
     :param source_data: A enumerable list of source sentences that will be translated.
     :param translator: The translator that will be used for each line of input.
-    :return: The number of lines translated, and the total time taken.
+    :return: Total time taken.
     """
 
-    i = 0
     total_time = 0.0
-    for i, line in enumerate(source_data, 1):
-        tic = time.time()
-        trans_input = translator.make_input(i, line)
-        logger.debug(" IN: %s", trans_input)
-        trans_output = translator.translate(trans_input)
-        trans_wall_time = time.time() - tic
-        total_time += trans_wall_time
-        logger.debug("OUT: %s", trans_output)
-        logger.debug("OUT: time=%.2f", trans_wall_time)
-        output_handler.handle(trans_input, trans_output, trans_wall_time)
-    return i, total_time
+    tic = time.time()
+    trans_inputs = [translator.make_input(i, line) for i, line in enumerate(source_data, 1)]
+    trans_outputs = translator.translate(trans_inputs)
+    total_time = time.time() - tic
+    for trans_input, trans_output in zip(trans_inputs, trans_outputs):
+        output_handler.handle(trans_input, trans_output)
+    return total_time
 
 
 def _setup_context(args, exit_stack):

--- a/test/system/test_seq_copy_sys.py
+++ b/test/system/test_seq_copy_sys.py
@@ -102,6 +102,7 @@ def test_seq_copy(train_params, translate_params, perplexity_thresh, bleu_thresh
         # Test model configuration
         perplexity, bleu = run_train_translate(train_params,
                                                translate_params,
+                                               None,  # no second set of parameters
                                                train_source_path,
                                                train_target_path,
                                                dev_source_path,
@@ -183,6 +184,7 @@ def test_seq_sort(train_params, translate_params, perplexity_thresh, bleu_thresh
         # Test model configuration
         perplexity, bleu = run_train_translate(train_params,
                                                translate_params,
+                                               None,
                                                train_source_path,
                                                train_target_path,
                                                dev_source_path,

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -173,6 +173,8 @@ def test_training_arg(test_params, expected_params):
                       checkpoints=None,
                       models=['model'],
                       beam_size=5,
+                      batch_size=16,
+                      chunk_size=10000,
                       ensemble_mode='linear',
                       bucket_width=(10, 2),
                       max_input_len=None,

--- a/test/unit/test_translate.py
+++ b/test/unit/test_translate.py
@@ -42,25 +42,30 @@ def mock_open(*args, **kargs):
 
 @unittest.mock.patch("builtins.open", new_callable=mock_open, read_data=TEST_DATA)
 def test_translate_by_file(mock_file, mock_translator, mock_output_handler):
+    mock_translator.translate.return_value = ['', '']
+    mock_translator.batch_size = 1
     mock_file.return_value = TEST_DATA.splitlines()
     sockeye.translate.read_and_translate(translator=mock_translator, output_handler=mock_output_handler,
-                                         source='/dev/null')
+                                         chunk_size=2, source='/dev/null')
 
     # Ensure that our translator has the correct input passed to it.
     mock_translator.make_input.assert_any_call(1, "Test file line 1")
     mock_translator.make_input.assert_any_call(2, "Test file line 2")
 
-    # Ensure translate gets called twice.  Input here will be a dummy mocked result, so we'll ignore it.
-    assert mock_translator.translate.call_count == 2
+    # Ensure translate gets called once.  Input here will be a dummy mocked result, so we'll ignore it.
+    assert mock_translator.translate.call_count == 1
 
 
 @unittest.mock.patch("sys.stdin", io.StringIO(TEST_DATA))
-def test_translate_by_stdin(mock_translator, mock_output_handler):
-    sockeye.translate.read_and_translate(translator=mock_translator, output_handler=mock_output_handler)
+def test_translate_by_stdin_chunk2(mock_translator, mock_output_handler):
+    mock_translator.translate.return_value = ['', '']
+    mock_translator.batch_size = 1
+    sockeye.translate.read_and_translate(translator=mock_translator, output_handler=mock_output_handler,
+                                         chunk_size=2)
 
     # Ensure that our translator has the correct input passed to it.
     mock_translator.make_input.assert_any_call(1, "Test file line 1\n")
     mock_translator.make_input.assert_any_call(2, "Test file line 2\n")
 
-    # Ensure translate gets called twice.  Input here will be a dummy mocked result, so we'll ignore it.
-    assert mock_translator.translate.call_count == 2
+    # Ensure translate gets called once.  Input here will be a dummy mocked result, so we'll ignore it.
+    assert mock_translator.translate.call_count == 1

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -177,11 +177,11 @@ def test_parse_version(version_string, expected_version):
 
 
 def test_check_version_disregards_minor():
-    utils.check_version("1.8.0")
+    utils.check_version("1.9.0")
 
 
 def test_check_version_checks_major():
-    version = "1.9.1"
+    version = "1.10.1"
     with pytest.raises(utils.SockeyeError) as e:
         utils.check_version(version)
     assert "Given major version (%s) does not match major code version (%s)" % (version, __version__)


### PR DESCRIPTION
* Implemented decoding in batches. Decoding speed improvement up to 3 times (for similar length inputs)
* Reading inputs is now done in chunks (--chunk-size, default 10k). In the future a possible alternative would be to batch inputs (supplied as an iteratable) directly.
* Batch size controlled from CLI