### PR TITLE
Increased test coverage of integration tests by adding checkpoint dec…

### DIFF
--- a/sockeye/checkpoint_decoder.py
+++ b/sockeye/checkpoint_decoder.py
@@ -43,9 +43,9 @@ class CheckpointDecoder:
     :param references: Path to file containing references.
     :param model: Model to load.
     :param max_input_len: Maximum input length.
+    :param batch_size: Batch size.
     :param beam_size: Size of the beam.
     :param bucket_width_source: Source bucket width.
-    :param bucket_width_target: Target bucket width.
     :param length_penalty_alpha: Alpha factor for the length penalty
     :param length_penalty_beta: Beta factor for the length penalty
     :param softmax_temperature: Optional parameter to control steepness of softmax distribution.
@@ -61,6 +61,7 @@ class CheckpointDecoder:
                  references: str,
                  model: str,
                  max_input_len: Optional[int] = None,
+                 batch_size: int = 16,
                  beam_size: int = C.DEFAULT_BEAM_SIZE,
                  bucket_width_source: int = 10,
                  length_penalty_alpha: float = 1.0,
@@ -75,7 +76,7 @@ class CheckpointDecoder:
         self.max_output_length_num_stds = max_output_length_num_stds
         self.ensemble_mode = ensemble_mode
         self.beam_size = beam_size
-        self.batch_size = 16
+        self.batch_size = batch_size
         self.bucket_width_source = bucket_width_source
         self.length_penalty_alpha = length_penalty_alpha
         self.length_penalty_beta = length_penalty_beta

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -38,6 +38,7 @@ ENCODER_DECODER_SETTINGS = [
      " --max-updates 10 --checkpoint-frequency 10 --optimizer adam --initial-learning-rate 0.01"
      " --rnn-dropout-inputs 0.5:0.1 --rnn-dropout-states 0.5:0.1 --embed-dropout 0.1 --rnn-decoder-hidden-dropout 0.01"
      " --rnn-decoder-state-init avg --rnn-encoder-reverse-input --rnn-dropout-recurrent 0.1:0.0"
+     " --rnn-h2h-init orthogonal_stacked"
      " --learning-rate-decay-param-reset --weight-normalization --source-factors-num-embed 5",
      "--beam-size 2",
      False, True, True),
@@ -72,6 +73,7 @@ ENCODER_DECODER_SETTINGS = [
      " --transformer-feed-forward-num-hidden 32"
      " --transformer-dropout-prepost 0.1 --transformer-preprocess n --transformer-postprocess dr"
      " --weight-tying --weight-tying-type src_trg_softmax"
+     " --weight-init-scale=3.0 --weight-init-xavier-factor-type=avg --embed-weight-init=normal"
      " --batch-size 8 --max-updates 10"
      " --checkpoint-frequency 10 --optimizer adam --initial-learning-rate 0.01",
      "--beam-size 2",


### PR DESCRIPTION
increases test coverage of checkpoint_decoder.py to 93% (was 0%).
Runs the checkpoint decoder on 1% of the dev data in `run_train_translate()`. No additional assertions added and the impact on speed for testing is minimal.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

