### PR TITLE
Fixed ignore in smoothed cross entropy metric and added a test. Thank…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 For each item we will potentially have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.11.1]
+### Fixed
+ - Fixed an issue with the use of `ignore` in `CrossEntropyMetric::cross_entropy_smoothed`. This was affecting
+ runs with Eve optimizer and label smoothing. Thanks @kobenaxie for reporting.
+
 ## [1.11.0]
 ### Added
  - Lexicon-based target vocabulary restriction for faster decoding. New CLI for top-k lexicon creation, sockeye.lexicon.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.11.0'
+__version__ = '1.11.1'

--- a/test/unit/test_optimizers.py
+++ b/test/unit/test_optimizers.py
@@ -11,14 +11,15 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import pytest
 from random import random
 
 import mxnet.ndarray as nd
+import pytest
 from mxnet import optimizer as opt
 
 import sockeye.constants as C
 from sockeye.optimizers import BatchState, CheckpointState, SockeyeOptimizer
+
 
 @pytest.mark.parametrize("optimizer, optimizer_params",
                          ((C.OPTIMIZER_ADAM, {}),


### PR DESCRIPTION
Fixes the use of ignore in `cross_entropy_smoothed` as brought up by #200 .
Thanks @kobenaxie !

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md

