### PR TITLE
Tiny context fix for vocab slice padding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 For each item we will potentially have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.11.2]
+### Fixed
+ - Fixed a bug where vocabulary slice padding was defaulting to CPU context.  This was affecting decoding on GPUs with
+ very small vocabularies.
+
 ## [1.11.1]
 ### Fixed
  - Fixed an issue with the use of `ignore` in `CrossEntropyMetric::cross_entropy_smoothed`. This was affecting

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.11.1'
+__version__ = '1.11.2'

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -957,7 +957,7 @@ class Translator:
                                vocab_slice_ids.shape[0], self.beam_size)
                 n = self.beam_size - vocab_slice_ids.shape[0] + 1
                 vocab_slice_ids = mx.nd.concat(vocab_slice_ids,
-                                               mx.nd.full((n,), val=self.vocab_target[C.EOS_SYMBOL]),
+                                               mx.nd.full((n,), val=self.vocab_target[C.EOS_SYMBOL], ctx=self.context),
                                                dim=0)
 
             pad_dist = mx.nd.full((self.batch_size * self.beam_size, vocab_slice_ids.shape[0]),


### PR DESCRIPTION
Vocab padding just needed a context arg for GPU decoding.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md

