### PR TITLE
Make sure all model parameters are prefixed by a model prefix. Default: ''

### DIFF
--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -453,7 +453,9 @@ class RecurrentDecoder(Decoder):
         # TODO: implement variant without input feeding
         self.config = config
         self.rnn_config = config.rnn_config
-        self.attention = rnn_attention.get_attention(config.attention_config, config.max_seq_len_source)
+        self.attention = rnn_attention.get_attention(config.attention_config,
+                                                     config.max_seq_len_source,
+                                                     prefix + C.ATTENTION_PREFIX)
         self.prefix = prefix
 
         self.num_hidden = self.rnn_config.num_hidden

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -34,13 +34,13 @@ logger = logging.getLogger(__name__)
 DecoderConfig = Union['RecurrentDecoderConfig', transformer.TransformerConfig, 'ConvolutionalDecoderConfig']
 
 
-def get_decoder(config: DecoderConfig) -> 'Decoder':
+def get_decoder(config: DecoderConfig, prefix: str) -> 'Decoder':
     if isinstance(config, RecurrentDecoderConfig):
-        return RecurrentDecoder(config=config, prefix=C.RNN_DECODER_PREFIX)
+        return RecurrentDecoder(config=config, prefix=prefix + C.RNN_DECODER_PREFIX)
     elif isinstance(config, ConvolutionalDecoderConfig):
-        return ConvolutionalDecoder(config=config, prefix=C.CNN_DECODER_PREFIX)
+        return ConvolutionalDecoder(config=config, prefix=prefix + C.CNN_DECODER_PREFIX)
     elif isinstance(config, transformer.TransformerConfig):
-        return TransformerDecoder(config=config, prefix=C.TRANSFORMER_DECODER_PREFIX)
+        return TransformerDecoder(config=config, prefix=prefix + C.TRANSFORMER_DECODER_PREFIX)
     else:
         raise ValueError("Unsupported decoder configuration")
 

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 DecoderConfig = Union['RecurrentDecoderConfig', transformer.TransformerConfig, 'ConvolutionalDecoderConfig']
 
 
-def get_decoder(config: DecoderConfig, prefix: str) -> 'Decoder':
+def get_decoder(config: DecoderConfig, prefix: str = '') -> 'Decoder':
     if isinstance(config, RecurrentDecoderConfig):
         return RecurrentDecoder(config=config, prefix=prefix + C.RNN_DECODER_PREFIX)
     elif isinstance(config, ConvolutionalDecoderConfig):

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -91,7 +91,7 @@ def get_recurrent_encoder(config: RecurrentEncoderConfig, prefix: str) -> 'Encod
     Returns an encoder stack with a bi-directional RNN, and a variable number of uni-directional forward RNNs.
 
     :param config: Configuration for recurrent encoder.
-    :param prefix: Prefix.
+    :param prefix: Prefix for variable names.
     :return: Encoder instance.
     """
     # TODO give more control on encoder architecture
@@ -141,7 +141,7 @@ def get_convolutional_encoder(config: ConvolutionalEncoderConfig, prefix: str) -
     Creates a convolutional encoder.
 
     :param config: Configuration for convolutional encoder.
-    :param prefix: Prefix.
+    :param prefix: Prefix for variable names.
     :return: Encoder instance.
     """
     encoders = list()  # type: List[Encoder]
@@ -161,7 +161,7 @@ def get_transformer_encoder(config: transformer.TransformerConfig, prefix: str) 
     positional encodings and a TransformerEncoder instance.
 
     :param config: Configuration for transformer encoder.
-    :param prefix: Prefix.
+    :param prefix: Prefix for variable names.
     :return: Encoder instance.
     """
     encoders = list()  # type: List[Encoder]
@@ -642,7 +642,7 @@ class RecurrentEncoder(Encoder):
     Uni-directional (multi-layered) recurrent encoder.
 
     :param rnn_config: RNN configuration.
-    :param prefix: Prefix.
+    :param prefix: Prefix for variable names.
     :param layout: Data layout.
     """
 
