### PR TITLE
Fix numpy warning in test_coverage_attention

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -47,17 +47,18 @@ def gaussian_vector(shape, return_symbol=False):
     return mx.sym.random_normal(shape=shape) if return_symbol else np.random.normal(size=shape)
 
 
-def integer_vector(shape, max_value, return_symbol=False):
+def integer_vector(shape, max_value, min_value=1, return_symbol=False):
     """
     Generates a random positive integer tensor
 
     :param shape: shape of the tensor.
     :param max_value: maximum integer value.
+    :param min_value: minimum integer value.
     :param return_symbol: True if the result should be a Symbol, False if it should be an Numpy array.
     :return: A random integer tensor.
     """
-    return mx.sym.round(mx.sym.random_uniform(shape=shape) * max_value) if return_symbol \
-        else np.round(np.random.uniform(size=shape) * max_value)
+    return mx.sym.round(mx.sym.random.uniform(low=min_value, high=max_value, shape=shape)) if return_symbol \
+        else np.random.randint(low=min_value, high=max_value, size=shape)
 
 
 def uniform_vector(shape, min_value=0, max_value=1, return_symbol=False):
@@ -70,7 +71,7 @@ def uniform_vector(shape, min_value=0, max_value=1, return_symbol=False):
     :param return_symbol: True if the result should be a mx.sym.Symbol, False if it should be a Numpy array
     :return:
     """
-    return mx.sym.random_uniform(low=min_value, high=max_value, shape=shape) if return_symbol \
+    return mx.sym.random.uniform(low=min_value, high=max_value, shape=shape) if return_symbol \
         else np.random.uniform(low=min_value, high=max_value, size=shape)
 
 

--- a/test/unit/test_attention.py
+++ b/test/unit/test_attention.py
@@ -15,9 +15,9 @@ import mxnet as mx
 import numpy as np
 import pytest
 
-import sockeye.rnn_attention
 import sockeye.constants as C
 import sockeye.coverage
+import sockeye.rnn_attention
 from test.common import gaussian_vector, integer_vector
 
 attention_types = [C.ATT_BILINEAR, C.ATT_DOT, C.ATT_DOT_SCALED, C.ATT_LOC, C.ATT_MLP]
@@ -119,7 +119,7 @@ def test_coverage_attention(attention_coverage_type,
     attention_prob_result = exec_output[1].asnumpy()
     dynamic_source_result = exec_output[2].asnumpy()
 
-    expected_probs = (1 / source_length_vector).reshape((batch_size, 1))
+    expected_probs = (1. / source_length_vector).reshape((batch_size, 1))
 
     assert context_result.shape == (batch_size, encoder_num_hidden)
     assert attention_prob_result.shape == (batch_size, source_seq_len)


### PR DESCRIPTION
This removes a warning when running pytest:
```
test/unit/test_attention.py::test_coverage_attention[tanh-4]
 [...]/test/unit/test_attention.py:124: RuntimeWarning: divide by zero encountered in true_divide
    expected_probs = np.ones_like(source_length_vector) /source_length_vector.reshape((batch_size, 1))

-- Docs: http://doc.pytest.org/en/latest/warnings.html
```

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [x] You have considered writing a test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

