### PR TITLE
Restrict device locking to a single process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.16.5]
+### Changed
+ - Device locking: Only one process will be acquiring GPUs at a time.
+ This will lead to consecutive device ids whenever possible.
+
 ## [1.16.4]
 ### Changed
  - Internal change: Standardized all data to be batch-major both at training and at inference time.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.16.4'
+__version__ = '1.16.5'

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 import time
 from contextlib import contextmanager, ExitStack
-from typing import Mapping, Any, List, Iterator, Iterable, Set, Tuple, Dict, Optional, Union, IO
+from typing import Mapping, Any, List, Iterator, Iterable, Set, Tuple, Dict, Optional, Union, IO, TypeVar
 
 import fcntl
 import mxnet as mx
@@ -564,33 +564,45 @@ def acquire_gpus(requested_device_ids: List[int], lock_dir: str = "/tmp",
     candidates_to_request += [remaining_device_ids for _ in range(num_arbitrary_device_ids)]
 
     while True:
+
         with ExitStack() as exit_stack:
-            acquired_gpus = []  # type: List[int]
             any_failed = False
-            for candidates in candidates_to_request:
-                gpu_id = exit_stack.enter_context(GpuFileLock(candidates=candidates, lock_dir=lock_dir))  # type: ignore
-                if gpu_id is not None:
-                    acquired_gpus.append(gpu_id)
-                else:
-                    if len(candidates) == 1:
-                        logger.info("Could not acquire GPU %d. It's currently locked.", candidates[0])
-                    any_failed = True
-                    break
-            if not any_failed:
+            acquired_gpus = []  # type: List[int]
+            with GpuFileLock(candidates=["master_lock"], lock_dir=lock_dir) as master_lock:
+                # Only one process, determined by the master lock, can try acquiring gpu locks at a time.
+                # This will make sure that we use consecutive device ids whenever possible.
+                if master_lock is not None:
+                    for candidates in candidates_to_request:
+                        gpu_id = exit_stack.enter_context(GpuFileLock(candidates=candidates,
+                                                                      lock_dir=lock_dir))  # type: ignore
+                        if gpu_id is not None:
+                            acquired_gpus.append(gpu_id)
+                        else:
+                            if len(candidates) == 1:
+                                logger.info("Could not acquire GPU %d. It's currently locked.", candidates[0])
+                            any_failed = True
+                            break
+            if master_lock is not None and not any_failed:
                 try:
                     yield acquired_gpus
                 except:
                     raise
                 return
-        # couldn't acquire all GPUs, let's wait and try again later
 
         # randomize so that multiple processes starting at the same time don't retry at a similar point in time
         if retry_wait_rand > 0:
             retry_wait_actual = retry_wait_min + random.randint(0, retry_wait_rand)
         else:
             retry_wait_actual = retry_wait_min
-        logger.info("Not enough GPUs available will try again in %ss." % retry_wait_actual)
+
+        if master_lock is None:
+            logger.info("Another process is acquiring GPUs at the moment will try again in %ss." % retry_wait_actual)
+        else:
+            logger.info("Not enough GPUs available will try again in %ss." % retry_wait_actual)
         time.sleep(retry_wait_actual)
+
+
+GpuDeviceType = TypeVar('GpuDeviceType')
 
 
 class GpuFileLock:
@@ -602,22 +614,23 @@ class GpuFileLock:
     :param lock_dir: The directory for storing the lock file.
     """
 
-    def __init__(self, candidates: List[int], lock_dir: str) -> None:
+    def __init__(self, candidates: List[GpuDeviceType], lock_dir: str) -> None:
         self.candidates = candidates
         self.lock_dir = lock_dir
         self.lock_file = None  # type: Optional[IO[Any]]
         self.lock_file_path = None  # type: Optional[str]
-        self.gpu_id = None  # type: Optional[int]
+        self.gpu_id = None  # type: Optional[GpuDeviceType]
         self._acquired_lock = False
 
-    def __enter__(self) -> Optional[int]:
+    def __enter__(self) -> Optional[GpuDeviceType]:
         for gpu_id in self.candidates:
-            lockfile_path = os.path.join(self.lock_dir, "sockeye.gpu%d.lock" % gpu_id)
+            lockfile_path = os.path.join(self.lock_dir, "sockeye.gpu{}.lock".format(gpu_id))
             try:
                 lock_file = open(lockfile_path, 'w')
             except IOError as e:
                 if errno.EACCES:
-                    logger.warning("GPU %d is currently locked by a different process (Permission denied).", gpu_id)
+                    logger.warning("GPU {} is currently locked by a different process "
+                                   "(Permission denied).".format(gpu_id))
                     continue
             try:
                 # exclusive non-blocking lock
@@ -631,7 +644,7 @@ class GpuFileLock:
                 self.lock_file = lock_file
                 self.lockfile_path = lockfile_path
 
-                logger.info("Acquired GPU %d." % gpu_id)
+                logger.info("Acquired GPU {}.".format(gpu_id))
 
                 return gpu_id
             except IOError as e:
@@ -640,12 +653,12 @@ class GpuFileLock:
                     logger.error("Failed acquiring GPU lock.", exc_info=True)
                     raise
                 else:
-                    logger.debug("GPU %d is currently locked.", gpu_id)
+                    logger.debug("GPU {} is currently locked.".format(gpu_id))
         return None
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.gpu_id is not None:
-            logger.info("Releasing GPU %d.", self.gpu_id)
+            logger.info("Releasing GPU {}.".format(self.gpu_id))
         if self.lock_file is not None:
             if self._acquired_lock:
                 fcntl.flock(self.lock_file, fcntl.LOCK_UN)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -64,6 +64,9 @@ def test_aquire_gpus(tmpdir, requested_device_ids, num_gpus_available, expected)
     with utils.acquire_gpus(requested_device_ids, lock_dir=str(tmpdir),
                             num_gpus_available=num_gpus_available) as acquired_gpus:
         assert set(acquired_gpus) == set(expected)
+        # make sure the master lock does not exist anymore after acquiring
+        # (but rather just one lock per acquired GPU)
+        assert len(tmpdir.listdir()) == len(acquired_gpus)
 
 
 # We expect the following settings to raise a ValueError


### PR DESCRIPTION
Device locking: Only one process will be acquiring GPUs at a time. This will lead to consecutive device ids whenever possible.

#### Pull Request Checklist ##
- [X] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [X] Unit tests pass (`pytest`)
- [X] You have considered writing a test
- [X] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [X] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

