### PR TITLE
Make sure all model parameters are prefixed by a model prefix. Default: ''

### DIFF
--- a/contrib/sacrebleu/README.md
+++ b/contrib/sacrebleu/README.md
@@ -67,6 +67,12 @@ Sacre BLEU.
 
 # VERSION HISTORY
 
+- 1.2.5 (13 March 2018)
+   - added wmt18/dev datasets (en-et and et-en)
+   - fixed logic with --force
+   - locale-independent installation
+   - added "--echo both" (tab-delimited)
+
 - 1.2.3 (28 January 2018)
    - metrics (`-m`) are now printed in the order requested
    - chrF now prints a version string (including the beta parameter, importantly)

--- a/contrib/sacrebleu/README.md
+++ b/contrib/sacrebleu/README.md
@@ -67,6 +67,11 @@ Sacre BLEU.
 
 # VERSION HISTORY
 
+- 1.2.6 (22 March 2018)
+   - added wmt17/ms (Microsoft's [additional ZH-EN references](https://github.com/MicrosoftTranslator/Translator-HumanParityData)).
+     Try `sacrebleu -t wmt17/ms --cite`.
+   - `--echo ref` now pastes together all references, if there is more than one
+
 - 1.2.5 (13 March 2018)
    - added wmt18/dev datasets (en-et and et-en)
    - fixed logic with --force

--- a/contrib/sacrebleu/sacrebleu.py
+++ b/contrib/sacrebleu/sacrebleu.py
@@ -84,6 +84,12 @@ Sacre BLEU.
 
 # VERSION HISTORY
 
+- 1.2.5 (13 March 2018)
+   - added wmt18/dev datasets (en-et and et-en)
+   - fixed logic with --force
+   - locale-independent installation
+   - added "--echo both" (tab-delimited)
+
 - 1.2.3 (28 January 2018)
    - metrics (`-m`) are now printed in the order requested
    - chrF now prints a version string (including the beta parameter, importantly)
@@ -170,7 +176,7 @@ from typing import List, Iterable, Tuple
 import math
 import unicodedata
 
-VERSION = '1.2.3'
+VERSION = '1.2.5'
 
 try:
     # SIGPIPE is not available on Windows machines, throwing an exception.
@@ -207,6 +213,12 @@ CHRF_BETA = 2
 # Many of these are *.sgm files, which are processed to produced plain text that can be used by this script.
 # The canonical location of unpacked, processed data is $SACREBLEU/$TEST/$SOURCE-$TARGET.{$SOURCE,$TARGET}
 DATASETS = {
+    'wmt18/dev': {
+        'data': ['http://data.statmt.org/wmt18/translation-task/dev.tgz'],
+        'description': 'Development data (Estonian<>English).',
+        'et-en': ['dev/newsdev2018-eten-src.et.sgm', 'dev/newsdev2018-eten-ref.en.sgm'],
+        'en-et': ['dev/newsdev2018-enet-src.en.sgm', 'dev/newsdev2018-enet-ref.et.sgm'],
+    },
     'wmt17': {
         'data': ['http://data.statmt.org/wmt17/translation-task/test.tgz'],
         'description': 'Official evaluation data.',
@@ -445,7 +457,7 @@ DATASETS = {
                  'https://wit3.fbk.eu/archive/2017-01-ted-test/texts/en/zh/en-zh.tgz',
                  'https://wit3.fbk.eu/archive/2017-01-ted-test/texts/zh/en/zh-en.tgz'],
         'description': 'Official evaluation data for IWSLT.',
-        'citation': '@InProceedings{iwslt2017,\n  author    = {Cettolo, Mauro and Federico, Marcello and Bentivogli, Luisa and Niehues, Jan and Stüker, Sebastian and Sudoh, Katsuitho and Yoshino, Koichiro and Federmann, Christian},\n  title     = {Overview of the IWSLT 2017 Evaluation Campaign},\n  booktitle = {14th International Workshop on Spoken Language Translation},\n  month     = {December},\n  year      = {2017},\n  address   = {Tokyo, Japan},\n  pages     = {2--14},\n  url       = {http://workshop2017.iwslt.org/downloads/iwslt2017_proceeding_v2.pdf\n}',
+        'citation': '@InProceedings{iwslt2017,\n  author    = {Cettolo, Mauro and Federico, Marcello and Bentivogli, Luisa and Niehues, Jan and Stüker, Sebastian and Sudoh, Katsuitho and Yoshino, Koichiro and Federmann, Christian},\n  title     = {Overview of the IWSLT 2017 Evaluation Campaign},\n  booktitle = {14th International Workshop on Spoken Language Translation},\n  month     = {December},\n  year      = {2017},\n  address   = {Tokyo, Japan},\n  pages     = {2--14},\n  url       = {http://workshop2017.iwslt.org/downloads/iwslt2017_proceeding_v2.pdf}\n}',
         'en-fr': ['en-fr/IWSLT17.TED.tst2017.en-fr.en.xml', 'fr-en/IWSLT17.TED.tst2017.fr-en.fr.xml'],
         'fr-en': ['fr-en/IWSLT17.TED.tst2017.fr-en.fr.xml', 'en-fr/IWSLT17.TED.tst2017.en-fr.en.xml'],
         'en-de': ['en-de/IWSLT17.TED.tst2017.en-de.en.xml', 'de-en/IWSLT17.TED.tst2017.de-en.de.xml'],
@@ -774,14 +786,14 @@ TOKENIZERS = {
 DEFAULT_TOKENIZER = '13a'
 
 
-def _open(file, encoding='utf-8'):
+def smart_open(file, mode='rt', encoding='utf-8'):
     """Convenience function for reading compressed or plain text files.
     :param file: The file to read.
     :param encoding: The file encoding.
     """
     if file.endswith('.gz'):
-        return gzip.open(file, 'rt', encoding=encoding)
-    return open(file, 'rt', encoding=encoding)
+        return gzip.open(file, mode=mode, encoding=encoding)
+    return open(file, mode=mode, encoding=encoding)
 
 
 def my_log(num):
@@ -934,12 +946,12 @@ def process_to_text(rawfile, txtfile):
     if not os.path.exists(txtfile) or os.path.getsize(txtfile) == 0:
         logging.info("Processing %s to %s", rawfile, txtfile)
         if rawfile.endswith('.sgm') or rawfile.endswith('.sgml'):
-            with _open(rawfile) as fin, open(txtfile, 'wt') as fout:
+            with smart_open(rawfile) as fin, smart_open(txtfile, 'wt') as fout:
                 for line in fin:
                     if line.startswith('<seg '):
                         print(_clean(re.sub(r'<seg.*?>(.*)</seg>.*?', '\\1', line)), file=fout)
         elif rawfile.endswith('.xml'): # IWSLT
-            with _open(rawfile) as fin, open(txtfile, 'wt') as fout:
+            with smart_open(rawfile) as fin, smart_open(txtfile, 'wt') as fout:
                 for line in fin:
                     if line.startswith('<seg '):
                         print(_clean(re.sub(r'<seg.*?>(.*)</seg>.*?', '\\1', line)), file=fout)
@@ -952,10 +964,15 @@ def print_test_set(test_set, langpair, side):
     """
 
     where = download_test_set(test_set, langpair)
-    infile = where[0] if side == 'src' else where[1]
-    with open(infile) as fin:
-        for line in fin:
-            print(line.rstrip())
+    if side == 'both':
+        with smart_open(where[0]) as src_in, smart_open(where[1]) as tgt_in:
+            for src, tgt in zip(src_in, tgt_in):
+                print(src.rstrip(), tgt.rstrip(), sep='\t')
+    else:
+        infile = where[0] if side == 'src' else where[1]
+        with smart_open(infile) as fin:
+            for line in fin:
+                print(line.rstrip())
 
 
 def download_test_set(test_set, langpair=None):
@@ -1106,13 +1123,13 @@ def corpus_bleu(sys_stream, ref_streams, smooth='exp', smooth_floor=0.0, force=F
         if lowercase:
             lines = [x.lower() for x in lines]
 
-        if (not force or tokenize != 'none') and lines[0].rstrip().endswith(' .'):
+        if not (force or tokenize == 'none') and lines[0].rstrip().endswith(' .'):
             tokenized_count += 1
 
             if tokenized_count == 100:
-                logging.warning('That\'s > 100 lines that end in a tokenized period (\'.\')')
+                logging.warning('That\'s 100 lines that end in a tokenized period (\'.\')')
                 logging.warning('It looks like you forgot to detokenize your test data, which may hurt your score.')
-                logging.warning('If you insist your data is tokenized, you can suppress this message with \'--force\'.')
+                logging.warning('If you insist your data is detokenized, or don\'t care, you can suppress this message with \'--force\'.')
 
         output, *refs = [TOKENIZERS[tokenize](x.rstrip()) for x in lines]
 
@@ -1263,8 +1280,8 @@ def main():
                             help='source-target language pair (2-char ISO639-1 codes)')
     arg_parser.add_argument('--download', type=str, default=None,
                             help='download a test set and quit')
-    arg_parser.add_argument('--echo', choices=['src', 'ref'], type=str, default=None,
-                            help='output the source or reference to STDOUT and quit')
+    arg_parser.add_argument('--echo', choices=['src', 'ref', 'both'], type=str, default=None,
+                            help='output the source (src), reference (ref), or both (both, pasted) to STDOUT and quit')
     arg_parser.add_argument('--input', '-i', type=str, default='-',
                             help='Read input from a file instead of STDIN')
     arg_parser.add_argument('refs', nargs='*', default=[],
@@ -1348,11 +1365,11 @@ def main():
     else:
         refs = args.refs
 
-    inputfh = io.TextIOWrapper(sys.stdin.buffer, encoding=args.encoding) if args.input == '-' else _open(args.input, args.encoding)
+    inputfh = io.TextIOWrapper(sys.stdin.buffer, encoding=args.encoding) if args.input == '-' else smart_open(args.input, encoding=args.encoding)
     system = inputfh.readlines()
 
     # Read references
-    refs = [_open(x, args.encoding).readlines() for x in refs]
+    refs = [smart_open(x, encoding=args.encoding).readlines() for x in refs]
 
     if args.langpair is not None:
         _, target = args.langpair.split('-')

--- a/contrib/sacrebleu/setup.py
+++ b/contrib/sacrebleu/setup.py
@@ -28,8 +28,8 @@ import os
 
 def get_version():
     VERSION_RE = re.compile(r'''VERSION\s+=\s+['"]([0-9.]+)['"]''')
-    init = open(os.path.join(os.path.dirname(__file__), 'sacrebleu.py')).read()
-    return VERSION_RE.search(init).group(1)
+    with open(os.path.join(os.path.dirname(__file__), 'sacrebleu.py'), encoding='utf-8') as fin:
+        return VERSION_RE.search(fin.read()).group(1)
 
 setup(
     name = 'sacrebleu',

--- a/contrib/sacrebleu/test.sh
+++ b/contrib/sacrebleu/test.sh
@@ -45,6 +45,20 @@ if [[ ! -d wmt17-submitted-data ]]; then
    tar xzf wmt17-submitted-data-v1.0.tgz
 fi
 
+# Test echoing of source, reference, and both
+../sacrebleu.py -t wmt17/ms -l zh-en --echo src > .tmp.echo
+diff .tmp.echo $SACREBLEU/wmt17/ms/zh-en.zh
+if [[ $? -ne 0 ]]; then
+    echo "Source echo failed."
+    exit 1
+fi
+../sacrebleu.py -t wmt17/ms -l zh-en --echo ref | cut -f3 > .tmp.echo
+diff .tmp.echo $SACREBLEU/wmt17/ms/zh-en.en.2
+if [[ $? -ne 0 ]]; then
+    echo "Source echo failed."
+    exit 1
+fi
+
 export LC_ALL=C
 
 # Pre-computed results from Moses' mteval-v13a.pl

--- a/contrib/sacrebleu/test.sh
+++ b/contrib/sacrebleu/test.sh
@@ -22,9 +22,19 @@
 
 set -u
 
+export SACREBLEU=$(pwd)/.sacrebleu
+
 # TEST 1: download and process WMT17 data
-[[ -d ~/.sacrebleu/wmt17 ]] && rm -f ~/.sacrebleu/wmt17/{en-*,*-en*}
+[[ -d $SACREBLEU/wmt17 ]] && rm -f $SACREBLEU/wmt17/{en-*,*-en*}
 ./sacrebleu.py --echo src -t wmt17 -l cs-en > /dev/null
+
+# Test loading via file instead of STDIN
+./sacrebleu.py -t wmt17 -l en-de --echo ref > .wmt17.en-de.de.tmp
+score=$(./sacrebleu.py -t wmt17 -l en-de -i .wmt17.en-de.de.tmp -b)
+if [[ $score != '100.00' ]]; then
+    echo "File test failed."
+    exit 1
+fi
 
 [[ ! -d data ]] && mkdir data
 cd data
@@ -34,6 +44,8 @@ if [[ ! -d wmt17-submitted-data ]]; then
    wget -q http://data.statmt.org/wmt17/translation-task/wmt17-submitted-data-v1.0.tgz
    tar xzf wmt17-submitted-data-v1.0.tgz
 fi
+
+export LC_ALL=C
 
 # Pre-computed results from Moses' mteval-v13a.pl
 declare -a MTEVAL=(23.15 25.12 27.45 30.95 28.98 34.56 30.1 33.12 33.17 28.09 32.48 32.97 17.67 26.04 35.12 20.51 19.95 20.2 16.18 20.22 16.55 20.12 14.18 14.69 13.69 13.79 12.64 13.06 15.25 22.8 22.67 26.33 26.08 26.6 27.11 26.56 16.61 26.02 26.71 21.24 20.8 26.65 15.45 18.16 28.3 26.69 17.15 20.28 9.33 20.72 15.87 11.47 1.05 15.96 14.46 13.72 22.04 15.51 13.64 16.76 18.31 16.19 17.01 10.15 18.63 14.35 16.63 10.84 17.91 20.14 20.79 21.05 16.93 17.48 17.99 22.3 25.37 25.32 23.83 32.05 10.08 27.11 28.41 29.79 9.98 16.03 10.37 9.81 11.62 19.93 13.93 16.43 30.52 25.93 34.87 23.92 31.05 29.02 32.07 18.58 21.31 36.28 35.84 19.96 16.13 6.13 21.13 27.62 22.48 14.31 16.23 12.42 16.79 15.72 22.02 20.0 21.92 18.98 33.88 33.95 34.71 31.47 31.18 36.94 15.9 34.51 30.77 12.42 17.91 13.52 17.54 18.05 12.64 22.18 25.62 16.38 20.08 22.32 18.98 25.78 18.51 16.47 20.76 26.38 15.94 21.28 20.48 24.51 33.23 11.39 15.5 25.7 26.0)

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -34,13 +34,13 @@ logger = logging.getLogger(__name__)
 DecoderConfig = Union['RecurrentDecoderConfig', transformer.TransformerConfig, 'ConvolutionalDecoderConfig']
 
 
-def get_decoder(config: DecoderConfig) -> 'Decoder':
+def get_decoder(config: DecoderConfig, prefix: str) -> 'Decoder':
     if isinstance(config, RecurrentDecoderConfig):
-        return RecurrentDecoder(config=config, prefix=C.RNN_DECODER_PREFIX)
+        return RecurrentDecoder(config=config, prefix=prefix + C.RNN_DECODER_PREFIX)
     elif isinstance(config, ConvolutionalDecoderConfig):
-        return ConvolutionalDecoder(config=config, prefix=C.CNN_DECODER_PREFIX)
+        return ConvolutionalDecoder(config=config, prefix=prefix + C.CNN_DECODER_PREFIX)
     elif isinstance(config, transformer.TransformerConfig):
-        return TransformerDecoder(config=config, prefix=C.TRANSFORMER_DECODER_PREFIX)
+        return TransformerDecoder(config=config, prefix=prefix + C.TRANSFORMER_DECODER_PREFIX)
     else:
         raise ValueError("Unsupported decoder configuration")
 

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -33,13 +33,13 @@ logger = logging.getLogger(__name__)
 EncoderConfig = Union['RecurrentEncoderConfig', transformer.TransformerConfig, 'ConvolutionalEncoderConfig']
 
 
-def get_encoder(config: EncoderConfig) -> 'Encoder':
+def get_encoder(config: EncoderConfig, prefix: str = '') -> 'Encoder':
     if isinstance(config, RecurrentEncoderConfig):
-        return get_recurrent_encoder(config)
+        return get_recurrent_encoder(config, prefix)
     elif isinstance(config, transformer.TransformerConfig):
-        return get_transformer_encoder(config)
+        return get_transformer_encoder(config, prefix)
     elif isinstance(config, ConvolutionalEncoderConfig):
-        return get_convolutional_encoder(config)
+        return get_convolutional_encoder(config, prefix)
     else:
         raise ValueError("Unsupported encoder configuration")
 
@@ -86,24 +86,26 @@ class ConvolutionalEncoderConfig(config.Config):
         self.positional_embedding_type = positional_embedding_type
 
 
-def get_recurrent_encoder(config: RecurrentEncoderConfig) -> 'Encoder':
+def get_recurrent_encoder(config: RecurrentEncoderConfig, prefix: str) -> 'Encoder':
     """
     Returns an encoder stack with a bi-directional RNN, and a variable number of uni-directional forward RNNs.
 
     :param config: Configuration for recurrent encoder.
+    :param prefix: Prefix.
     :return: Encoder instance.
     """
     # TODO give more control on encoder architecture
     encoders = list()  # type: List[Encoder]
 
     if config.conv_config is not None:
-        encoders.append(ConvolutionalEmbeddingEncoder(config.conv_config, prefix=C.CHAR_SEQ_ENCODER_PREFIX))
+        encoders.append(ConvolutionalEmbeddingEncoder(config.conv_config, prefix=prefix + C.CHAR_SEQ_ENCODER_PREFIX))
         if config.conv_config.add_positional_encoding:
             # If specified, add positional encodings to segment embeddings
             encoders.append(AddSinCosPositionalEmbeddings(num_embed=config.conv_config.num_embed,
                                                           scale_up_input=False,
                                                           scale_down_positions=False,
-                                                          prefix="%sadd_positional_encodings" % C.CHAR_SEQ_ENCODER_PREFIX))
+                                                          prefix="%s%sadd_positional_encodings" %
+                                                                 (prefix, C.CHAR_SEQ_ENCODER_PREFIX)))
         encoders.append(ConvertLayout(C.TIME_MAJOR, num_hidden=encoders[-1].get_num_hidden()))
     else:
         encoders.append(ConvertLayout(C.TIME_MAJOR, num_hidden=0))
@@ -117,7 +119,7 @@ def get_recurrent_encoder(config: RecurrentEncoderConfig) -> 'Encoder':
 
     # One layer bi-directional RNN:
     encoders.append(BiDirectionalRNNEncoder(rnn_config=config.rnn_config.copy(num_layers=1),
-                                            prefix=C.BIDIRECTIONALRNN_PREFIX,
+                                            prefix=prefix + C.BIDIRECTIONALRNN_PREFIX,
                                             layout=C.TIME_MAJOR))
 
     if config.rnn_config.num_layers > 1:
@@ -126,7 +128,7 @@ def get_recurrent_encoder(config: RecurrentEncoderConfig) -> 'Encoder':
         remaining_rnn_config = config.rnn_config.copy(num_layers=config.rnn_config.num_layers - 1,
                                                       first_residual_layer=config.rnn_config.first_residual_layer - 1)
         encoders.append(RecurrentEncoder(rnn_config=remaining_rnn_config,
-                                         prefix=C.STACKEDRNN_PREFIX,
+                                         prefix=prefix + C.STACKEDRNN_PREFIX,
                                          layout=C.TIME_MAJOR))
 
     encoders.append(ConvertLayout(C.BATCH_MAJOR, encoders[-1].get_num_hidden()))
@@ -134,12 +136,12 @@ def get_recurrent_encoder(config: RecurrentEncoderConfig) -> 'Encoder':
     return EncoderSequence(encoders)
 
 
-def get_convolutional_encoder(config: ConvolutionalEncoderConfig) -> 'Encoder':
+def get_convolutional_encoder(config: ConvolutionalEncoderConfig, prefix: str) -> 'Encoder':
     """
     Creates a convolutional encoder.
 
     :param config: Configuration for convolutional encoder.
-    :param embed_weight: Optionally use an existing embedding matrix instead of creating a new one.
+    :param prefix: Prefix.
     :return: Encoder instance.
     """
     encoders = list()  # type: List[Encoder]
@@ -148,17 +150,18 @@ def get_convolutional_encoder(config: ConvolutionalEncoderConfig) -> 'Encoder':
                                              max_seq_len=config.max_seq_len_source,
                                              fixed_pos_embed_scale_up_input=False,
                                              fixed_pos_embed_scale_down_positions=True,
-                                             prefix=C.SOURCE_POSITIONAL_EMBEDDING_PREFIX))
+                                             prefix=prefix + C.SOURCE_POSITIONAL_EMBEDDING_PREFIX))
     encoders.append(ConvolutionalEncoder(config=config))
     return EncoderSequence(encoders)
 
 
-def get_transformer_encoder(config: transformer.TransformerConfig) -> 'Encoder':
+def get_transformer_encoder(config: transformer.TransformerConfig, prefix: str) -> 'Encoder':
     """
     Returns a Transformer encoder, consisting of an embedding layer with
     positional encodings and a TransformerEncoder instance.
 
     :param config: Configuration for transformer encoder.
+    :param prefix: Prefix.
     :return: Encoder instance.
     """
     encoders = list()  # type: List[Encoder]
@@ -167,11 +170,11 @@ def get_transformer_encoder(config: transformer.TransformerConfig) -> 'Encoder':
                                              config.max_seq_len_source,
                                              fixed_pos_embed_scale_up_input=True,
                                              fixed_pos_embed_scale_down_positions=False,
-                                             prefix=C.SOURCE_POSITIONAL_EMBEDDING_PREFIX))
+                                             prefix=prefix + C.SOURCE_POSITIONAL_EMBEDDING_PREFIX))
     if config.conv_config is not None:
-        encoders.append(ConvolutionalEmbeddingEncoder(config.conv_config))
+        encoders.append(ConvolutionalEmbeddingEncoder(config.conv_config, prefix=prefix + C.CHAR_SEQ_ENCODER_PREFIX))
 
-    encoders.append(TransformerEncoder(config))
+    encoders.append(TransformerEncoder(config, prefix=prefix + C.TRANSFORMER_ENCODER_PREFIX))
 
     return EncoderSequence(encoders)
 

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -890,8 +890,9 @@ class Translator:
                  source_vocabs: List[vocab.Vocab],
                  target_vocab: vocab.Vocab,
                  restrict_lexicon: Optional[lexicon.TopKLexicon] = None,
-                 store_beam : bool = False) -> None:
+                 store_beam: bool = False) -> None:
         self.context = context
+        self.smallest_k_func = utils.smallest_k if self.context == mx.cpu() else utils.smallest_k_mx
         self.length_penalty = length_penalty
         self.source_vocabs = source_vocabs
         self.vocab_target = target_vocab
@@ -1279,13 +1280,16 @@ class Translator:
 
             # (3) get beam_size winning hypotheses for each sentence block separately
             # TODO(fhieber): once mx.nd.topk is sped-up no numpy conversion necessary anymore.
-            scores = scores.asnumpy()  # convert to numpy once to minimize cross-device copying
+            if self.context == mx.cpu():
+                scores = scores.asnumpy()  # convert to numpy once to minimize cross-device copying
+
             for sent in range(self.batch_size):
                 rows = slice(sent * self.beam_size, (sent + 1) * self.beam_size)
                 sliced_scores = scores if t == 1 and self.batch_size == 1 else scores[rows]
                 # TODO we could save some tiny amount of time here by not running smallest_k for a finished sent
                 (best_hyp_indices[rows], best_word_indices[rows]), \
-                scores_accumulated[rows, 0] = utils.smallest_k(sliced_scores, self.beam_size, t == 1)
+                    scores_accumulated[rows, 0] = self.smallest_k_func(sliced_scores, self.beam_size, t == 1)
+
                 # offsetting since the returned smallest_k() indices were slice-relative
                 best_hyp_indices[rows] += rows.start
 

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -91,33 +91,36 @@ class SockeyeModel:
     time.
 
     :param config: Model configuration.
+    :param prefix: Name prefix for all parameters of this model.
     """
 
-    def __init__(self, config: ModelConfig) -> None:
+    def __init__(self, config: ModelConfig, prefix: str = '') -> None:
         self.config = copy.deepcopy(config)
         self.config.freeze()
+        self.prefix = prefix
         logger.info("%s", self.config)
 
         # encoder & decoder first (to know the decoder depth)
-        self.encoder = encoder.get_encoder(self.config.config_encoder)
-        self.decoder = decoder.get_decoder(self.config.config_decoder)
+        self.encoder = encoder.get_encoder(self.config.config_encoder, self.prefix)
+        self.decoder = decoder.get_decoder(self.config.config_decoder, self.prefix)
 
         # source & target embeddings
-        embed_weight_source, embed_weight_target, out_weight_target = self._get_embed_weights()
+        embed_weight_source, embed_weight_target, out_weight_target = self._get_embed_weights(prefix)
         self.embedding_source = encoder.Embedding(self.config.config_embed_source,
-                                                  prefix=C.SOURCE_EMBEDDING_PREFIX,
+                                                  prefix=prefix + C.SOURCE_EMBEDDING_PREFIX,
                                                   embed_weight=embed_weight_source,
                                                   is_source=True)
 
         self.embedding_target = encoder.Embedding(self.config.config_embed_target,
-                                                  prefix=C.TARGET_EMBEDDING_PREFIX,
+                                                  prefix=prefix + C.TARGET_EMBEDDING_PREFIX,
                                                   embed_weight=embed_weight_target)
 
         # output layer
         self.output_layer = layers.OutputLayer(hidden_size=self.decoder.get_num_hidden(),
                                                vocab_size=self.config.vocab_target_size,
                                                weight=out_weight_target,
-                                               weight_normalization=self.config.weight_normalization)
+                                               weight_normalization=self.config.weight_normalization,
+                                               prefix=prefix + C.DEFAULT_OUTPUT_LAYER_PREFIX)
 
         self.params = None  # type: Optional[Dict]
         self.aux_params = None  # type: Optional[Dict]
@@ -166,6 +169,10 @@ class SockeyeModel:
                                                      "This is either not a model directory or the first training "
                                                      "checkpoint has not happened yet." % fname)
         self.params, self.aux_params = utils.load_params(fname)
+        utils.check_condition(all(name.startswith(self.prefix) for name in self.params.keys()),
+                              "Not all parameter names start with model prefix '%s'" % self.prefix)
+        utils.check_condition(all(name.startswith(self.prefix) for name in self.aux_params.keys()),
+                              "Not all auxiliary parameter names start with model prefix '%s'" % self.prefix)
         logger.info('Loaded params from "%s"', fname)
 
     @staticmethod
@@ -179,28 +186,29 @@ class SockeyeModel:
         with open(fname, "w") as out:
             out.write(__version__)
 
-    def _get_embed_weights(self) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, mx.sym.Symbol]:
+    def _get_embed_weights(self, prefix: str) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, mx.sym.Symbol]:
         """
         Returns embedding parameters for source and target.
         When source and target embeddings are shared, they are created here and passed in to each side,
         instead of being created in the Embedding constructors.
 
+        :param prefix: Prefix.
         :return: Tuple of source and target parameter symbols.
         """
