### PR TITLE
Loading/saving/init auxiliary parameters of the models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
--# Changelog
+# Changelog
 All notable changes to the project are documented in this file.
 
 Version numbers are of the form `1.0.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+-# Changelog
 All notable changes to the project are documented in this file.
 
 Version numbers are of the form `1.0.0`.
@@ -9,6 +9,13 @@ e.g. due to changing the architecture or simply modifying model parameter names.
 Note that Sockeye has checks in place to not translate with an old model that was trained with an incompatible version.
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
+
+
+## [1.16.6]
+### Changed
+ - Loading/Saving auxiliary parameters of the models. Before aux parameters were not saved or used for initialization.
+ Therefore the parameters of certain layers were ignored (e.g., BatchNorm) and randomly initialized. This change
+ enables to properly load, save and initialize the layers which use auxiliary parameters.
 
 ## [1.16.5]
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.16.5'
+__version__ = '1.16.6'

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -131,8 +131,8 @@ class InferenceModel(model.SockeyeModel):
         self.decoder_module.bind(data_shapes=max_decoder_data_shapes, for_training=False, grad_req="null")
 
         self.load_params_from_file(self.fname_params)
-        self.encoder_module.init_params(arg_params=self.params, allow_missing=False)
-        self.decoder_module.init_params(arg_params=self.params, allow_missing=False)
+        self.encoder_module.init_params(arg_params=self.params, aux_params=self.aux_params, allow_missing=False)
+        self.decoder_module.init_params(arg_params=self.params, aux_params=self.aux_params, allow_missing=False)
 
         if self.cache_output_layer_w_b:
             if self.output_layer.weight_normalization:

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -110,6 +110,8 @@ class SockeyeModel:
         self.output_layer = None  # type: Optional[layers.OutputLayer]
         self._is_built = False
         self.params = None  # type: Optional[Dict]
+        self.aux_params = None  # type: Optional[Dict]
+
 
     def save_config(self, folder: str):
         """
@@ -140,7 +142,10 @@ class SockeyeModel:
         :param fname: Path to save parameters to.
         """
         assert self._is_built
-        utils.save_params(self.params.copy(), fname)
+        if self.aux_params is not None:
+            utils.save_params(self.params.copy(), fname, self.aux_params.copy())
+        else:
+            utils.save_params(self.params.copy(), fname)
         logging.info('Saved params to "%s"', fname)
 
     def load_params_from_file(self, fname: str):
@@ -153,7 +158,7 @@ class SockeyeModel:
         utils.check_condition(os.path.exists(fname), "No model parameter file found under %s. "
                                                      "This is either not a model directory or the first training "
                                                      "checkpoint has not happened yet." % fname)
-        self.params, _ = utils.load_params(fname)
+        self.params, self.aux_params = utils.load_params(fname)
         logger.info('Loaded params from "%s"', fname)
 
     @staticmethod

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -594,7 +594,8 @@ class TrainingModel(model.SockeyeModel):
 
     def _save_params(self, output_folder: str, checkpoint: int) -> str:
         """
-        Synchronizes parameters across devices, saves the parameters to disk, and updates self.params.
+        Synchronizes parameters across devices, saves the parameters to disk, and updates self.params
+        and self.aux_params.
 
         :param output_folder: The folder in which the parameters will be serialized in.
         :param checkpoint: The current checkpoint used for creating a unique parameter file name.
@@ -610,7 +611,7 @@ class TrainingModel(model.SockeyeModel):
 
     def _load_params(self, output_folder: str, checkpoint: int):
         """
-        Loads parameters from disk, sets self.params and module's parameters.
+        Loads parameters from disk, sets self.params, self.aux_params and module's parameters.
         """
         params_fname = os.path.join(output_folder, C.PARAMS_NAME % checkpoint)
         self.load_params_from_file(params_fname)  # sets self.params

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -270,7 +270,7 @@ class TrainingModel(model.SockeyeModel):
                          for_training=True, force_rebind=True, grad_req='write')
         self.module.symbol.save(os.path.join(output_folder, C.SYMBOL_NAME))
 
-        self.module.init_params(initializer=initializer, arg_params=self.params, aux_params=None,
+        self.module.init_params(initializer=initializer, arg_params=self.params, aux_params=self.aux_params,
                                 allow_missing=allow_missing_params, force_init=False)
         self._log_params()
         initial_params_fname = self._save_params(output_folder, checkpoint=0)
@@ -603,6 +603,7 @@ class TrainingModel(model.SockeyeModel):
         arg_params, aux_params = self.module.get_params()
         self.module.set_params(arg_params, aux_params)
         self.params = arg_params
+        self.aux_params = aux_params
         params_base_fname = C.PARAMS_NAME % checkpoint
         self.save_params_to_file(os.path.join(output_folder, params_base_fname))
         return params_base_fname
@@ -613,7 +614,7 @@ class TrainingModel(model.SockeyeModel):
         """
         params_fname = os.path.join(output_folder, C.PARAMS_NAME % checkpoint)
         self.load_params_from_file(params_fname)  # sets self.params
-        self.module.set_params(arg_params=self.params, aux_params={})
+        self.module.set_params(arg_params=self.params, aux_params=self.aux_params)
 
     def _evaluate(self, training_state, val_iter, val_metric):
         """


### PR DESCRIPTION
Loading/Saving auxiliary parameters of the models. Before aux parameters were not saved or used for initialization. Therefore the parameters of certain layers were ignored (e.g., BatchNorm) and randomly initialized. This change enables to properly load, save and initialize the layers which use auxiliary parameters.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

