### PR TITLE
Transformers now always use linear output transformation after co…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 For each item we will potentially have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.12.0]
+### Changed
+ - Transformers now always use the linear output transformation after combining attention heads, even if input & output
+ depth do not differ.
+
 ## [1.11.2]
 ### Fixed
  - Fixed a bug where vocabulary slice padding was defaulting to CPU context.  This was affecting decoding on GPUs with

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.11.2'
+__version__ = '1.12.0'

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -196,7 +196,7 @@ class TransformerDecoder(Decoder):
         self.final_process = transformer.TransformerProcessBlock(sequence=config.preprocess_sequence,
                                                                  num_hidden=config.model_size,
                                                                  dropout=config.dropout_prepost,
-                                                                 prefix="%sfinal_process" % prefix)
+                                                                 prefix="%sfinal_process_" % prefix)
 
         # Embedding & output parameters
         if embed_weight is None:

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -335,13 +335,12 @@ class MultiHeadAttentionBase:
         # (batch, queries_max_length, depth)
         contexts = combine_heads(contexts, queries_max_length, self.heads)
 
-        if self.depth_out != self.depth:
-            # contexts: (batch, queries_max_length, output_depth)
-            contexts = mx.sym.FullyConnected(data=contexts,
-                                             weight=self.w_h2o,
-                                             bias=self.b_h2o,
-                                             num_hidden=self.depth_out,
-                                             flatten=False)
+        # contexts: (batch, queries_max_length, output_depth)
+        contexts = mx.sym.FullyConnected(data=contexts,
+                                         weight=self.w_h2o,
+                                         bias=self.b_h2o,
+                                         num_hidden=self.depth_out,
+                                         flatten=False)
 
         return contexts
 

--- a/test/system/test_seq_copy_sys.py
+++ b/test/system/test_seq_copy_sys.py
@@ -26,33 +26,33 @@ _SEED_TRAIN = 13
 _SEED_DEV = 17
 
 
