### PR TITLE
reorganized beam search for pruning

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -842,6 +842,11 @@ def add_inference_args(params):
                                type=int_greater_or_equal(1),
                                default=5,
                                help='Size of the beam. Default: %(default)s.')
+    decode_params.add_argument('--beam-prune', '-p',
+                               type=float,
+                               default=0,
+                               help='Pruning threshold for beam search. All hypotheses with unnormalized scores less than '
+                               'this amount below the best (unnormalized) hypothesis are discarded (0 = off).')
     decode_params.add_argument('--batch-size',
                                type=int_greater_or_equal(1),
                                default=1,

--- a/sockeye/checkpoint_decoder.py
+++ b/sockeye/checkpoint_decoder.py
@@ -129,6 +129,7 @@ class CheckpointDecoder:
                                           self.bucket_width_source,
                                           self.bucket_width_target,
                                           inference.LengthPenalty(self.length_penalty_alpha, self.length_penalty_beta),
+                                          0.0,
                                           models,
                                           vocab_source,
                                           vocab_target)

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -84,6 +84,7 @@ def main():
                                                   bucket_target_width,
                                                   sockeye.inference.LengthPenalty(args.length_penalty_alpha,
                                                                                   args.length_penalty_beta),
+                                                  args.beam_prune,
                                                   models,
                                                   vocab_source,
                                                   vocab_target,

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -214,8 +214,7 @@ class Accuracy(mx.metric.EvalMetric):
             self.num_inst += n
 
 
-def smallest_k(matrix: np.ndarray, k: int,
-               only_first_row: bool = False) -> Tuple[Tuple[np.ndarray, np.ndarray], np.ndarray]:
+def smallest_k(matrix: np.ndarray, k: int) -> Tuple[Tuple[np.ndarray, np.ndarray], np.ndarray]:
     """
     Find the smallest elements in a numpy matrix.
 
@@ -224,10 +223,7 @@ def smallest_k(matrix: np.ndarray, k: int,
     :param only_first_row: If true the search is constrained to the first row of the matrix.
     :return: The row indices, column indices and values of the k smallest items in matrix.
     """
-    if only_first_row:
-        flatten = matrix[:1, :].flatten()
-    else:
-        flatten = matrix.flatten()
+    flatten = matrix.flatten()
 
     # args are the indices in flatten of the k smallest elements
     args = np.argpartition(flatten, k)[:k]

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -184,6 +184,7 @@ def test_training_arg(test_params, expected_params):
                       checkpoints=None,
                       models=['model'],
                       beam_size=5,
+                      beam_prune=0,
                       batch_size=1,
                       chunk_size=1,
                       ensemble_mode='linear',


### PR DESCRIPTION
- each sentence now has an active beam size, which generalizes the former special case for t=1 and allows pruning
- length normalization is applied only to completed hypotheses
- `--beam-prune` specifies a width that will prune all hypotheses outside the beam set by the best completed hyp's value

#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md

