### PR TITLE
[v1.18] Enable embedding logging to tensorboard

### DIFF
--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -220,4 +220,22 @@ class SockeyeModel:
                                                                   self.decoder.get_num_hidden()))
                 w_out_target = w_embed_target
 
+        self._embed_weight_source_name = w_embed_source.name
+        self._embed_weight_target_name = w_embed_target.name
+        self._out_weight_target_name = w_out_target.name
         return w_embed_source, w_embed_target, w_out_target
+
+    def get_source_embed_params(self) -> Optional[mx.nd.NDArray]:
+        if self.params is None:
+            return None
+        return self.params.get(self._embed_weight_source_name)
+
+    def get_target_embed_params(self) -> Optional[mx.nd.NDArray]:
+        if self.params is None:
+            return None
+        return self.params.get(self._embed_weight_target_name)
+
+    def get_output_embed_params(self) -> Optional[mx.nd.NDArray]:
+        if self.params is None:
+            return None
+        return self.params.get(self._out_weight_target_name)

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -793,7 +793,9 @@ def main():
 
         trainer = training.EarlyStoppingTrainer(model=training_model,
                                                 optimizer_config=create_optimizer_config(args, source_vocab_sizes),
-                                                max_params_files_to_keep=args.keep_last_params)
+                                                max_params_files_to_keep=args.keep_last_params,
+                                                source_vocabs=source_vocabs,
+                                                target_vocab=target_vocab)
 
         trainer.fit(train_iter=train_iter,
                     validation_iter=eval_iter,

--- a/sockeye/vocab.py
+++ b/sockeye/vocab.py
@@ -18,7 +18,7 @@ import os
 from collections import Counter
 from contextlib import ExitStack
 from itertools import chain, islice
-from typing import Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from . import utils
 from . import constants as C
@@ -229,7 +229,7 @@ def load_or_create_vocabs(source_paths: List[str],
     return [vocab_source] + vocab_source_factors, vocab_target
 
 
-def reverse_vocab(vocab: Mapping) -> InverseVocab:
+def reverse_vocab(vocab: Vocab) -> InverseVocab:
     """
     Returns value-to-key mapping from key-to-value-mapping.
 
@@ -237,6 +237,16 @@ def reverse_vocab(vocab: Mapping) -> InverseVocab:
     :return: A mapping from values to keys.
     """
     return {v: k for k, v in vocab.items()}
+
+
+def get_ordered_tokens_from_vocab(vocab: Vocab) -> List[str]:
+    """
+    Returns the list of tokens in a vocabulary, ordered by increasing vocabulary id.
+
+    :param vocab: Input vocabulary.
+    :return: List of tokens.
+    """
+    return [token for token, token_id in sorted(vocab.items(), key=lambda i: i[1])]
 
 
 def are_identical(*vocabs: Vocab):

--- a/test/unit/test_vocab.py
+++ b/test/unit/test_vocab.py
@@ -5,7 +5,7 @@
 # is located at
 #
 #     http://aws.amazon.com/apache2.0/
-# 
+#
 # or in the "license" file accompanying this file. This file is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
@@ -14,7 +14,7 @@
 import pytest
 
 import sockeye.constants as C
-from sockeye.vocab import build_vocab
+from sockeye.vocab import build_vocab, get_ordered_tokens_from_vocab
 
 test_vocab = [
         # Example 1
@@ -41,6 +41,7 @@ def test_build_vocab(data, size, min_count, expected):
     vocab = build_vocab(data, size, min_count)
     assert vocab == expected
 
+
 test_constants = [
         # Example 1
         (["one two three", "one two three"], 3, 1, C.VOCAB_SYMBOLS),
@@ -59,3 +60,10 @@ def test_constants_in_vocab(data, size, min_count, constants):
     vocab = build_vocab(data, size, min_count)
     for const in constants:
         assert const in vocab
+
+
+@pytest.mark.parametrize("vocab, expected_output", [({"<pad>": 0, "a": 4, "b": 2}, ["<pad>", "b", "a"]),
+                                                    ({}, [])])
+def test_get_ordered_tokens_from_vocab(vocab, expected_output):
+    assert get_ordered_tokens_from_vocab(vocab) == expected_output
+


### PR DESCRIPTION
This adds logging of embedding parameters to the projector tab of Tensorboard using mxboard.
We log source/target/output embeddings (which are potentially equal with weight tying) so that they can be inspected for every checkpoint in Tensorboard using PCA/T-SNE visualizations.
![screen shot 2018-04-09 at 09 02 28](https://user-images.githubusercontent.com/2027990/38483881-c7e14ab2-3bd4-11e8-8687-a1240f4dd800.png)
(The screenshot shows the source embedding for a sequence copy task of 10 digits with the 5 nearest neighbours of '10' to the right)

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

