### PR TITLE
allow `--tokenize none`

### DIFF
--- a/contrib/sacrebleu/sacrebleu.py
+++ b/contrib/sacrebleu/sacrebleu.py
@@ -1292,7 +1292,7 @@ def main():
                             help='use case-insensitive BLEU (default: actual case)')
     arg_parser.add_argument('--smooth', '-s', choices=['exp', 'floor', 'none'], default='exp',
                             help='smoothing method: exponential decay (default), floor (0 count -> 0.01), or none')
-    arg_parser.add_argument('--tokenize', '-tok', choices=[x for x in TOKENIZERS.keys() if x != 'none'], default='13a',
+    arg_parser.add_argument('--tokenize', '-tok', choices=TOKENIZERS.keys(), default='13a',
                             help='tokenization method to use')
     arg_parser.add_argument('--language-pair', '-l', dest='langpair', default=None,
                             help='source-target language pair (2-char ISO639-1 codes)')
@@ -1377,6 +1377,10 @@ def main():
     elif args.test_set is not None and len(args.refs) > 0:
         logging.error('I need exactly one of (a) a predefined test set (-t) or (b) a list of references')
         sys.exit(1)
+
+    if args.test_set is not None and args.tokenize == 'none':
+        logging.warning('Using "--tokenize none" with a predefined test set\n'
+                        '(which is not tokenized). This is probably a bad idea.')
 
     if args.test_set:
         _, *refs = download_test_set(args.test_set, args.langpair)


### PR DESCRIPTION
This may be useful with a custom test set which is already tokenized.
Either the detokenized version of the reference may not be available
or you want to explore what is the effect of de/tokenization
e.g. when replicating an experiment from a paper
which used multi-bleu.perl on tokenized output
(which is a bad practice, I know).

#### Pull Request Checklist ##
- [*] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

