### PR TITLE
Length argument for dot_attention is now optional. Saves a SequenceMa…

### DIFF
--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -182,7 +182,7 @@ class Encoder(ABC):
     @abstractmethod
     def encode(self,
                data: mx.sym.Symbol,
-               data_length: mx.sym.Symbol,
+               data_length: Optional[mx.sym.Symbol],
                seq_len: int) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, int]:
         """
         Encodes data given sequence lengths of individual examples and maximum sequence length.
@@ -220,7 +220,7 @@ class BatchMajor2TimeMajor(Encoder):
 
     def encode(self,
                data: mx.sym.Symbol,
-               data_length: mx.sym.Symbol,
+               data_length: Optional[mx.sym.Symbol],
                seq_len: int) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, int]:
         """
         Encodes data given sequence lengths of individual examples and maximum sequence length.
@@ -593,7 +593,7 @@ class RecurrentEncoder(Encoder):
 
     def encode(self,
                data: mx.sym.Symbol,
-               data_length: mx.sym.Symbol,
+               data_length: Optional[mx.sym.Symbol],
                seq_len: int) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, int]:
         """
         Encodes data given sequence lengths of individual examples and maximum sequence length.

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -87,9 +87,9 @@ class TransformerEncoderBlock:
                                                dropout=config.dropout_prepost,
                                                prefix="%sff_post_" % prefix)
 
-    def __call__(self, data: mx.sym.Symbol, data_length: mx.sym.Symbol, length: int) -> mx.sym.Symbol:
+    def __call__(self, data: mx.sym.Symbol, lengths: mx.sym.Symbol, max_length: int) -> mx.sym.Symbol:
         # self-attention
-        data_self_att = self.self_attention(self.pre_self_attention(data, None), data_length, length)
+        data_self_att = self.self_attention(self.pre_self_attention(data, None), max_length, lengths=lengths, bias=None)
         data = self.post_self_attention(data_self_att, data)
 
         # feed-forward
@@ -151,7 +151,6 @@ class TransformerDecoderBlock:
 
     def __call__(self,
                  target: mx.sym.Symbol,
-                 target_lengths: mx.sym.Symbol,
                  target_max_length: int,
                  target_bias: mx.sym.Symbol,
                  source: mx.sym.Symbol,
@@ -160,8 +159,8 @@ class TransformerDecoderBlock:
 
         # self-attention
         target_self_att = self.self_attention(self.pre_self_attention(target, None),
-                                              target_lengths,
                                               target_max_length,
+                                              lengths=None,
                                               bias=target_bias)
         target = self.post_self_attention(target_self_att, target)
 


### PR DESCRIPTION
…sk for self-attention in transformer decoders, as they always use an auto-regressive target bias.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)