@@ -689,7 +689,7 @@ class BiDirectionalRNNEncoder(Encoder):
     States from both RNNs are concatenated together.
 
     :param rnn_config: RNN configuration.
-    :param prefix: Prefix.
+    :param prefix: Prefix for variable names.
     :param layout: Data layout.
     :param encoder_class: Recurrent encoder class to use.
     """

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -33,13 +33,13 @@ logger = logging.getLogger(__name__)
 EncoderConfig = Union['RecurrentEncoderConfig', transformer.TransformerConfig, 'ConvolutionalEncoderConfig']
 
 
-def get_encoder(config: EncoderConfig) -> 'Encoder':
+def get_encoder(config: EncoderConfig, prefix: str = '') -> 'Encoder':
     if isinstance(config, RecurrentEncoderConfig):
-        return get_recurrent_encoder(config)
+        return get_recurrent_encoder(config, prefix)
     elif isinstance(config, transformer.TransformerConfig):
-        return get_transformer_encoder(config)
+        return get_transformer_encoder(config, prefix)
     elif isinstance(config, ConvolutionalEncoderConfig):
-        return get_convolutional_encoder(config)
+        return get_convolutional_encoder(config, prefix)
     else:
         raise ValueError("Unsupported encoder configuration")
 
@@ -86,24 +86,26 @@ class ConvolutionalEncoderConfig(config.Config):
         self.positional_embedding_type = positional_embedding_type
 
 
-def get_recurrent_encoder(config: RecurrentEncoderConfig) -> 'Encoder':
+def get_recurrent_encoder(config: RecurrentEncoderConfig, prefix: str) -> 'Encoder':
     """
     Returns an encoder stack with a bi-directional RNN, and a variable number of uni-directional forward RNNs.
 
     :param config: Configuration for recurrent encoder.
+    :param prefix: Prefix.
     :return: Encoder instance.
     """
     # TODO give more control on encoder architecture
     encoders = list()  # type: List[Encoder]
 
     if config.conv_config is not None:
-        encoders.append(ConvolutionalEmbeddingEncoder(config.conv_config, prefix=C.CHAR_SEQ_ENCODER_PREFIX))
+        encoders.append(ConvolutionalEmbeddingEncoder(config.conv_config, prefix=prefix + C.CHAR_SEQ_ENCODER_PREFIX))
         if config.conv_config.add_positional_encoding:
             # If specified, add positional encodings to segment embeddings
             encoders.append(AddSinCosPositionalEmbeddings(num_embed=config.conv_config.num_embed,
                                                           scale_up_input=False,
                                                           scale_down_positions=False,
-                                                          prefix="%sadd_positional_encodings" % C.CHAR_SEQ_ENCODER_PREFIX))
+                                                          prefix="%s%sadd_positional_encodings" %
+                                                                 (prefix, C.CHAR_SEQ_ENCODER_PREFIX)))
         encoders.append(ConvertLayout(C.TIME_MAJOR, num_hidden=encoders[-1].get_num_hidden()))
     else:
         encoders.append(ConvertLayout(C.TIME_MAJOR, num_hidden=0))
@@ -117,7 +119,7 @@ def get_recurrent_encoder(config: RecurrentEncoderConfig) -> 'Encoder':
 
     # One layer bi-directional RNN:
     encoders.append(BiDirectionalRNNEncoder(rnn_config=config.rnn_config.copy(num_layers=1),
-                                            prefix=C.BIDIRECTIONALRNN_PREFIX,
+                                            prefix=prefix + C.BIDIRECTIONALRNN_PREFIX,
                                             layout=C.TIME_MAJOR))
 
     if config.rnn_config.num_layers > 1:
@@ -126,7 +128,7 @@ def get_recurrent_encoder(config: RecurrentEncoderConfig) -> 'Encoder':
         remaining_rnn_config = config.rnn_config.copy(num_layers=config.rnn_config.num_layers - 1,
                                                       first_residual_layer=config.rnn_config.first_residual_layer - 1)
         encoders.append(RecurrentEncoder(rnn_config=remaining_rnn_config,
-                                         prefix=C.STACKEDRNN_PREFIX,
+                                         prefix=prefix + C.STACKEDRNN_PREFIX,
                                          layout=C.TIME_MAJOR))
 
     encoders.append(ConvertLayout(C.BATCH_MAJOR, encoders[-1].get_num_hidden()))
@@ -134,12 +136,12 @@ def get_recurrent_encoder(config: RecurrentEncoderConfig) -> 'Encoder':
     return EncoderSequence(encoders)
 
 
-def get_convolutional_encoder(config: ConvolutionalEncoderConfig) -> 'Encoder':
+def get_convolutional_encoder(config: ConvolutionalEncoderConfig, prefix: str) -> 'Encoder':
     """
     Creates a convolutional encoder.
 
     :param config: Configuration for convolutional encoder.
