### PR TITLE
WIP: Clamp vocab to be a multiple of 16

### DIFF
--- a/sockeye/vocab.py
+++ b/sockeye/vocab.py
@@ -67,7 +67,8 @@ def build_vocab(data: Iterable[str], num_words: int = 50000, min_count: int = 1)
     pruned_vocab = sorted(((c, w) for w, c in raw_vocab.items() if c >= min_count), reverse=True)
 
     vocab = islice((w for c, w in pruned_vocab), num_words)
-
+    div_16_len = int(len(pruned_vocab) / 16) * 16 - len(C.VOCAB_SYMBOLS)
+    vocab = islice(vocab, div_16_len)
     word_to_id = {word: idx for idx, word in enumerate(chain(C.VOCAB_SYMBOLS, vocab))}
     logger.info("Vocabulary: types: %d/%d/%d/%d (initial/min_pruned/max_pruned/+special) " +
                 "[min_frequency=%d, max_num_types=%d]",


### PR DESCRIPTION
Opening a PR for discussion.  I'll have to fix some unit tests before it's merged.

This PR clamps vocab to a multiple of 16.  Vocab size at this stage should be somewhat arbitrary already compared to the user's input during training right?  Would you guys be opposed to us clamping the vocab to the most frequent tokens up to a multiple of 16?  Having a vocab be a multiple of 16 is a requirement for tensorcores, but I think it should have a minimal impact for other models.  If you're not comfortable with it as the default behaviour we could also make it an option that's enabled when fp16 mode is active.

#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