-@pytest.mark.parametrize("train_params, translate_params, perplexity_thresh, bleu_thresh", [
-    # "Vanilla" LSTM encoder-decoder with attention
-    ("--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
+@pytest.mark.parametrize("name, train_params, translate_params, perplexity_thresh, bleu_thresh", [
+    ("Copy:lstm",
+     "--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
      " --rnn-attention-num-hidden 32 --batch-size 16 --loss cross-entropy --optimized-metric perplexity"
      " --checkpoint-frequency 1000 --optimizer adam --initial-learning-rate 0.001"
      " --rnn-dropout-states 0.0:0.1 --embed-dropout 0.1:0.0 --max-updates 4000 --weight-normalization",
      "--beam-size 5",
      1.01,
      0.99),
-    # "Vanilla" LSTM encoder-decoder translating in chunks (due to lower --max-input-len)
-    ("--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
+    ("Copy:chunking",
+     "--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
      " --rnn-attention-num-hidden 32 --batch-size 16 --loss cross-entropy --optimized-metric perplexity"
      " --checkpoint-frequency 1000 --optimizer adam --initial-learning-rate 0.001"
      " --rnn-dropout-states 0.0:0.1 --embed-dropout 0.1:0.0 --max-updates 5000",
      "--beam-size 5 --max-input-len 4",
      1.01,
      0.99),
-    # "Vanilla" LSTM encoder-decoder with attention (word-based batching)
-    ("--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
+    ("Copy:word-based-batching",
+     "--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
      " --rnn-attention-num-hidden 32 --batch-size 80 --batch-type word --loss cross-entropy "
      " --optimized-metric perplexity --max-updates 5000 --checkpoint-frequency 1000 --optimizer adam "
      " --initial-learning-rate 0.001 --rnn-dropout-states 0.0:0.1 --embed-dropout 0.1:0.0 --layer-normalization",
      "--beam-size 5",
      1.01,
      0.99),
-    # 2-layer transformer encoder, LSTM decoder with attention
-    ("--encoder transformer --num-layers 2:1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32"
+    ("Copy:transformer:lstm",
+     "--encoder transformer --num-layers 2:1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32"
      " --rnn-attention-type mhdot --rnn-attention-num-hidden 32 --batch-size 16 --rnn-attention-mhdot-heads 1"
      " --loss cross-entropy --optimized-metric perplexity --max-updates 5000"
      " --transformer-attention-heads 4 --transformer-model-size 64"
@@ -61,8 +61,8 @@ _SEED_DEV = 17
      "--beam-size 5",
      1.01,
      0.99),
-    # # LSTM encoder, 1-layer transformer decoder
-    ("--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32"
+    ("Copy:lstm:transformer",
+     "--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32"
      " --decoder transformer --batch-size 16"
      " --loss cross-entropy --optimized-metric perplexity --max-updates 3000"
      " --transformer-attention-heads 4 --transformer-model-size 32"
@@ -71,9 +71,9 @@ _SEED_DEV = 17
      "--beam-size 5",
      1.01,
      0.98),
-    # 2-layer transformer
-    ("--encoder transformer --decoder transformer"
-     " --batch-size 16 --max-updates 3000"
+    ("Copy:transformer:transformer",
+     "--encoder transformer --decoder transformer"
+     " --batch-size 16 --max-updates 4000"
      " --num-layers 2 --transformer-attention-heads 4 --transformer-model-size 32"
      " --transformer-feed-forward-num-hidden 64"
      " --checkpoint-frequency 1000 --optimizer adam --initial-learning-rate 0.001"
@@ -81,8 +81,8 @@ _SEED_DEV = 17
      "--beam-size 1",
      1.01,
      0.999),
-    # 3-layer cnn
-    ("--encoder cnn --decoder cnn "
+    ("Copy:cnn",
+     "--encoder cnn --decoder cnn "
      " --batch-size 16 --num-layers 3 --max-updates 3000"
      " --cnn-num-hidden 32 --cnn-positional-embedding-type fixed"
      " --checkpoint-frequency 1000 --optimizer adam --initial-learning-rate 0.001",
@@ -90,7 +90,7 @@ _SEED_DEV = 17
      1.01,
      0.999)
 ])
-def test_seq_copy(train_params, translate_params, perplexity_thresh, bleu_thresh):
+def test_seq_copy(name, train_params, translate_params, perplexity_thresh, bleu_thresh):
     """Task: copy short sequences of digits"""
     with tmp_digits_dataset("test_seq_copy.", _TRAIN_LINE_COUNT, _LINE_MAX_LENGTH, _DEV_LINE_COUNT,
                             _LINE_MAX_LENGTH, seed_train=_SEED_TRAIN, seed_dev=_SEED_DEV) as data:
@@ -105,30 +105,31 @@ def test_seq_copy(train_params, translate_params, perplexity_thresh, bleu_thresh
                                                               max_seq_len=_LINE_MAX_LENGTH + 1,
                                                               restrict_lexicon=True,
                                                               work_dir=data['work_dir'])
+        logger.info("test: %s", name)
         logger.info("perplexity=%f, bleu=%f, bleu_restrict=%f", perplexity, bleu, bleu_restrict)
         assert perplexity <= perplexity_thresh
         assert bleu >= bleu_thresh
         assert bleu_restrict >= bleu_thresh
 
 
-@pytest.mark.parametrize("train_params, translate_params, perplexity_thresh, bleu_thresh", [
-    # "Vanilla" LSTM encoder-decoder with attention
-    ("--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
+@pytest.mark.parametrize("name, train_params, translate_params, perplexity_thresh, bleu_thresh", [
+    ("Sort:lstm",
+     "--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
      " --rnn-attention-num-hidden 32 --batch-size 16 --loss cross-entropy --optimized-metric perplexity"
      " --max-updates 5000 --checkpoint-frequency 1000 --optimizer adam --initial-learning-rate 0.001",
      "--beam-size 5",
      1.04,
      0.98),
-    # "Vanilla" LSTM encoder-decoder with attention (word-based batching)
-    ("--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
+    ("Sort:word-based-batching",
+     "--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
      " --rnn-attention-num-hidden 32 --batch-size 80 --batch-type word --loss cross-entropy"
      " --optimized-metric perplexity --max-updates 5000 --checkpoint-frequency 1000 --optimizer adam "
      " --initial-learning-rate 0.001 --rnn-dropout-states 0.0:0.1 --embed-dropout 0.1:0.0",
      "--beam-size 5",
      1.04,
      0.98),
-    # 1-layer transformer encoder, LSTM decoder with attention
-    ("--encoder transformer --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32"
+    ("Sort:transformer:lstm",
+     "--encoder transformer --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32"
      " --rnn-attention-type mhdot --rnn-attention-num-hidden 32 --batch-size 16 --rnn-attention-mhdot-heads 2"
      " --loss cross-entropy --optimized-metric perplexity --max-updates 5000"
      " --transformer-attention-heads 4 --transformer-model-size 64"
@@ -137,8 +138,8 @@ def test_seq_copy(train_params, translate_params, perplexity_thresh, bleu_thresh
      "--beam-size 5",
      1.03,
      0.98),
-    # LSTM encoder, 2-layer transformer decoder
-    ("--encoder rnn --num-layers 1:2 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32"
+    ("Sort:lstm:transformer",
+     "--encoder rnn --num-layers 1:2 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32"
      " --decoder transformer --batch-size 16"
      " --loss cross-entropy --optimized-metric perplexity --max-updates 7000"
      " --transformer-attention-heads 4 --transformer-model-size 64"
@@ -147,8 +148,8 @@ def test_seq_copy(train_params, translate_params, perplexity_thresh, bleu_thresh
      "--beam-size 5",
      1.03,
      0.98),
-    # 2-layer transformer
-    ("--encoder transformer --decoder transformer"
+    ("Sort:transformer",
+     "--encoder transformer --decoder transformer"
      " --batch-size 16 --max-updates 5000"
      " --num-layers 2 --transformer-attention-heads 4 --transformer-model-size 32"
      " --transformer-feed-forward-num-hidden 64"
@@ -157,8 +158,8 @@ def test_seq_copy(train_params, translate_params, perplexity_thresh, bleu_thresh
      "--beam-size 1",
      1.03,
      0.99),
-    # 3-layer cnn
-    ("--encoder cnn --decoder cnn "
+    ("Sort:cnn",
+     "--encoder cnn --decoder cnn "
      " --batch-size 16 --num-layers 3 --max-updates 5000"
      " --cnn-num-hidden 32 --cnn-positional-embedding-type fixed"
      " --checkpoint-frequency 1000 --optimizer adam --initial-learning-rate 0.001",
@@ -166,7 +167,7 @@ def test_seq_copy(train_params, translate_params, perplexity_thresh, bleu_thresh
      1.10,
      0.93)
 ])
-def test_seq_sort(train_params, translate_params, perplexity_thresh, bleu_thresh):
+def test_seq_sort(name, train_params, translate_params, perplexity_thresh, bleu_thresh):
     """Task: sort short sequences of digits"""
     with tmp_digits_dataset("test_seq_sort.", _TRAIN_LINE_COUNT, _LINE_MAX_LENGTH, _DEV_LINE_COUNT,
                             _LINE_MAX_LENGTH, sort_target=True, seed_train=_SEED_TRAIN, seed_dev=_SEED_DEV) as data:
@@ -181,6 +182,7 @@ def test_seq_sort(train_params, translate_params, perplexity_thresh, bleu_thresh
                                                               max_seq_len=_LINE_MAX_LENGTH + 1,
                                                               restrict_lexicon=True,
                                                               work_dir=data['work_dir'])
+        logger.info("test: %s", name)
         logger.info("perplexity=%f, bleu=%f, bleu_restrict=%f", perplexity, bleu, bleu_restrict)
         assert perplexity <= perplexity_thresh
         assert bleu >= bleu_thresh


### PR DESCRIPTION
…mbining attention heads, even if input & output depth do not differ. Updated a system test to account for the additional parameters. Named system tests for easier selection using , for example "pytest -k "Copy:transformer".

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md

