### PR TITLE
sacrebleu 1.1.7 update

### DIFF
--- a/contrib/sacrebleu/README.md
+++ b/contrib/sacrebleu/README.md
@@ -67,6 +67,10 @@ Sacré BLEU.
 
 # VERSION HISTORY
 
+- 1.1.7 (22 November 2017)
+   - small bugfix in tokenization_13a (not affecting WMT references)
+     thanks to Martin Popel
+
 - 1.1.6 (15 November 2017)
    - bugfix for tokenization warning
 

--- a/contrib/sacrebleu/README.md
+++ b/contrib/sacrebleu/README.md
@@ -67,9 +67,11 @@ Sacré BLEU.
 
 # VERSION HISTORY
 
-- 1.1.7 (22 November 2017)
-   - small bugfix in tokenization_13a (not affecting WMT references)
-     thanks to Martin Popel
+- 1.1.7 (27 November 2017)
+   - thanks to Martin Popel for:
+      - small bugfix in tokenization_13a (not affecting WMT references)
+      - adding `--tok intl` (international tokenization)
+   - added wmt17/dev and wmt17/dev sets (for languages intro'd those years)
 
 - 1.1.6 (15 November 2017)
    - bugfix for tokenization warning
@@ -94,9 +96,9 @@ Sacré BLEU.
 
 - 1.0.3 (4 November 2017).
    - Contributions from Christian Federmann:
-   - Added explicit support for encoding  
-   - Fixed Windows support
-   - Bugfix in handling reference length with multiple refs
+      - Added explicit support for encoding  
+      - Fixed Windows support
+      - Bugfix in handling reference length with multiple refs
 
 - version 1.0.1 (1 November 2017).
    - Small bugfix affecting some versions of Python.

--- a/contrib/sacrebleu/README.md
+++ b/contrib/sacrebleu/README.md
@@ -68,6 +68,7 @@ Sacré BLEU.
 # VERSION HISTORY
 
 - 1.1.7 (27 November 2017)
+   - corpus_bleu() now raises an exception if input streams are different lengths
    - thanks to Martin Popel for:
       - small bugfix in tokenization_13a (not affecting WMT references)
       - adding `--tok intl` (international tokenization)

--- a/contrib/sacrebleu/sacrebleu.py
+++ b/contrib/sacrebleu/sacrebleu.py
@@ -13,7 +13,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-VERSION = '1.1.6'
+VERSION = '1.1.7'
 
 """
 SacréBLEU provides hassle-free computation of shareable, comparable, and reproducible BLEU scores.
@@ -84,6 +84,10 @@ After all, even with all its problems, BLEU is the default and---admit it---well
 Sacré BLEU.
 
 # VERSION HISTORY
+
+- 1.1.7 (22 November 2017)
+   - small bugfix in tokenization_13a (not affecting WMT references)
+     thanks to Martin Popel
 
 - 1.1.6 (15 November 2017)
    - bugfix for tokenization warning
@@ -394,9 +398,9 @@ def tokenize_13a(line):
     norm = norm.replace('-\n', '')
     norm = norm.replace('\n', ' ')
     norm = norm.replace('&quot;', '"')
-    norm = norm.replace('&amp;', '"')
-    norm = norm.replace('&lt;', '"')
-    norm = norm.replace('&gt;', '"')
+    norm = norm.replace('&amp;', '&')
+    norm = norm.replace('&lt;', '<')
+    norm = norm.replace('&gt;', '>')
 
     # language-dependent part (assuming Western languages):
     norm = " {} ".format(norm)

--- a/contrib/sacrebleu/sacrebleu.py
+++ b/contrib/sacrebleu/sacrebleu.py
@@ -915,7 +915,7 @@ def main():
                             help='use case-insensitive BLEU (default: actual case)')
     arg_parser.add_argument('--smooth', '-s', choices=['exp', 'floor', 'none'], default='exp',
                             help='smoothing method: exponential decay (default), floor (0 count -> 0.01), or none')
-    arg_parser.add_argument('--tokenize', '-tok', choices=list(filter(lambda x: x != 'none', TOKENIZERS.keys())), default='13a',
+    arg_parser.add_argument('--tokenize', '-tok', choices=[x for x in TOKENIZERS.keys() if x != 'none'], default='13a',
                             help='tokenization method to use')
     arg_parser.add_argument('--language-pair', '-l', dest='langpair', default=None,
                             help='source-target language pair (2-char ISO639-1 codes)')

--- a/contrib/sacrebleu/sacrebleu.py
+++ b/contrib/sacrebleu/sacrebleu.py
@@ -85,9 +85,11 @@ Sacré BLEU.
 
 # VERSION HISTORY
 
-- 1.1.7 (22 November 2017)
-   - small bugfix in tokenization_13a (not affecting WMT references)
-     thanks to Martin Popel
+- 1.1.7 (27 November 2017)
+   - thanks to Martin Popel for:
+      - small bugfix in tokenization_13a (not affecting WMT references)
+      - adding `--tok intl` (international tokenization)
+   - added wmt17/dev and wmt17/dev sets (for languages intro'd those years)
 
 - 1.1.6 (15 November 2017)
    - bugfix for tokenization warning
@@ -112,9 +114,9 @@ Sacré BLEU.
 
 - 1.0.3 (4 November 2017).
    - Contributions from Christian Federmann:
-   - Added explicit support for encoding  
-   - Fixed Windows support
-   - Bugfix in handling reference length with multiple refs
+      - Added explicit support for encoding  
+      - Fixed Windows support
+      - Bugfix in handling reference length with multiple refs
 
 - version 1.0.1 (1 November 2017).
    - Small bugfix affecting some versions of Python.
@@ -216,6 +218,14 @@ data = {
         'en-zh': ['newstest2017-enzh-src.en.sgm', 'newstest2017-enzh-ref.zh.sgm'],
         'zh-en': ['newstest2017-zhen-src.zh.sgm', 'newstest2017-zhen-ref.en.sgm'],
     },
+    'wmt17/dev': {
+        'data': 'http://data.statmt.org/wmt17/translation-task/dev.tgz',
+        'description': 'Development sets released for new languages in 2017.',
+        'en-lv': ['dev/newsdev2017-enlv-src.en.sgm', 'dev/newsdev2017-enlv-ref.lv.sgm'], 
+        'en-zh': ['dev/newsdev2017-enzh-src.en.sgm', 'dev/newsdev2017-enzh-ref.zh.sgm'],
+        'lv-en': ['dev/newsdev2017-lven-src.lv.sgm', 'dev/newsdev2017-lven-ref.en.sgm'],
+        'zh-en': ['dev/newsdev2017-zhen-src.zh.sgm', 'dev/newsdev2017-zhen-ref.en.sgm'],
+    },
     'wmt16': {
         'data': 'http://data.statmt.org/wmt16/translation-task/test.tgz',
         'description': 'Official evaluation data.',
@@ -241,6 +251,14 @@ data = {
         'data': 'http://data.statmt.org/wmt16/translation-task/test.tgz',
         'description': 'EN-FI with two references.',
         'en-fi': ['test/newstest2016-enfi-src.en.sgm', 'test/newstest2016-enfi-ref.fi.sgm', 'test/newstestB2016-enfi-ref.fi.sgm'],
+    },
+    'wmt16/dev': {
+        'data': 'http://data.statmt.org/wmt16/translation-task/dev.tgz',
+        'description': 'Development sets released for new languages in 2016.',
+        'en-ro': ['dev/newsdev2016-enro-src.en.sgm', 'dev/newsdev2016-enro-ref.ro.sgm'],
+        'en-tr': ['dev/newsdev2016-entr-src.en.sgm', 'dev/newsdev2016-entr-ref.tr.sgm'],
+        'ro-en': ['dev/newsdev2016-roen-src.ro.sgm', 'dev/newsdev2016-roen-ref.en.sgm'],
+        'tr-en': ['dev/newsdev2016-tren-src.tr.sgm', 'dev/newsdev2016-tren-ref.en.sgm']
     },
     'wmt15': {
         'data': 'http://statmt.org/wmt15/test.tgz',

--- a/test/unit/test_bleu.py
+++ b/test/unit/test_bleu.py
@@ -50,6 +50,8 @@ test_case_degenerate_stats = [((Statistics([0, 0, 0, 0], [4, 4, 2, 1]), 0, 1), 0
                               ((Statistics([0, 0, 0, 0], [0, 0, 0, 0]), 0, 0), 0.1, 0.0),
                               ((Statistics([0, 0, 0, 0], [0, 0, 0, 0]), 1, 5), 0.01, 0.0)]
 
+test_cases_uneven = [(["I am one sentence"], ["But I", "am two"]),
+                     (["And I", "am a number of sentences", "three actually"], ["Compared to just one reference"])]
 
 @pytest.mark.parametrize("hypotheses, references, expected_bleu", test_cases)
 def test_bleu(hypotheses, references, expected_bleu):
@@ -85,7 +87,20 @@ def test_offset(hypothesis, reference, expected_with_offset, expected_without_of
     score_with_offset = sacrebleu.raw_corpus_bleu(hypothesis, reference, 0.1).score / 100
     assert abs(expected_with_offset - score_with_offset) < EPSILON
 
+
 @pytest.mark.parametrize("statistics, offset, expected_score", test_case_degenerate_stats)
 def test_degenerate_statistics(statistics, offset, expected_score):
     score = sacrebleu.compute_bleu(statistics[0].common, statistics[0].total, statistics[1], statistics[2], smooth='floor', smooth_floor=offset).score / 100
     assert score == expected_score
+
+
+@pytest.mark.parametrize("hypotheses, references, expected_bleu", test_cases)
+def test_bleu(hypotheses, references, expected_bleu):
+    bleu = sacrebleu.raw_corpus_bleu(hypotheses, [references], .01).score / 100
+    assert abs(bleu - expected_bleu) < EPSILON
+
+
+@pytest.mark.parametrize("hypotheses, references", test_cases_uneven)
+def test_degenerate_uneven(hypotheses, references):
+    with pytest.raises(EOFError, match=r'.*stream.*'):
+        sacrebleu.raw_corpus_bleu(hypotheses, references)

--- a/test/unit/test_bleu.py
+++ b/test/unit/test_bleu.py
@@ -94,12 +94,6 @@ def test_degenerate_statistics(statistics, offset, expected_score):
     assert score == expected_score
 
 
-@pytest.mark.parametrize("hypotheses, references, expected_bleu", test_cases)
-def test_bleu(hypotheses, references, expected_bleu):
-    bleu = sacrebleu.raw_corpus_bleu(hypotheses, [references], .01).score / 100
-    assert abs(bleu - expected_bleu) < EPSILON
-
-
 @pytest.mark.parametrize("hypotheses, references", test_cases_uneven)
 def test_degenerate_uneven(hypotheses, references):
     with pytest.raises(EOFError, match=r'.*stream.*'):


### PR DESCRIPTION
Updates to 1.1.7

Changes:
- added wmt17/dev and wmt17/dev sets (for languages intro'd those years)
- thanks to Martin Popel for:
   - small bugfix in tokenization_13a (not affecting WMT references)
   - adding `--tok intl` (international tokenization)


#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md