-    :param embed_weight: Optionally use an existing embedding matrix instead of creating a new one.
+    :param prefix: Prefix.
     :return: Encoder instance.
     """
     encoders = list()  # type: List[Encoder]
@@ -148,17 +150,18 @@ def get_convolutional_encoder(config: ConvolutionalEncoderConfig) -> 'Encoder':
                                              max_seq_len=config.max_seq_len_source,
                                              fixed_pos_embed_scale_up_input=False,
                                              fixed_pos_embed_scale_down_positions=True,
-                                             prefix=C.SOURCE_POSITIONAL_EMBEDDING_PREFIX))
+                                             prefix=prefix + C.SOURCE_POSITIONAL_EMBEDDING_PREFIX))
     encoders.append(ConvolutionalEncoder(config=config))
     return EncoderSequence(encoders)
 
 
-def get_transformer_encoder(config: transformer.TransformerConfig) -> 'Encoder':
+def get_transformer_encoder(config: transformer.TransformerConfig, prefix: str) -> 'Encoder':
     """
     Returns a Transformer encoder, consisting of an embedding layer with
     positional encodings and a TransformerEncoder instance.
 
     :param config: Configuration for transformer encoder.
+    :param prefix: Prefix.
     :return: Encoder instance.
     """
     encoders = list()  # type: List[Encoder]
@@ -167,11 +170,11 @@ def get_transformer_encoder(config: transformer.TransformerConfig) -> 'Encoder':
                                              config.max_seq_len_source,
                                              fixed_pos_embed_scale_up_input=True,
                                              fixed_pos_embed_scale_down_positions=False,
-                                             prefix=C.SOURCE_POSITIONAL_EMBEDDING_PREFIX))
+                                             prefix=prefix + C.SOURCE_POSITIONAL_EMBEDDING_PREFIX))
     if config.conv_config is not None:
-        encoders.append(ConvolutionalEmbeddingEncoder(config.conv_config))
+        encoders.append(ConvolutionalEmbeddingEncoder(config.conv_config, prefix=prefix + C.CHAR_SEQ_ENCODER_PREFIX))
 
-    encoders.append(TransformerEncoder(config))
+    encoders.append(TransformerEncoder(config, prefix=prefix + C.TRANSFORMER_ENCODER_PREFIX))
 
     return EncoderSequence(encoders)
 

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -105,14 +105,14 @@ class SockeyeModel:
         self.decoder = decoder.get_decoder(self.config.config_decoder, prefix=self.prefix)
 
         # source & target embeddings
-        embed_weight_source, embed_weight_target, out_weight_target = self._get_embed_weights(prefix)
+        embed_weight_source, embed_weight_target, out_weight_target = self._get_embed_weights(self.prefix)
         self.embedding_source = encoder.Embedding(self.config.config_embed_source,
-                                                  prefix=prefix + C.SOURCE_EMBEDDING_PREFIX,
+                                                  prefix=self.prefix + C.SOURCE_EMBEDDING_PREFIX,
                                                   embed_weight=embed_weight_source,
                                                   is_source=True)
 
         self.embedding_target = encoder.Embedding(self.config.config_embed_target,
-                                                  prefix=prefix + C.TARGET_EMBEDDING_PREFIX,
+                                                  prefix=self.prefix + C.TARGET_EMBEDDING_PREFIX,
                                                   embed_weight=embed_weight_target)
 
         # output layer
@@ -120,7 +120,7 @@ class SockeyeModel:
                                                vocab_size=self.config.vocab_target_size,
                                                weight=out_weight_target,
                                                weight_normalization=self.config.weight_normalization,
-                                               prefix=prefix + C.DEFAULT_OUTPUT_LAYER_PREFIX)
+                                               prefix=self.prefix + C.DEFAULT_OUTPUT_LAYER_PREFIX)
 
         self.params = None  # type: Optional[Dict]
         self.aux_params = None  # type: Optional[Dict]

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -91,33 +91,36 @@ class SockeyeModel:
     time.
 
     :param config: Model configuration.
+    :param prefix: Name prefix for all parameters of this model.
     """
 
