### PR TITLE
Fail early on non-regular files (e.g. bash process substitutions), 

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -16,11 +16,28 @@ Defines commandline arguments for the main CLIs with reasonable defaults.
 """
 import argparse
 import sys
+import os
 from typing import Callable, Optional
 
 from sockeye.lr_scheduler import LearningRateSchedulerFixedStep
 from . import constants as C
 from . import data_io
+
+def is_file() -> Callable:
+    """
+    Returns a method that can be used in argument parsing to check the argument is a regular file or a symbolic link,
+    but not, e.g., a process substitution.
+
+    :return: A method that can be used as a type in argparse.
+    """
+
+    def check_regular_file(value_to_check):
+        value_to_check = str(value_to_check)
+        if not os.path.isfile(value_to_check):
+            raise argparse.ArgumentTypeError("must exist and be a regular file.")
+        return value_to_check
+
+    return check_regular_file
 
 
 def int_greater_or_equal(threshold: int) -> Callable:
@@ -169,9 +186,11 @@ def add_io_args(params):
 
     data_params.add_argument('--source', '-s',
                              required=True,
+                             type=is_file(),
                              help='Source side of parallel training data.')
     data_params.add_argument('--target', '-t',
                              required=True,
+                             type=is_file(),
                              help='Target side of parallel training data.')
     data_params.add_argument('--limit',
                              default=None,
@@ -180,9 +199,11 @@ def add_io_args(params):
 
     data_params.add_argument('--validation-source', '-vs',
                              required=True,
+                             type=is_file(),
                              help='Source side of validation data.')
     data_params.add_argument('--validation-target', '-vt',
                              required=True,
+                             type=is_file(),
                              help='Target side of validation data.')
 
     data_params.add_argument('--output', '-o',

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -23,7 +23,7 @@ from sockeye.lr_scheduler import LearningRateSchedulerFixedStep
 from . import constants as C
 from . import data_io
 
-def is_file() -> Callable:
+def regular_file() -> Callable:
     """
     Returns a method that can be used in argument parsing to check the argument is a regular file or a symbolic link,
     but not, e.g., a process substitution.
@@ -186,11 +186,11 @@ def add_io_args(params):
 
     data_params.add_argument('--source', '-s',
                              required=True,
-                             type=is_file(),
+                             type=regular_file(),
                              help='Source side of parallel training data.')
     data_params.add_argument('--target', '-t',
                              required=True,
-                             type=is_file(),
+                             type=regular_file(),
                              help='Target side of parallel training data.')
     data_params.add_argument('--limit',
                              default=None,
@@ -199,11 +199,11 @@ def add_io_args(params):
 
     data_params.add_argument('--validation-source', '-vs',
                              required=True,
-                             type=is_file(),
+                             type=regular_file(),
                              help='Source side of validation data.')
     data_params.add_argument('--validation-target', '-vt',
                              required=True,
-                             type=is_file(),
+                             type=regular_file(),
                              help='Target side of validation data.')
 
     data_params.add_argument('--output', '-o',

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -95,6 +95,9 @@ def check_arg_compatibility(args: argparse.Namespace):
     check_condition(args.optimized_metric == C.BLEU or args.optimized_metric in args.metrics,
                     "Must optimize either BLEU or one of tracked metrics (--metrics)")
 
+    check_condition(all(os.path.isfile(f) for f in [args.source, args.target, args.validation_source, args.validation_target]),
+                    "All training and validation inputs must be regular files")
+
 
 def check_resume(args: argparse.Namespace, output_folder: str) -> Tuple[bool, str]:
     """

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -95,9 +95,6 @@ def check_arg_compatibility(args: argparse.Namespace):
     check_condition(args.optimized_metric == C.BLEU or args.optimized_metric in args.metrics,
                     "Must optimize either BLEU or one of tracked metrics (--metrics)")
 
-    check_condition(all(os.path.isfile(f) for f in [args.source, args.target, args.validation_source, args.validation_target]),
-                    "All training and validation inputs must be regular files")
-
 
 def check_resume(args: argparse.Namespace, output_folder: str) -> Tuple[bool, str]:
     """

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -314,7 +314,7 @@ def _create_argument_values_that_must_be_files(params):
     to_unlink = set()
     for arg, val in grouper(params, 2):
         if arg in regular_files_params and not os.path.isfile(val):
-            to_unlink.add((val, open(val, 'a')))
+            to_unlink.add((val, open(val, 'w')))
     return to_unlink
 
 


### PR DESCRIPTION
…since multiple passes over inputs are needed.

I keep forgetting about this and run into situations when only after vocabularies are built (which takes time), a cryptic error about some division by zero is displayed (meaning the attempt to do a second path over a process substitution input has failed).