### PR TITLE
Use stack instead of expand_dims, concat for memory efficiency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ### Added
 - Optionally store the beam search history to a `json` output using the `beam_store` output handler.
 
+### Changed
+- Use stack operator instead of expand_dims + concat in RNN decoder. Reduces memory usage.
+
 ## [1.17.1]
 ### Changed
  - Updated to [MXNet 1.1.0](https://github.com/apache/incubator-mxnet/tree/1.1.0)

--- a/sockeye/coverage.py
+++ b/sockeye/coverage.py
@@ -174,6 +174,7 @@ class GRUCoverage(Coverage):
                 data=mx.sym.expand_dims(data=prev_hidden, axis=1, name="%sexpand_decoder" % self.prefix),
                 axis=1, size=source_seq_len, name="%sbroadcast_decoder" % self.prefix)
 
+            # (batch_size, source_seq_len, 1)
             expanded_att_scores = mx.sym.expand_dims(data=attention_prob_scores,
                                                      axis=2,
                                                      name="%sexpand_attention_scores" % self.prefix)

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -455,7 +455,7 @@ class AddSinCosPositionalEmbeddings(PositionalEncoder):
         sin = mx.sym.sin(scaled_positions)
         cos = mx.sym.cos(scaled_positions)
 
-        # (batch_size, num_embed/2)
+        # (batch_size, num_embed)
         pos_embedding = mx.sym.concat(sin, cos, dim=1)
 
         if self.scale_up_input:

--- a/sockeye/rnn_attention.py
+++ b/sockeye/rnn_attention.py
@@ -171,7 +171,7 @@ class Attention(object):
         :param source_length: Source length. Shape: (batch_size,).
         :param source_seq_len: Maximum length of source sequences.
         """
-        dynamic_source = mx.sym.expand_dims(mx.sym.expand_dims(mx.sym.zeros_like(source_length), axis=1), axis=2)
+        dynamic_source = mx.sym.reshape(mx.sym.zeros_like(source_length), shape=(-1, 1, 1))
         # dynamic_source: (batch_size, source_seq_len, num_hidden_dynamic_source)
         dynamic_source = mx.sym.broadcast_to(dynamic_source, shape=(0, source_seq_len, self.dynamic_source_num_hidden))
         return AttentionState(context=None, probs=None, dynamic_source=dynamic_source)


### PR DESCRIPTION
This is a memory improvement for RNN decoders.
As stated in https://github.com/apache/incubator-mxnet/pull/9934 the use of `mx.sym.stack` is more memory efficient than `mx.sym.expand_dims` followed by `mx.sym.concat`.
I ran a quick test between these two patterns by stacking/concatenating an array of size (128, 100, 512) 100 times, and the memory used on the GPU went from 5249MB to 2736MB when using `mx.sym.stack`.

I searched through the codebase if there are other cases for this, but the combination of RNN decoder hidden states over time seems to be the only place where this is relevant. Note that this only applies to cases where you want to concatenate on a separate axis. 

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

