### PR TITLE
[WIP] initial implementation of scheduled sampling; do not merge

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -805,6 +805,17 @@ def add_training_args(params):
                               type=int,
                               default=-1,
                               help='Keep only the last n params files, use -1 to keep all files. Default: %(default)s')
+    train_params.add_argument('--scheduled-sampling-type',
+                              choices=C.SAMPLING_SCHEDULES,
+                              default=None,
+                              help="Use scheduled sampling as target side in training rather than teacher forcing."
+                                   "Default: %(default).")
+    train_params.add_argument('--scheduled-sampling-params',
+                              nargs='+',
+                              type=float,
+                              default=None,
+                              help="Parameters of the scheduled sampling decay strategy (Bengio NIPS '15).")
+
 
 
 def add_train_cli_args(params):

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -263,6 +263,11 @@ LR_DECAY_OPT_STATES_RESET_CHOICES = [LR_DECAY_OPT_STATES_RESET_OFF,
                                      LR_DECAY_OPT_STATES_RESET_INITIAL,
                                      LR_DECAY_OPT_STATES_RESET_BEST]
 
+# Scheduled sampling decay rates
+SAMPLING_SCHEDULES = ["linear-decay", "exponential-decay", "inv-sigmoid-decay"]
+COMPUTE_LOG_PROB_EPSILON = 1e-10
+
+
 GRADIENT_CLIPPING_TYPE_ABS = 'abs'
 GRADIENT_CLIPPING_TYPE_NORM = 'norm'
 GRADIENT_CLIPPING_TYPE_NONE = 'none'

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -61,6 +61,8 @@ class ModelConfig(Config):
                  config_encoder: Config,
                  config_decoder: Config,
                  config_loss: loss.LossConfig,
+                 scheduled_sampling_type: Optional[str] = None,
+                 scheduled_sampling_params: Optional[list] = None,
                  weight_tying: bool = False,
                  weight_tying_type: Optional[str] = C.WEIGHT_TYING_TRG_SOFTMAX,
                  weight_normalization: bool = False) -> None:
@@ -75,11 +77,14 @@ class ModelConfig(Config):
         self.config_encoder = config_encoder
         self.config_decoder = config_decoder
         self.config_loss = config_loss
+        self.scheduled_sampling_type = scheduled_sampling_type
+        self.scheduled_sampling_params = scheduled_sampling_params
         self.weight_tying = weight_tying
         self.weight_tying_type = weight_tying_type
         self.weight_normalization = weight_normalization
         if weight_tying and weight_tying_type is None:
             raise RuntimeError("weight_tying_type must be specified when using weight_tying.")
+
 
 
 class SockeyeModel:


### PR DESCRIPTION
Feedback requested: basic implementation of scheduled sampling performed in sym_gen rather than in the decoder. This version runs but converges much more slowly than the vanilla version without sampling. There is an issue in tracking the 'updates' state of the training module to where we compute the sampling threshold.

#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

