### PR TITLE
Explicit dependency on DMLC tensorboard fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,15 @@ running the following:
 where `${CUDA_VERSION}` can be `75` (7.5), `80` (8.0), or `90` (9.0).
 
 ### Optional dependencies
-In order to track learning curves during training you can optionally install dmlc's tensorboard fork
- (````pip install tensorboard````).
+In order to track learning curves during training you can optionally install dmlc's fork of tensorboard
+ (````pip install tensorboard==1.0.0a6````).
+ 
 If you want to create alignment plots you will need to install matplotlib (````pip install matplotlib````).
 
 In general you can install all optional dependencies from the Sockeye source folder using:
 ```bash
 > pip install '.[optional]'
 ```
-
 
 ### Running sockeye
 

--- a/docs/user_documentation.md
+++ b/docs/user_documentation.md
@@ -64,9 +64,9 @@ scratch.
 
 Sockeye can write all evaluation metrics in a tensorboard compatible format.
 This way you can monitor the training progress in the browser.
-If you have not yet installed dmlc's tensorboard fork do so as follows:
+If you have not installed dmlc's fork of tensorboard do so as follows:
 ```bash
-> pip install tensorboard
+> pip install tensorboard==1.0.0a6
 ```
 
 Now when training specify the additional command line parameter `--use-tensorboard` to `sockeye.train`. 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ args = dict(
     tests_require=['pytest', 'pytest-cov'],
 
     extras_require={
-        'optional': ['tensorboard', 'matplotlib'],
+        'optional': ['tensorboard==1.0.0a6', 'matplotlib'],
         'dev': get_requirements('requirements.dev.txt')
     },
 

--- a/tutorials/wmt/README.md
+++ b/tutorials/wmt/README.md
@@ -25,7 +25,7 @@ pip install matplotlib
 
 We will visualize training progress using `tensorboard`. Install it using:
 ```bash
-pip install tensorboard
+pip install tensorboard==1.0.0a6
 ```
 
 All of the commands below assume you're running on a CPU.


### PR DESCRIPTION
The default package installed when invoking ```pip install tensorboard``` is now Tensorflow's tensorboard (https://pypi.python.org/pypi/tensorboard).

This change makes our dependency on the dmlc fork explicit.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./pre-commit.sh` or manual run of pylint & mypy)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

