### PR TITLE
bugfix in logic for displaying tokenization warning, no longer quits

### DIFF
--- a/contrib/sacrebleu/README.md
+++ b/contrib/sacrebleu/README.md
@@ -67,6 +67,9 @@ Sacré BLEU.
 
 # VERSION HISTORY
 
+- 1.1.6 (15 November 2017)
+   - bugfix for tokenization warning
+
 - 1.1.5 (12 November 2017)
    - added -b option (only output the BLEU score)
    - removed fi-en from list of WMT16/17 systems with more than one reference

--- a/contrib/sacrebleu/test.sh
+++ b/contrib/sacrebleu/test.sh
@@ -53,7 +53,7 @@ for pair in cs-en de-en en-cs en-de en-fi en-lv en-ru en-tr en-zh fi-en lv-en ru
 
         # mteval=$($MOSES/scripts/generic/mteval-v13a.pl -c -s $src -r $ref -t $sgm 2> /dev/null | grep "BLEU score" | cut -d' ' -f9)
         # mteval=$(echo "print($bleu1 * 100)" | python)
-        score=$(cat $txt | ../sacrebleu.py -t wmt17 -l $source-$target --tok $tokenizer --force -b)
+        score=$(cat $txt | ../sacrebleu.py -t wmt17 -l $source-$target --tok $tokenizer -b)
 
         echo "import sys; sys.exit(1 if abs($score-${MTEVAL[$i]}) > 0.04 else 0)" | python
 

--- a/requirements.gpu-cu75.txt
+++ b/requirements.gpu-cu75.txt
@@ -2,4 +2,4 @@ pyyaml
 mxnet-cu75==0.12.0
 numpy>=1.12
 typing
-sacrebleu>=1.1.4
+sacrebleu>=1.1.6

--- a/requirements.gpu-cu80.txt
+++ b/requirements.gpu-cu80.txt
@@ -2,4 +2,4 @@ pyyaml
 mxnet-cu80==0.12.0
 numpy>=1.12
 typing
-sacrebleu>=1.1.4
+sacrebleu>=1.1.6

--- a/requirements.gpu-cu90.txt
+++ b/requirements.gpu-cu90.txt
@@ -2,4 +2,4 @@ pyyaml
 mxnet-cu90==0.12.0
 numpy>=1.12
 typing
-sacrebleu>=1.1.4
+sacrebleu>=1.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pyyaml
 mxnet==0.12.0
 numpy>=1.12
 typing
-sacrebleu>=1.1.4
+sacrebleu>=1.1.6


### PR DESCRIPTION
This fixes #204

- bugfix in logic for displaying tokenization warning, 
- sacrebleu no longer quits
- release 1.1.6 of sacrebleu

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md
