### PR TITLE
Freeze embeddings

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -156,6 +156,19 @@ def multiple_values(num_values: int = 0,
     return parse
 
 
+def string2bool(string : str) -> bool:
+    """
+    Parses a string as a bool value. This function can be used as the
+    'data_type' argument of multiple_values.
+    """
+    if string in ["True", "true", "1"]:
+        return True
+    elif string in ["False", "false", "0"]:
+        return False
+    else:
+        raise argparse.ArgumentTypeError("Could not parse boolean value '%s'" % string)
+
+
 def file_or_stdin() -> Callable:
     """
     Returns a file descriptor from stdin or opening a file from a given path.
@@ -596,6 +609,10 @@ def add_model_parameters(params):
                               help='Embedding size for additional source factors. '
                                    'You must provide as many dimensions as '
                                    '(validation) source factor files. Default: %(default)s.')
+    model_params.add_argument('--freeze-embed',
+                              type=multiple_values(num_values=2, data_type=string2bool),
+                              default=(False, False),
+                              help='Freeze the embeddings for source or target. Default: %(default)s.')
 
     # attention arguments
     model_params.add_argument('--rnn-attention-type',
@@ -1087,8 +1104,9 @@ def add_init_embedding_args(params):
                         help='List of input vocabularies as token-index dictionaries in .json format.')
     params.add_argument('--vocabularies-out', '-o', required=True, nargs='+',
                         help='List of output vocabularies as token-index dictionaries in .json format.')
-    params.add_argument('--names', '-n', required=True, nargs='+',
-                        help='List of Sockeye parameter names for (embedding) weights.')
+    params.add_argument('--names', '-n', nargs='+',
+                        help='List of Sockeye parameter names for (embedding) weights. Default: %(default)s.',
+                        default=[n + "weight" for n in [C.SOURCE_EMBEDDING_PREFIX, C.TARGET_EMBEDDING_PREFIX]])
     params.add_argument('--file', '-f', required=True,
                         help='File to write initialized parameters to.')
     params.add_argument('--encoding', '-c', type=str, default=C.VOCAB_ENCODING,

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -281,6 +281,7 @@ class EmbeddingConfig(config.Config):
                  vocab_size: int,
                  num_embed: int,
                  dropout: float,
+                 frozen: bool = False,
                  factor_configs: Optional[List[FactorConfig]] = None) -> None:
         super().__init__()
         self.vocab_size = vocab_size
@@ -288,6 +289,7 @@ class EmbeddingConfig(config.Config):
         self.dropout = dropout
         self.factor_configs = factor_configs
         self.num_factors = 1
+        self.frozen = frozen
         if self.factor_configs is not None:
             self.num_factors += len(self.factor_configs)
 
@@ -315,6 +317,8 @@ class Embedding(Encoder):
         if self.embed_weight is None:
             self.embed_weight = mx.sym.Variable(prefix + "weight",
                                                 shape=(self.config.vocab_size, self.config.num_embed))
+        if self.config.frozen:
+            self.embed_weight = mx.sym.BlockGrad(self.embed_weight)
 
         self.embed_factor_weights = []  # type: List[mx.sym.Symbol]
         if self.config.factor_configs is not None:

--- a/sockeye/init_embedding.py
+++ b/sockeye/init_embedding.py
@@ -139,10 +139,10 @@ def main():
                         "'output vocabularies' and 'Sockeye parameter names' should be provided.")
            sys.exit(1)
 
-    params = {} # type: Dict[str, mx.nd.NDArray]
-    weight_file_cache = {} # type: Dict[str, np.ndarray]
-    for weight_file, vocab_in_file, vocab_out_file, name in zip(args.weight_files, args.vocabularies_in, \
-                                                               args.vocabularies_out, args.names):
+    params = {}  # type: Dict[str, mx.nd.NDArray]
+    weight_file_cache = {}  # type: Dict[str, np.ndarray]
+    for weight_file, vocab_in_file, vocab_out_file, name in zip(args.weight_files, args.vocabularies_in,
+                                                                args.vocabularies_out, args.names):
         weight = load_weight(weight_file, name, weight_file_cache)
         logger.info('Loading input/output vocabularies: %s %s', vocab_in_file, vocab_out_file)
         vocab_in = vocab.vocab_from_json(vocab_in_file, encoding=args.encoding)

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -591,6 +591,7 @@ def create_model_config(args: argparse.Namespace,
     """
     num_embed_source, num_embed_target = args.num_embed
     embed_dropout_source, embed_dropout_target = args.embed_dropout
+    embed_freeze_source, embed_freeze_target = args.freeze_embed
     source_vocab_size, *source_factor_vocab_sizes = source_vocab_sizes
 
     check_encoder_decoder_args(args)
@@ -615,10 +616,12 @@ def create_model_config(args: argparse.Namespace,
     config_embed_source = encoder.EmbeddingConfig(vocab_size=source_vocab_size,
                                                   num_embed=num_embed_source,
                                                   dropout=embed_dropout_source,
+                                                  frozen=embed_freeze_source,
                                                   factor_configs=source_factor_configs)
 
     config_embed_target = encoder.EmbeddingConfig(vocab_size=target_vocab_size,
                                                   num_embed=num_embed_target,
+                                                  frozen=embed_freeze_target,
                                                   dropout=embed_dropout_target)
 
     config_loss = loss.LossConfig(name=args.loss,

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -77,6 +77,7 @@ def test_device_args(test_params, expected_params):
               num_layers=(1, 1),
               num_embed=(512, 512),
               source_factors_num_embed=[],
+              freeze_embed=(False, False),
               rnn_attention_type='mlp',
               rnn_attention_num_hidden=None,
               rnn_attention_coverage_type='count',


### PR DESCRIPTION
Added an option for freezing (input/output) embeddings.
Probably use only in combination with sockeye.init_embedding.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

