### PR TITLE
Updated exception logging for Python3.4

### DIFF
--- a/sockeye/log.py
+++ b/sockeye/log.py
@@ -97,6 +97,11 @@ LOGGING_CONFIGS = {
 }
 
 
+def _is_python34() -> bool:
+    version = sys.version_info
+    return version[0] == 3 and version[1] == 4
+
+
 def setup_main_logger(name: str, file_logging=True, console=True, path: Optional[str] = None) -> logging.Logger:
     """
     Return a logger that configures logging for the main application.
@@ -120,7 +125,13 @@ def setup_main_logger(name: str, file_logging=True, console=True, path: Optional
     logger = logging.getLogger(name)
 
     def exception_hook(exc_type, exc_value, exc_traceback):
-        logger.exception("UNCAUGHT EXCEPTION", exc_info=(exc_type, exc_value, exc_traceback))
+        if _is_python34():
+            # Python3.4 does not seem to handle logger.exception() well
+            import traceback
+            traceback = "".join(traceback.format_tb(exc_traceback)) + exc_type.name
+            logger.error("Uncaught exception\n%s", traceback)
+        else:
+            logger.exception("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
 
     sys.excepthook = exception_hook
 


### PR DESCRIPTION
This addresses an issue with Python3.4 where the logger.exception() call does not seem to work properly.
If running on Python3.4 this now formats and logs the exception + traceback explicitly.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)