-    def __init__(self, config: ModelConfig) -> None:
+    def __init__(self, config: ModelConfig, prefix: str = '') -> None:
         self.config = copy.deepcopy(config)
         self.config.freeze()
+        self.prefix = prefix
         logger.info("%s", self.config)
 
         # encoder & decoder first (to know the decoder depth)
-        self.encoder = encoder.get_encoder(self.config.config_encoder)
-        self.decoder = decoder.get_decoder(self.config.config_decoder)
+        self.encoder = encoder.get_encoder(self.config.config_encoder, self.prefix)
+        self.decoder = decoder.get_decoder(self.config.config_decoder, self.prefix)
 
         # source & target embeddings
-        embed_weight_source, embed_weight_target, out_weight_target = self._get_embed_weights()
+        embed_weight_source, embed_weight_target, out_weight_target = self._get_embed_weights(prefix)
         self.embedding_source = encoder.Embedding(self.config.config_embed_source,
-                                                  prefix=C.SOURCE_EMBEDDING_PREFIX,
+                                                  prefix=prefix + C.SOURCE_EMBEDDING_PREFIX,
                                                   embed_weight=embed_weight_source,
                                                   is_source=True)
 
         self.embedding_target = encoder.Embedding(self.config.config_embed_target,
-                                                  prefix=C.TARGET_EMBEDDING_PREFIX,
+                                                  prefix=prefix + C.TARGET_EMBEDDING_PREFIX,
                                                   embed_weight=embed_weight_target)
 
         # output layer
         self.output_layer = layers.OutputLayer(hidden_size=self.decoder.get_num_hidden(),
                                                vocab_size=self.config.vocab_target_size,
                                                weight=out_weight_target,
-                                               weight_normalization=self.config.weight_normalization)
+                                               weight_normalization=self.config.weight_normalization,
+                                               prefix=prefix + C.DEFAULT_OUTPUT_LAYER_PREFIX)
 
         self.params = None  # type: Optional[Dict]
         self.aux_params = None  # type: Optional[Dict]
@@ -166,6 +169,10 @@ class SockeyeModel:
                                                      "This is either not a model directory or the first training "
                                                      "checkpoint has not happened yet." % fname)
         self.params, self.aux_params = utils.load_params(fname)
+        utils.check_condition(all(name.startswith(self.prefix) for name in self.params.keys()),
+                              "Not all parameter names start with model prefix '%s'" % self.prefix)
+        utils.check_condition(all(name.startswith(self.prefix) for name in self.aux_params.keys()),
+                              "Not all auxiliary parameter names start with model prefix '%s'" % self.prefix)
         logger.info('Loaded params from "%s"', fname)
 
     @staticmethod
