### PR TITLE
[1.18] restrict-lexicon: Allow specification of topk at runtime.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ### Changed
 - Change default target vocab name in model folder to `vocab.trg.0.json`
 - Changed serialization format of top-k lexica to pickle/Numpy instead of JSON.
+- `sockeye-lexicon` now supports two subcommands: create & inspect.
+  The former provides the same functionality as the previous CLI.
+  The latter allows users to pass source words to the top-k lexicon to inspect the set of allowed target words.
 
 ### Added
 - Added ability to choose a smaller `k` at decoding runtime for lexicon restriction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ## [1.18.0]
 ### Changed
 - Change default target vocab name in model folder to `vocab.trg.0.json`
+- Changed serialization format of top-k lexica to pickle/Numpy instead of JSON.
+
+### Added
+- Added ability to choose a smaller `k` at decoding runtime for lexicon restriction.
 
 ## [1.17.4]
 ### Added

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1033,8 +1033,13 @@ def add_inference_args(params):
     decode_params.add_argument('--restrict-lexicon',
                                type=str,
                                default=None,
-                               help="Specify top-k lexicon to restrict output vocabulary based on source.  See lexicon "
+                               help="Specify top-k lexicon to restrict output vocabulary based on source. See lexicon "
                                     "module. Default: %(default)s.")
