### PR TITLE
Attention in upper layer fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 For each item we will potentially have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.13.0]
+### Fixed
+ - Fixed the attention in upper layers (`--rnn-attention-in-upper-layers`), which was previously not passed correctly
+   to the decoder.
+
 ## [1.12.2]
 ### Changed
  - Updated to [MXNet 0.12.1](https://github.com/apache/incubator-mxnet/releases/tag/0.12.1), which includes an important

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.12.2'
+__version__ = '1.13.0'

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -492,7 +492,7 @@ class RecurrentDecoder(Decoder):
                                   "output dimensions do not match.")
 
         # Stacked RNN
-        if self.rnn_config.num_layers == 1 or not self.rnn_config.attention_in_upper_layers:
+        if self.rnn_config.num_layers == 1 or not self.config.attention_in_upper_layers:
             self.rnn_pre_attention = rnn.get_stacked_rnn(self.rnn_config, self.prefix, parallel_inputs=False)
             self.rnn_post_attention = None
         else:
@@ -536,7 +536,8 @@ class RecurrentDecoder(Decoder):
         Creates parameters for encoder last state transformation into decoder layer initial states.
         """
         self.init_ws, self.init_bs, self.init_norms = [], [], []
-        state_shapes = self.rnn_pre_attention.state_shape
+        # shallow copy of the state shapes:
+        state_shapes = list(self.rnn_pre_attention.state_shape)
         if self.rnn_post_attention:
             state_shapes += self.rnn_post_attention.state_shape
         for state_idx, (_, init_num_hidden) in enumerate(state_shapes):
@@ -689,7 +690,8 @@ class RecurrentDecoder(Decoder):
         Calls reset on the RNN cell.
         """
         self.rnn_pre_attention.reset()
-        cells_to_reset = self.rnn_pre_attention._cells
+        # Shallow copy of cells
+        cells_to_reset = list(self.rnn_pre_attention._cells)
         if self.rnn_post_attention:
             self.rnn_post_attention.reset()
             cells_to_reset += self.rnn_post_attention._cells

--- a/sockeye/rnn.py
+++ b/sockeye/rnn.py
@@ -47,8 +47,7 @@ class RNNConfig(Config):
                  dropout_recurrent: float = 0,
                  residual: bool = False,
                  first_residual_layer: int = 2,
-                 forget_bias: float = 0.0,
-                 attention_in_upper_layers: bool = False) -> None:
+                 forget_bias: float = 0.0) -> None:
         super().__init__()
         self.cell_type = cell_type
         self.num_hidden = num_hidden
@@ -59,7 +58,6 @@ class RNNConfig(Config):
         self.residual = residual
         self.first_residual_layer = first_residual_layer
         self.forget_bias = forget_bias
-        self.attention_in_upper_layers = attention_in_upper_layers
 
 
 class SequentialRNNCellParallelInput(mx.rnn.SequentialRNNCell):


### PR DESCRIPTION
Attention in upper layers had reasons for why it wasn't working in the current master:
1. in `train.py` `attention_in_upper_layers` was set for RecurrentDecoderConfig but in the decoder it was read from RNNConfig, where the default value of `False` was used.
2. Both the `state_shapes` and the `_cells` members where modified in `_create_state_init_parameters ` and `reset `. This was fixed by doing a shallow copy.


