### PR TITLE
Fixes a bug introduced with the revised data iterator: max_observed_{…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 For each item we will potentially have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.10.3]
+### Changed
+ - Fixed a bug with max_observed_{source,target}_len being computed on the complete data set, not only on the
+ sentences actually added to the buckets based on `--max_seq_len`.
+
 ## [1.10.2]
 ### Added
  - `--max-num-epochs` flag to train for a maximum number of passes through the training data.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.10.1'
+__version__ = '1.10.3'


### PR DESCRIPTION
…source,target}_len should only be computed on sentence pairs added to the buckets.

This fixes issue #182  which was introduced in #178 .
Also moved other data iterator statistics below the continue so that they are accurate w.r.t what is actually added to the training dataset.