+    decode_params.add_argument('--restrict-lexicon-topk',
+                               type=int,
+                               default=None,
+                               help="Specify the number of translations to load for each source word from the lexicon "
+                                    "given with --restrict-lexicon. Default: Load all entries from the lexicon.")
 
     decode_params.add_argument('--output-type',
                                default='translation',

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -217,30 +217,23 @@ def add_extract_args(params):
 
 
 def add_lexicon_args(params):
-    lexicon_params = params.add_argument_group("Lexicon")
-    lexicon_params.add_argument(
-        "--input",
-        "-i",
-        required=True,
-        type=str,
-        help="Probabilistic lexicon (fast_align format) to use for building top-k lexicon.")
-    lexicon_params.add_argument(
-        "--output",
-        "-o",
-        required=True,
-        type=str,
-        help="JSON file to write top-k lexicon to.")
-    lexicon_params.add_argument(
-        "--model",
-        "-m",
-        required=True,
-        type=str,
-        help="Trained model directory for source and target vocab.")
-    lexicon_params.add_argument(
-        "-k",
-        type=int,
-        default=20,
-        help="Number of target translations to keep per source. Default: %(default)s.")
+    lexicon_params = params.add_argument_group("Model & Top-k")
+    lexicon_params.add_argument("--model", "-m", required=True,
+                                help="Model directory containing source and target vocabularies.")
+    lexicon_params.add_argument("-k", type=int, default=20,
+                                help="Number of target translations to keep per source. Default: %(default)s.")
+
+
+def add_lexicon_create_args(params):
+    lexicon_params = params.add_argument_group("I/O")
+    lexicon_params.add_argument("--input", "-i", required=True,
+                                help="Probabilistic lexicon (fast_align format) to build top-k lexicon from.")
+    lexicon_params.add_argument("--output", "-o", required=True, help="File name to write top-k lexicon to.")
+
+
+def add_lexicon_inspect_args(params):
+    lexicon_params = params.add_argument_group("Lexicon to inspect")
+    lexicon_params.add_argument("--lexicon", "-l", required=True, help="File name of top-k lexicon to inspect.")
 
 
 def add_logging_args(params):

--- a/sockeye/lexicon.py
+++ b/sockeye/lexicon.py
@@ -239,7 +239,7 @@ class TopKLexicon:
 
     def load(self, path: str, k: Optional[int] = None):
         """
-        Load lexicon from Numpy array file.
+        Load lexicon from Numpy array file. The top-k target ids will be sorted by increasing target id.
 
         :param path: Path to Numpy array file.
         :param k: Optionally load less items than stored in path.
@@ -256,7 +256,7 @@ class TopKLexicon:
             top_k = loaded_k
         self.lex = np.zeros((len(self.vocab_source), top_k), dtype=_lex.dtype)
         for src_id, trg_ids in enumerate(_lex):
-            self.lex[src_id, :] = trg_ids[:top_k]
+            self.lex[src_id, :] = np.sort(trg_ids[:top_k])
         logger.info("Loaded top-%d lexicon from \"%s\".", top_k, path)
 
     def get_trg_ids(self, src_ids: np.ndarray) -> np.ndarray:

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -18,7 +18,7 @@ import argparse
 import sys
 import time
 from contextlib import ExitStack
-from typing import Generator, Optional, Iterable, List
+from typing import Generator, Optional, List
 
 import mxnet as mx
 from math import ceil
@@ -70,11 +70,11 @@ def main():
             max_output_length_num_stds=args.max_output_length_num_stds,
             decoder_return_logit_inputs=args.restrict_lexicon is not None,
             cache_output_layer_w_b=args.restrict_lexicon is not None)
-        restrict_lexicon = None # type: TopKLexicon
-        store_beam = args.output_type == C.OUTPUT_HANDLER_BEAM_STORE
+        restrict_lexicon = None  # type: Optional[TopKLexicon]
         if args.restrict_lexicon:
             restrict_lexicon = TopKLexicon(source_vocabs[0], target_vocab)
-            restrict_lexicon.load(args.restrict_lexicon)
+            restrict_lexicon.load(args.restrict_lexicon, k=args.restrict_lexicon_topk)
+        store_beam = args.output_type == C.OUTPUT_HANDLER_BEAM_STORE
         translator = inference.Translator(context=context,
                                           ensemble_mode=args.ensemble_mode,
                                           bucket_source_width=args.bucket_width,

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -194,6 +194,7 @@ def test_training_arg(test_params, expected_params):
                       bucket_width=10,
                       max_input_len=None,
                       restrict_lexicon=None,
+                      restrict_lexicon_topk=None,
                       softmax_temperature=None,
                       output_type='translation',
                       sure_align_threshold=0.9,

--- a/test/unit/test_lexicon.py
+++ b/test/unit/test_lexicon.py
@@ -21,7 +21,6 @@ import sockeye.lexicon
 
 
 def test_topk_lexicon():
-
     lexicon = ["a\ta\t-0.6931471805599453",
                "a\tb\t-1.2039728043259361",
                "a\tc\t-1.6094379124341003",
@@ -44,9 +43,9 @@ def test_topk_lexicon():
         # Test against known lexicon
         expected = np.zeros((len(C.VOCAB_SYMBOLS) + len(vocab_list), k), dtype=np.int)
         # a -> special + a b
-        expected[len(C.VOCAB_SYMBOLS),:2] = [len(C.VOCAB_SYMBOLS), len(C.VOCAB_SYMBOLS) + 1]
+        expected[len(C.VOCAB_SYMBOLS), :2] = [len(C.VOCAB_SYMBOLS), len(C.VOCAB_SYMBOLS) + 1]
         # b -> special + b
-        expected[len(C.VOCAB_SYMBOLS) + 1,:1] = [len(C.VOCAB_SYMBOLS) + 1]
+        expected[len(C.VOCAB_SYMBOLS) + 1, :1] = [len(C.VOCAB_SYMBOLS) + 1]
         assert np.all(lex.lex == expected)
 
         # Test save/load
@@ -56,7 +55,6 @@ def test_topk_lexicon():
         assert np.all(lex.lex == expected)
 
         # Test lookup
-
         trg_ids = lex.get_trg_ids(np.array([[vocab["a"], vocab["c"]]], dtype=np.int))
         expected = np.array([vocab[symbol] for symbol in C.VOCAB_SYMBOLS + ["a", "b"]], dtype=np.int)
         assert np.all(trg_ids == expected)
@@ -67,4 +65,20 @@ def test_topk_lexicon():
 
         trg_ids = lex.get_trg_ids(np.array([[vocab["c"]]], dtype=np.int))
         expected = np.array([vocab[symbol] for symbol in C.VOCAB_SYMBOLS], dtype=np.int)
+        assert np.all(trg_ids == expected)
+
+        # Test load with smaller k
+        small_k = k - 1
+        lex.load(json_lex_path, k=small_k)
+        assert lex.lex.shape[1] == small_k
+        trg_ids = lex.get_trg_ids(np.array([[vocab["a"]]], dtype=np.int))
+        expected = np.array([vocab[symbol] for symbol in C.VOCAB_SYMBOLS + ["a"]], dtype=np.int)
+        assert np.all(trg_ids == expected)
+
+        # Test load with larger k
+        large_k = k + 1
+        lex.load(json_lex_path, k=large_k)
+        assert lex.lex.shape[1] == k
+        trg_ids = lex.get_trg_ids(np.array([[vocab["a"], vocab["c"]]], dtype=np.int))
+        expected = np.array([vocab[symbol] for symbol in C.VOCAB_SYMBOLS + ["a", "b"]], dtype=np.int)
         assert np.all(trg_ids == expected)

--- a/test/unit/test_lexicon.py
+++ b/test/unit/test_lexicon.py
@@ -49,10 +49,11 @@ def test_topk_lexicon():
         assert np.all(lex.lex == expected)
 
         # Test save/load
+        expected_sorted = np.sort(expected, axis=1)
         json_lex_path = os.path.join(work_dir, "lex.json")
         lex.save(json_lex_path)
         lex.load(json_lex_path)
-        assert np.all(lex.lex == expected)
+        assert np.all(lex.lex == expected_sorted)
 
         # Test lookup
         trg_ids = lex.get_trg_ids(np.array([[vocab["a"], vocab["c"]]], dtype=np.int))


### PR DESCRIPTION
This allows selecting the number of elements considered for each source word at runtime, if the `--restrict-lexicon` functionality is used.
- Added a new flag `--restrict-lexicon-topk` that controls this. If the lexicon on disk contains fewer elements than this value, a warning is given and the maximum number of elements from the lexicon on disk is used.
- Changed serialization of TopKLexicon to numpy arrays as this simplifies the logic. @mjdenkowski in order to allow the selection at runtime, I removed the sorting by trg_ids. The lexicon rows are now sorted by decreasing logprob. As far as I can tell this is ok.
- Changed lexicon CLI to expose two subcommands: "create" and "inspect". The former behaves as the previous CLI. The latter allows inspecting an existing lexicon by passing input tokens to STDIN. The CLI then lists the set of unique target tokens allowed by that top-k lexicon.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

