### PR TITLE
[WIP] Fix stopping criterion bug in beam search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.15]
+### Fixed
+- Fixed a bug during beam search stopping. Instead of stopping when all the `beam_size` hypothesis were finished, the model was continuing to decode due to losing track of when they had all finished. Now the models translate faster and quality also improved.
+
 ## [1.14.1]
 ### Changed
  - Sorting sentences during decoding before splitting them into batches.

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1085,7 +1085,7 @@ class Translator:
             lengths += mx.nd.cast(1 - mx.nd.expand_dims(finished, axis=1), dtype='float32')
 
             # (6) determine which hypotheses in the beam are now finished
-            finished = ((best_word_indices == C.PAD_ID) + (best_word_indices == self.vocab_target[C.EOS_SYMBOL]))
+            finished = mx.nd.max(sequences == self.vocab_target[C.EOS_SYMBOL], axis=1)
             if mx.nd.sum(finished).asscalar() == self.batch_size * self.beam_size:  # all finished
                 break
 


### PR DESCRIPTION
Small fix for a large bug in beam search. In the context of generating [beam visualisation similar to OpenNMT's](http://opennmt.net/OpenNMT/translation/beam_search/#visualizing-the-beam-search) (PR coming at a later stage) I noticed that the beam search was running along many more time steps after all the hypothesis were completed, often hitting the max length. Here is an example:

<img width="1158" alt="beam_broken" src="https://user-images.githubusercontent.com/6504048/33514978-add3910c-d75c-11e7-9701-6598ae1fe17d.png">

In the above example, the beam went on for 4 extra steps that are essentially wasted computation. 

The problem was relying on `best_word_indices` to determine which hypothesis are finished. Since we run the whole beam forward, the hypothesis were generating beyond the `EOS_TOKEN` (ID 3), and this was throwing off the `finished` array.

For example, at this time step `t`, the second hypothesis has finished and all the values seem reasonable:

<img width="853" alt="screen shot 2017-12-02 at 02 58 43" src="https://user-images.githubusercontent.com/6504048/33515001-2a2b866a-d75d-11e7-9a6d-e2993f352782.png">

If we move the beam one step forward, `finished` only marks the fourth and fifth hypotheses as finished. The second one went on a loop generating token 30:

<img width="1066" alt="screen shot 2017-12-02 at 02 59 33" src="https://user-images.githubusercontent.com/6504048/33515029-7554ff22-d75d-11e7-8b4a-d1e5947fd14b.png">

The fix is not to rely on `best_word_indices` to determine which hypothesis are complete, but get it directly from `sequences` through a `max` over axis 1.

I tested my change on a small model trained on IWSLT data and got a 1.5x speed up (GPU decoding on a p2.xlarge):

* **Without fix**: `[INFO:__main__] Processed 5431 lines in 5431 batches. Total time: 1773.8679, sec/sent: 0.3266, sent/sec: 3.0617`
* **With fix**: `[INFO:__main__] Processed 5431 lines in 5431 batches. Total time: 1181.2254, sec/sent: 0.2175, sent/sec: 4.5978`

The quality also improved (detokenised, IWSLT DE->EN test set):

* **Without fix**: 26.82 BLEU
* **With fix**: 32.76 BLEU

A quick diff on the tokenised data shows that a lot of the end repetitions are gone (fix on the right):

<img width="1376" alt="screen shot 2017-12-02 at 05 26 11" src="https://user-images.githubusercontent.com/6504048/33515607-ec4b9c78-d765-11e7-9c9f-f61854826d0b.png">

A look at a before and after on one of the more wasteful beam searches shows the improvement:

**Without fix**:

<img width="987" alt="screen shot 2017-12-02 at 04 42 42" src="https://user-images.githubusercontent.com/6504048/33515628-1abcdcde-d766-11e7-9f39-f66bed2b2738.png">

**With fix**:

<img width="481" alt="screen shot 2017-12-02 at 04 42 54" src="https://user-images.githubusercontent.com/6504048/33515623-11fe46b4-d766-11e7-9c84-eb05ee366be7.png">

## Still to do

* The above was tested on sockeye 1.12.0. I would have to confirm the changes on the latest master.
* PR forthcoming on adding the beam visualization and dumping to a json format, to better diagnose these kinds of problems in the future.
* It seems the problem is not fully fixed, as can be seen in one of the beam searches with the fix below, it seems that sockeye is still trying to generate hypotheses past an EOS. I haven't had time to do a deeper dive into this. Probably the beam search code should be rewritten to be cleaner and allow more flexibility for dropping/filtering hypotheses. For now the current change already brings improvement.

<img width="932" alt="screen shot 2017-12-02 at 13 41 41" src="https://user-images.githubusercontent.com/6504048/33515658-9d62559c-d766-11e7-8980-567d5f92c12d.png">


#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [X] Updated CHANGELOG.md