### PR TITLE
init_embedding.py now supports all vocabulary-sized weights and raw Sockeye parameters

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1045,13 +1045,13 @@ def add_build_vocab_args(params):
 
 def add_init_embedding_args(params):
     params.add_argument('--embeddings', '-e', required=True, nargs='+',
-                        help='List of input embedding weights in .npy format.')
+                        help='List of input (embedding) weights in .npy, .npz or Sockeye parameter format.')
     params.add_argument('--vocabularies-in', '-i', required=True, nargs='+',
                         help='List of input vocabularies as token-index dictionaries in .json format.')
     params.add_argument('--vocabularies-out', '-o', required=True, nargs='+',
                         help='List of output vocabularies as token-index dictionaries in .json format.')
     params.add_argument('--names', '-n', required=True, nargs='+',
-                        help='List of Sockeye parameter names for embedding weights.')
+                        help='List of Sockeye parameter names for (embedding) weights.')
     params.add_argument('--file', '-f', required=True,
                         help='File to write initialized parameters to.')
     params.add_argument('--encoding', '-c', type=str, default=C.VOCAB_ENCODING,

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1044,8 +1044,8 @@ def add_build_vocab_args(params):
 
 
 def add_init_embedding_args(params):
-    params.add_argument('--embeddings', '-e', required=True, nargs='+',
-                        help='List of input (embedding) weights in .npy, .npz or Sockeye parameter format.')
+    params.add_argument('--weight-files', '-w', required=True, nargs='+',
+                        help='List of input weight files in .npy, .npz or Sockeye parameter format.')
     params.add_argument('--vocabularies-in', '-i', required=True, nargs='+',
                         help='List of input vocabularies as token-index dictionaries in .json format.')
     params.add_argument('--vocabularies-out', '-o', required=True, nargs='+',

--- a/test/unit/test_init_embedding.py
+++ b/test/unit/test_init_embedding.py
@@ -25,7 +25,7 @@ import sockeye.init_embedding as init_embedding
          {'w2': 0, 'w3': 1, 'w4': 2, 'w5': 3},
          mx.nd.array([[2, 2, 2], [3, 3, 3], [0, 0, 0], [0, 0, 0]]))
 ])
-def test_init_embedding(embed, vocab_in, vocab_out, expected_embed_init):
-    embed_init = init_embedding.init_embedding(embed, vocab_in, vocab_out)
+def test_init_weight(embed, vocab_in, vocab_out, expected_embed_init):
+    embed_init = init_embedding.init_weight(embed, vocab_in, vocab_out)
 
     assert (embed_init == expected_embed_init).asnumpy().all()


### PR DESCRIPTION
init_embedding.py now supports all vocabulary-sized weights (e.g. source/target_embed_weight, target_output_weight and target_output_bias) and raw Sockeye parameters (e.g. params.XXX).

#### Pull Request Checklist ##
- [X] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [X] Unit tests pass (`pytest`)
- [X] System tests pass (`pytest test/system`)
- [X] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [X] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


  