### PR TITLE
Added flag to strip <unk> symbols from translate output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.17.5]
+### Added
+- Added a flag `--strip-unknown-words` to `sockeye.translate` to remove any `<unk>` symbols from the output strings.
+
 ## [1.17.4]
 ### Added
 - Added a flag `--fixed-param-names` to prevent certain parameters from being optimized during training.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.17.4'
+__version__ = '1.17.5'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1035,6 +1035,10 @@ def add_inference_args(params):
                                default=None,
                                help="Specify top-k lexicon to restrict output vocabulary based on source.  See lexicon "
                                     "module. Default: %(default)s.")
+    decode_params.add_argument('--strip-unknown-words',
+                               action='store_true',
+                               default=False,
+                               help='Remove any <unk> symbols from outputs. Default: %(default)s.')
 
     decode_params.add_argument('--output-type',
                                default='translation',

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -743,7 +743,6 @@ class Translation:
         self.beam_history = beam_history
 
 
-
 def empty_translation() -> Translation:
     return Translation(target_ids=[], attention_matrix=np.asarray([[0]]), score=-np.inf)
 
@@ -878,6 +877,7 @@ class Translator:
     :param target_vocab: Target vocabulary.
     :param restrict_lexicon: Top-k lexicon to use for target vocabulary restriction.
     :param store_beam: If True, store the beam search history and return it in the TranslatorOutput.
+    :param strip_unknown_words: If True, removes any <unk> symbols from outputs.
     """
 
     def __init__(self,
@@ -889,7 +889,8 @@ class Translator:
                  source_vocabs: List[vocab.Vocab],
                  target_vocab: vocab.Vocab,
                  restrict_lexicon: Optional[lexicon.TopKLexicon] = None,
-                 store_beam: bool = False) -> None:
+                 store_beam: bool = False,
+                 strip_unknown_words: bool = False) -> None:
         self.context = context
         self.smallest_k_func = utils.smallest_k if self.context == mx.cpu() else utils.smallest_k_mx
         self.length_penalty = length_penalty
@@ -901,6 +902,9 @@ class Translator:
         self.start_id = self.vocab_target[C.BOS_SYMBOL]
         assert C.PAD_ID == 0, "pad id should be 0"
         self.stop_ids = {self.vocab_target[C.EOS_SYMBOL], C.PAD_ID}  # type: Set[int]
+        self.strip_ids = self.stop_ids.copy()  # ids to strip from the output
+        if strip_unknown_words:
+            self.strip_ids.add(self.vocab_target[C.UNK_SYMBOL])
         self.models = models
         self.interpolation_func = self._get_interpolation_func(ensemble_mode)
         self.beam_size = self.models[0].beam_size
@@ -1060,9 +1064,9 @@ class Translator:
         attention_matrix = translation.attention_matrix[1:, :]
 
         target_tokens = [self.vocab_target_inv[target_id] for target_id in target_ids]
+
         target_string = C.TOKEN_SEPARATOR.join(
-            target_token for target_id, target_token in zip(target_ids, target_tokens) if
-            target_id not in self.stop_ids)
+            tok for target_id, tok in zip(target_ids, target_tokens) if target_id not in self.strip_ids)
         attention_matrix = attention_matrix[:, :len(trans_input.tokens)]
 
         if isinstance(translation.beam_history, list):

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -84,7 +84,8 @@ def main():
                                           source_vocabs=source_vocabs,
                                           target_vocab=target_vocab,
                                           restrict_lexicon=restrict_lexicon,
-                                          store_beam=store_beam)
+                                          store_beam=store_beam,
+                                          strip_unknown_words=args.strip_unknown_words)
         read_and_translate(translator=translator,
                            output_handler=output_handler,
                            chunk_size=args.chunk_size,

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -199,7 +199,8 @@ def test_training_arg(test_params, expected_params):
                       sure_align_threshold=0.9,
                       max_output_length_num_stds=2,
                       length_penalty_alpha=1.0,
-                      length_penalty_beta=0.0)),
+                      length_penalty_beta=0.0,
+                      strip_unknown_words=False)),
 ])
 def test_inference_args(test_params, expected_params):
     _test_args(test_params, expected_params, arguments.add_inference_args)


### PR DESCRIPTION
Adds an option to strip <unk> symbols from the output.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