@@ -179,28 +186,29 @@ class SockeyeModel:
         with open(fname, "w") as out:
             out.write(__version__)
 
-    def _get_embed_weights(self) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, mx.sym.Symbol]:
+    def _get_embed_weights(self, prefix: str) -> Tuple[mx.sym.Symbol, mx.sym.Symbol, mx.sym.Symbol]:
         """
         Returns embedding parameters for source and target.
         When source and target embeddings are shared, they are created here and passed in to each side,
         instead of being created in the Embedding constructors.
 
+        :param prefix: Prefix.
         :return: Tuple of source and target parameter symbols.
         """
-        w_embed_source = mx.sym.Variable(C.SOURCE_EMBEDDING_PREFIX + "weight",
+        w_embed_source = mx.sym.Variable(prefix + C.SOURCE_EMBEDDING_PREFIX + "weight",
                                          shape=(self.config.config_embed_source.vocab_size,
                                                 self.config.config_embed_source.num_embed))
-        w_embed_target = mx.sym.Variable(C.TARGET_EMBEDDING_PREFIX + "weight",
+        w_embed_target = mx.sym.Variable(prefix + C.TARGET_EMBEDDING_PREFIX + "weight",
                                          shape=(self.config.config_embed_target.vocab_size,
                                                 self.config.config_embed_target.num_embed))
-        w_out_target = mx.sym.Variable("target_output_weight",
+        w_out_target = mx.sym.Variable(prefix + "target_output_weight",
                                        shape=(self.config.vocab_target_size, self.decoder.get_num_hidden()))
 
         if self.config.weight_tying:
             if C.WEIGHT_TYING_SRC in self.config.weight_tying_type \
                     and C.WEIGHT_TYING_TRG in self.config.weight_tying_type:
                 logger.info("Tying the source and target embeddings.")
-                w_embed_source = w_embed_target = mx.sym.Variable(C.SHARED_EMBEDDING_PREFIX + "weight",
+                w_embed_source = w_embed_target = mx.sym.Variable(prefix + C.SHARED_EMBEDDING_PREFIX + "weight",
                                                                   shape=(self.config.config_embed_source.vocab_size,
                                                                          self.config.config_embed_source.num_embed))
 

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -101,8 +101,8 @@ class SockeyeModel:
         logger.info("%s", self.config)
 
         # encoder & decoder first (to know the decoder depth)
-        self.encoder = encoder.get_encoder(self.config.config_encoder, self.prefix)
-        self.decoder = decoder.get_decoder(self.config.config_decoder, self.prefix)
+        self.encoder = encoder.get_encoder(self.config.config_encoder, prefix=self.prefix)
+        self.decoder = decoder.get_decoder(self.config.config_decoder, prefix=self.prefix)
 
         # source & target embeddings
         embed_weight_source, embed_weight_target, out_weight_target = self._get_embed_weights(prefix)

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -140,9 +140,9 @@ class TrainingModel(model.SockeyeModel):
             # logits: (batch_size * target_seq_len, target_vocab_size)
             logits = self.output_layer(target_decoded)
 
-            probs = self.model_loss.get_loss(logits, labels)
+            loss_output = self.model_loss.get_loss(logits, labels)
 
-            return mx.sym.Group(probs), data_names, label_names
+            return mx.sym.Group(loss_output), data_names, label_names
 
         if self._bucketing:
             logger.info("Using bucketing. Default max_seq_len=%s", default_bucket_key)


### PR DESCRIPTION
Most of our layer implementations already support naming parameters with a prefix. This change propagates this pattern up to the SockeyeModel class to allow prefixing all parameter names of a model with a certain name. By default the model prefix is the empty string, so nothing changes. 
In the future this allows to create multiple models / model components with different parameter sets.

I added a check in SockeyeModel.load_params_from_file() to ensure the loaded parameters match a prefix.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

