### PR TITLE
Support for evaluating multiple hypothesis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 
 ## [1.17.3]
 ### Changed
-- `sockeye.evaluate` can now handle multiple hypothesis.
+- `sockeye.evaluate` can now handle multiple hypotheses files by simply specifying `--hypotheses file1 file2...`.
+For each metric the mean and standard deviation will be reported across files.
 
 ## [1.17.2]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.17.3]
+### Changed
+- `sockeye.evaluate` can now handle multiple hypothesis.
+
 ## [1.17.2]
 ### Added
 - Optionally store the beam search history to a `json` output using the `beam_store` output handler.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.17.2'
+__version__ = '1.17.3'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1055,8 +1055,9 @@ def add_evaluate_args(params):
                              help="File with references.")
     eval_params.add_argument('--hypotheses', '-i',
                              type=file_or_stdin(),
-                             default=sys.stdin,
-                             help="File with hypotheses. If none will read from stdin. Default: %(default)s.")
+                             default=[sys.stdin],
+                             nargs='+',
+                             help="File(s) with hypotheses. If none will read from stdin. Default: %(default)s.")
     eval_params.add_argument('--metrics',
                              nargs='+',
                              default=[C.BLEU, C.CHRF],

--- a/sockeye/evaluate.py
+++ b/sockeye/evaluate.py
@@ -17,7 +17,9 @@ Evaluation CLI. Prints corpus BLEU
 import argparse
 import logging
 import sys
+import numpy as np
 from typing import Iterable, Optional
+from collections import defaultdict
 
 from contrib import sacrebleu
 from sockeye.log import setup_main_logger, log_sockeye_version
@@ -55,7 +57,8 @@ def raw_corpus_chrf(hypotheses: Iterable[str], references: Iterable[str]) -> flo
 
 def main():
     params = argparse.ArgumentParser(description='Evaluate translations by calculating metrics with '
-                                                 'respect to a reference set.')
+                                                 'respect to a reference set. If multiple hypothesis are given the mean'
+                                                 'and standard deviation of the metrics are reported.')
     arguments.add_evaluate_args(params)
     arguments.add_logging_args(params)
     args = params.parse_args()
@@ -70,35 +73,58 @@ def main():
     logger.info("Arguments: %s", args)
 
     references = [' '.join(e) for e in data_io.read_content(args.references)]
-    hypotheses = [h.strip() for h in args.hypotheses]
-    logger.info("%d hypotheses | %d references", len(hypotheses), len(references))
+    all_hypotheses = [[h.strip() for h in hypotheses] for hypotheses in args.hypotheses]
+    metrics = args.metrics
+    logger.info("%d hypotheses | %d references", len(all_hypotheses), len(references))
 
     if not args.not_strict:
-        utils.check_condition(len(hypotheses) == len(references),
-                              "Number of hypotheses (%d) and references (%d) does not match." % (len(hypotheses),
-                                                                                                 len(references)))
+        for hypotheses in all_hypotheses:
+            utils.check_condition(len(hypotheses) == len(references),
+                                  "Number of hypotheses (%d) and references (%d) does not match." % (len(hypotheses),
+                                                                                                     len(references)))
+    metric_info = []
+    for metric in metrics:
+        metric_info.append("%s\t(s_opt)" % metric)
+    logger.info("\t".join(metric_info))
 
     if not args.sentence:
-        scores = []
-        for metric in args.metrics:
-            if metric == C.BLEU:
-                bleu_score = raw_corpus_bleu(hypotheses, references, args.offset)
-                scores.append("%.6f" % bleu_score)
-            elif metric == C.CHRF:
-                chrf_score = raw_corpus_chrf(hypotheses, references)
-                scores.append("%.6f" % chrf_score)
-        print("\t".join(scores), file=sys.stdout)
-    else:
-        for h, r in zip(hypotheses, references):
-            scores = []
-            for metric in args.metrics:
+        scores = defaultdict(list)
+        for hypotheses in all_hypotheses:
+            for metric in metrics:
                 if metric == C.BLEU:
-                    bleu = raw_corpus_bleu([h], [r], args.offset)
-                    scores.append("%.6f" % bleu)
+                    score = raw_corpus_bleu(hypotheses, references, args.offset)
                 elif metric == C.CHRF:
-                    chrf_score = raw_corpus_chrf(h, r)
-                    scores.append("%.6f" % chrf_score)
-            print("\t".join(scores), file=sys.stdout)
+                    score = raw_corpus_chrf(hypotheses, references)
+                else:
+                    raise ValueError("Unknown metric %s." % metric)
+                scores[metric].append(score)
+        _print_mean_std_score(metrics, scores)
+    else:
+        for hypotheses in all_hypotheses:
+            for h, r in zip(hypotheses, references):
+                scores = defaultdict(list)
+                for metric in metrics:
+                    if metric == C.BLEU:
+                        score = raw_corpus_bleu([h], [r], args.offset)
+                    elif metric == C.CHRF:
+                        score = raw_corpus_chrf(h, r)
+                    else:
+                        raise ValueError("Unknown metric %s." % metric)
+                    scores[metric].append(score)
+                _print_mean_std_score(metrics, scores)
+
+
+def _print_mean_std_score(metrics, scores):
+    scores_mean_std = []
+    for metric in metrics:
+        if len(scores[metric]) > 1:
+            score_mean = np.asscalar(np.mean(scores[metric]))
+            score_std = np.asscalar(np.std(scores[metric], ddof=1))
+            scores_mean_std.append("%.3f\t%.3f" % (score_mean, score_std))
+        else:
+            score = scores[metric][0]
+            scores_mean_std.append("%.3f\t(-)" % score)
+    print("\t".join(scores_mean_std))
 
 
 if __name__ == '__main__':

--- a/sockeye/evaluate.py
+++ b/sockeye/evaluate.py
@@ -57,8 +57,8 @@ def raw_corpus_chrf(hypotheses: Iterable[str], references: Iterable[str]) -> flo
 
 def main():
     params = argparse.ArgumentParser(description='Evaluate translations by calculating metrics with '
-                                                 'respect to a reference set. If multiple hypothesis are given the mean'
-                                                 'and standard deviation of the metrics are reported.')
+                                                 'respect to a reference set. If multiple hypotheses files are given'
+                                                 'the mean and standard deviation of the metrics are reported.')
     arguments.add_evaluate_args(params)
     arguments.add_logging_args(params)
     args = params.parse_args()


### PR DESCRIPTION
Adds support for evaluating multiple hypothesis by calculating mean and standard deviation. I decided for a format similar to multeval, which we could later extend to bootstrap-resampled standard deviation of scores. 

With a single hypotheses file we get:
```
[INFO:__main__] bleu	(s_opt)	chrf	(s_opt)
0.123	(-)	0.345	(-)
```

With multiple we get:
```
[INFO:__main__] bleu	(s_opt)	chrf	(s_opt)
0.123	(0.123)	0.345	(0.345)
```
I was thinking about adding this to sacrebleu too, but this issue is that right now it would need to handle hypothesis from a CLI flag instead of stdin. Let me know if you think this would be worthwhile doing.

#### Pull Request Checklist ##
- [X] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [X] Unit tests pass (`pytest`)
- [X] Passed code style checking (`./style-check.sh`)
- [X] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

