### PR TITLE
Simplify numpy-based top-k

### DIFF
--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -258,9 +258,7 @@ def smallest_k(matrix: np.ndarray, k: int,
         flatten = matrix.flatten()
 
     # args are the indices in flatten of the k smallest elements
-    args = np.argpartition(flatten, k)[:k]
-    # args are the indices in flatten of the sorted k smallest elements
-    args = args[np.argsort(flatten[args])]
+    args = np.argpartition(flatten, range(k))[:k]
     # flatten[args] are the values for args
     return np.unravel_index(args, matrix.shape), flatten[args]
 


### PR DESCRIPTION
Modify the `np.argpartition` call to return an already sorted top-k to
avoid the extra sort. Single change from this PR: https://github.com/awslabs/sockeye/pull/338

#### Pull Request Checklist ##
- [X] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [X] Unit tests pass (`pytest`)
- [X] System tests pass (`pytest test/system`)
- [X] Passed code style checking (`./style-check.sh`)
- [X] You have considered writing a test

N/A

- N/A Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- N/A Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- N/A Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