-        w_embed_source = mx.sym.Variable(C.SOURCE_EMBEDDING_PREFIX + "weight",
+        w_embed_source = mx.sym.Variable(prefix + C.SOURCE_EMBEDDING_PREFIX + "weight",
                                          shape=(self.config.config_embed_source.vocab_size,
                                                 self.config.config_embed_source.num_embed))
-        w_embed_target = mx.sym.Variable(C.TARGET_EMBEDDING_PREFIX + "weight",
+        w_embed_target = mx.sym.Variable(prefix + C.TARGET_EMBEDDING_PREFIX + "weight",
                                          shape=(self.config.config_embed_target.vocab_size,
                                                 self.config.config_embed_target.num_embed))
-        w_out_target = mx.sym.Variable("target_output_weight",
+        w_out_target = mx.sym.Variable(prefix + "target_output_weight",
                                        shape=(self.config.vocab_target_size, self.decoder.get_num_hidden()))
 
         if self.config.weight_tying:
             if C.WEIGHT_TYING_SRC in self.config.weight_tying_type \
                     and C.WEIGHT_TYING_TRG in self.config.weight_tying_type:
                 logger.info("Tying the source and target embeddings.")
-                w_embed_source = w_embed_target = mx.sym.Variable(C.SHARED_EMBEDDING_PREFIX + "weight",
+                w_embed_source = w_embed_target = mx.sym.Variable(prefix + C.SHARED_EMBEDDING_PREFIX + "weight",
                                                                   shape=(self.config.config_embed_source.vocab_size,
                                                                          self.config.config_embed_source.num_embed))
 

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -140,9 +140,9 @@ class TrainingModel(model.SockeyeModel):
             # logits: (batch_size * target_seq_len, target_vocab_size)
             logits = self.output_layer(target_decoded)
 
-            probs = self.model_loss.get_loss(logits, labels)
+            loss_output = self.model_loss.get_loss(logits, labels)
 
-            return mx.sym.Group(probs), data_names, label_names
+            return mx.sym.Group(loss_output), data_names, label_names
 
         if self._bucketing:
             logger.info("Using bucketing. Default max_seq_len=%s", default_bucket_key)


### PR DESCRIPTION
Most of our layer implementations already support naming parameters with a prefix. This change propagates this pattern up to the SockeyeModel class to allow prefixing all parameter names of a model with a certain name. By default the model prefix is the empty string, so nothing changes. 
In the future this allows to create multiple models / model components with different parameter sets.

I added a check in SockeyeModel.load_params_from_file() to ensure the loaded parameters match a prefix.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

