### PR TITLE
Bug when loading external parameters for initialization

### DIFF
--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -305,7 +305,7 @@ class TrainingModel(model.SockeyeModel):
         self.aux_params = aux_params
         super().save_params_to_file(fname)
 
-    def load_params_from_file(self, fname: str, set_params: bool = True):
+    def load_params_from_file(self, fname: str, allow_missing_params: bool = False):
         """
         Loads parameters from a file and sets the parameters of the underlying module and this model instance.
 
@@ -313,8 +313,9 @@ class TrainingModel(model.SockeyeModel):
         :param set_params: Set the params in the module.
         """
         super().load_params_from_file(fname)  # sets self.params & self.aux_params
-        if set_params:
-            self.module.set_params(arg_params=self.params, aux_params=self.aux_params)
+        self.module.set_params(arg_params=self.params,
+                               aux_params=self.aux_params,
+                               allow_missing=allow_missing_params)
 
     def install_monitor(self, monitor_pattern: str, monitor_stat_func_name: str):
         """
@@ -720,7 +721,7 @@ class EarlyStoppingTrainer:
         self.model.initialize_parameters(self.optimizer_config.initializer, allow_missing_params)
         if params is not None:
             logger.info("Training will start with parameters loaded from '%s'", params)
-            self.model.load_params_from_file(params, set_params=False)
+            self.model.load_params_from_file(params, allow_missing_params=allow_missing_params)
         self.model.log_parameters()
 
     def _initialize_optimizer(self):

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -310,7 +310,7 @@ class TrainingModel(model.SockeyeModel):
         Loads parameters from a file and sets the parameters of the underlying module and this model instance.
 
         :param fname: File name to load parameters from.
-        :param set_params: Set the params in the module.
+        :param allow_missing_params: If set, the given parameters are allowed to be a subset of the Module parameters.
         """
         super().load_params_from_file(fname)  # sets self.params & self.aux_params
         self.module.set_params(arg_params=self.params,

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -305,14 +305,16 @@ class TrainingModel(model.SockeyeModel):
         self.aux_params = aux_params
         super().save_params_to_file(fname)
 
-    def load_params_from_file(self, fname: str):
+    def load_params_from_file(self, fname: str, set_params: bool = True):
         """
         Loads parameters from a file and sets the parameters of the underlying module and this model instance.
 
         :param fname: File name to load parameters from.
+        :param set_params: Set the params in the module.
         """
         super().load_params_from_file(fname)  # sets self.params & self.aux_params
-        self.module.set_params(arg_params=self.params, aux_params=self.aux_params)
+        if set_params:
+            self.module.set_params(arg_params=self.params, aux_params=self.aux_params)
 
     def install_monitor(self, monitor_pattern: str, monitor_stat_func_name: str):
         """
@@ -718,7 +720,7 @@ class EarlyStoppingTrainer:
         self.model.initialize_parameters(self.optimizer_config.initializer, allow_missing_params)
         if params is not None:
             logger.info("Training will start with parameters loaded from '%s'", params)
-            self.model.load_params_from_file(params)
+            self.model.load_params_from_file(params, set_params=False)
         self.model.log_parameters()
 
     def _initialize_optimizer(self):


### PR DESCRIPTION
(Bug introduced in #304)

Calling set_params directly after loading the params from file does not
honor the allow_missing flag. I allowed skipping the set_params call and
let the handling of allow_missing to init_params, as it was done
pre-#304. However set_params also accepts an allow_missing parameter. I
am not sure of the difference between the two variants, though,
therefore the [WIP].

We should probably consider adding a test for this.

(description of the change)

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]' until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

