### PR TITLE
use hard link instead of soft

### DIFF
--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -817,7 +817,7 @@ class EarlyStoppingTrainer:
         actual_best_params_fname = C.PARAMS_NAME % self.state.best_checkpoint
         if os.path.lexists(best_params_path):
             os.remove(best_params_path)
-        os.symlink(actual_best_params_fname, best_params_path)
+        os.link(actual_best_params_fname, best_params_path)
 
     def _update_best_optimizer_states(self, lr_decay_opt_states_reset: str):
         if lr_decay_opt_states_reset == C.LR_DECAY_OPT_STATES_RESET_BEST:


### PR DESCRIPTION
Is there any reason we're using a soft link for `params.best`? A hard link would not add space and would allow safer cleanup, e.g.,

    rm model/params.0*

after training completed would not risk deleting the best model file.

#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

