### PR TITLE
sacrebleu 1.1.5

### DIFF
--- a/contrib/sacrebleu/README.md
+++ b/contrib/sacrebleu/README.md
@@ -67,6 +67,11 @@ Sacré BLEU.
 
 # VERSION HISTORY
 
+- 1.1.5 (12 November 2017)
+   - added -b option (only output the BLEU score)
+   - removed fi-en from list of WMT16/17 systems with more than one reference
+   - added WMT16/tworefs and WMT17/tworefs for scoring with both en-fi references
+
 - 1.1.4 (10 November 2017)
    - added effective order for sentence-level BLEU computation
    - added unit tests from sockeye

--- a/contrib/sacrebleu/test.sh
+++ b/contrib/sacrebleu/test.sh
@@ -53,7 +53,7 @@ for pair in cs-en de-en en-cs en-de en-fi en-lv en-ru en-tr en-zh fi-en lv-en ru
 
         # mteval=$($MOSES/scripts/generic/mteval-v13a.pl -c -s $src -r $ref -t $sgm 2> /dev/null | grep "BLEU score" | cut -d' ' -f9)
         # mteval=$(echo "print($bleu1 * 100)" | python)
-        score=$(cat $txt | ../sacrebleu.py -t wmt17 -l $source-$target --tok $tokenizer --force | cut -d' ' -f3)
+        score=$(cat $txt | ../sacrebleu.py -t wmt17 -l $source-$target --tok $tokenizer --force -b)
 
         echo "import sys; sys.exit(1 if abs($score-${MTEVAL[$i]}) > 0.04 else 0)" | python
 

--- a/test/common.py
+++ b/test/common.py
@@ -259,12 +259,12 @@ def run_train_translate(train_params: str,
 
         # Measure BLEU
         bleu = sacrebleu.raw_corpus_bleu(open(out_path, "r").readlines(),
-                                         [open(dev_target_path, "r").readlines()], 0.01)
+                                         [open(dev_target_path, "r").readlines()], 0.01).score
 
         bleu_restrict = None
         if restrict_lexicon:
             bleu_restrict = sacrebleu.raw_corpus_bleu(open(out_restrict_path, "r").readlines(),
-                                      [open(dev_target_path, "r").readlines()], 0.01)
+                                      [open(dev_target_path, "r").readlines()], 0.01).score
         # Run BLEU cli
         eval_params = "{} {} ".format(sockeye.evaluate.__file__,
                                       _EVAL_PARAMS_COMMON.format(hypotheses=out_path, references=dev_target_path), )


### PR DESCRIPTION
Small improvements and a bugfix:

- Add '-b' option
- Straightened out WMT16/17 Finnish test sets, adds a test set version that uses two references
- bugfix in test/common.py (now returning bleu score instead of BLEU object)

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md