### PR TITLE
Allow empty sequences in train/validation data and skip them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 *.egg**
 .*.swp
 .mypy_cache
+.pytest_cache
 tags
 sockeye/__pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.3]
+### Changed
+- Training now supports training and validation data that contains empty segments. If a segment is empty, it is skipped
+  during loading and a warning message including the number of empty segments is printed.
+
 ## [1.18.2]
 ### Changed
 - Removed combined linear projection of keys & values in source attention transformer layers for

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.2'
+__version__ = '1.18.3'

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -1024,7 +1024,7 @@ class SequenceReader(Iterable):
                 sequence = tokens2ids(tokens, self.vocab)
             else:
                 sequence = strids2ids(tokens)
-            if not sequence:
+            if len(sequence) == 0:
                 yield None
                 continue
             if vocab is not None and self.add_bos:
@@ -1032,7 +1032,7 @@ class SequenceReader(Iterable):
             yield sequence
 
 
-def parallel_iter(source_iters: Sequence[Iterable], target_iterable: Iterable):
+def parallel_iter(source_iters: Sequence[Iterable[Optional[Any]]], target_iterable: Iterable[Optional[Any]]):
     """
     Yields parallel source(s), target sequences from iterables.
     Checks for token parallelism in source sequences.
@@ -1073,7 +1073,7 @@ def get_parallel_bucket(buckets: List[Tuple[int, int]],
                         length_target: int) -> Optional[Tuple[int, Tuple[int, int]]]:
     """
     Returns bucket index and bucket from a list of buckets, given source and target length.
-    Returns (None, None) if no bucket fits or one or both lengths are 0.
+    Returns (None, None) if no bucket fits.
 
     :param buckets: List of buckets.
     :param length_source: Length of source sequence.

--- a/test/unit/test_data_io.py
+++ b/test/unit/test_data_io.py
@@ -105,8 +105,9 @@ def test_ids2strids(ids, expected_string):
     assert string == expected_string
 
 
-sequence_reader_tests = [(["1 2 3", "2", "14", "2 2 2"], False, False),
+sequence_reader_tests = [(["1 2 3", "2", "", "2 2 2"], False, False),
                          (["a b c", "c"], True, False),
+                         (["a b c", ""], True, False),
                          (["a b c", "c"], True, True)]
 
 
@@ -116,34 +117,93 @@ def test_sequence_reader(sequences, use_vocab, add_bos):
         path = os.path.join(work_dir, 'input')
         with open(path, 'w') as f:
             for sequence in sequences:
-                f.write(sequence + "\n")
+                print(sequence, file=f)
 
         vocabulary = vocab.build_vocab(sequences) if use_vocab else None
 
         reader = data_io.SequenceReader(path, vocab=vocabulary, add_bos=add_bos)
 
         read_sequences = [s for s in reader]
-        assert reader.is_done()
-        assert len(read_sequences) == reader.count
+        assert len(read_sequences) == len(sequences)
 
         if vocabulary is None:
             with pytest.raises(SockeyeError) as e:
                 _ = data_io.SequenceReader(path, vocab=vocabulary, add_bos=True)
             assert str(e.value) == "Adding a BOS symbol requires a vocabulary"
 
-            expected_sequences = [data_io.strids2ids(get_tokens(s)) for s in sequences]
+            expected_sequences = [data_io.strids2ids(get_tokens(s)) if s else None for s in sequences]
             assert read_sequences == expected_sequences
         else:
-            expected_sequences = [data_io.tokens2ids(get_tokens(s), vocabulary) for s in sequences]
+            expected_sequences = [data_io.tokens2ids(get_tokens(s), vocabulary) if s else None for s in sequences]
             if add_bos:
-                expected_sequences = [[vocabulary[C.BOS_SYMBOL]] + s for s in expected_sequences]
+                expected_sequences = [[vocabulary[C.BOS_SYMBOL]] + s if s else None for s in expected_sequences]
             assert read_sequences == expected_sequences
 
-        # check raise for multiple concurrent iters
-        _ = iter(reader)
-        with pytest.raises(SockeyeError) as e:
-            iter(reader)
-        assert str(e.value) == "Can not iterate multiple times simultaneously."
+
+@pytest.mark.parametrize("source_iterables, target_iterable",
+                         [
+                             (
+                                     [[[0], [1, 1], [2], [3, 3, 3]], [[0], [1, 1], [2], [3, 3, 3]]],
+                                     [[0], [1]]
+                             ),
+                             (
+                                     [[[0], [1, 1]], [[0], [1, 1]]],
+                                     [[0], [1, 1], [2], [3, 3, 3]]
+                             ),
+                             (
+                                     [[[0], [1, 1]]],
+                                     [[0], [1, 1], [2], [3, 3, 3]]
+                             ),
+                         ])
+def test_nonparallel_iter(source_iterables, target_iterable):
+    with pytest.raises(SockeyeError) as e:
+        list(data_io.parallel_iter(source_iterables, target_iterable))
+    assert str(e.value) == "Different number of lines in source(s) and target iterables."
+
+
+@pytest.mark.parametrize("source_iterables, target_iterable",
+                         [
+                             (
+                                     [[[0], [1, 1]], [[0], [1]]],
+                                     [[0], [1]]
+                             )
+                         ])
+def test_nontoken_parallel_iter(source_iterables, target_iterable):
+    with pytest.raises(SockeyeError) as e:
+        list(data_io.parallel_iter(source_iterables, target_iterable))
+    assert str(e.value).startswith("Source sequences are not token-parallel")
+
+
+@pytest.mark.parametrize("source_iterables, target_iterable, expected",
+                         [
+                             (
+                                     [[[0], [1, 1]], [[0], [1, 1]]],
+                                     [[0], [1]],
+                                     [(([0], [0]), [0]), (([1, 1], [1, 1]), [1])]
+                             ),
+                             (
+                                     [[[0], None], [[0], None]],
+                                     [[0], [1]],
+                                     [(([0], [0]), [0])]
+                             ),
+                             (
+                                     [[[0], [1, 1]], [[0], [1, 1]]],
+                                     [[0], None],
+                                     [(([0], [0]), [0])]
+                             ),
+                             (
+                                     [[None, [1, 1]], [None, [1, 1]]],
+                                     [None, [1]],
+                                     [(([1, 1], [1, 1]), [1])]
+                             ),
+                             (
+                                     [[None, [1, 1]], [None, [1, 1]]],
+                                     [None, None],
+                                     []
+                             )
+                         ])
+def test_parallel_iter(source_iterables, target_iterable, expected):
+    assert list(data_io.parallel_iter(source_iterables, target_iterable)) == expected
 
 
 def test_sample_based_define_bucket_batch_sizes():


### PR DESCRIPTION
Previously sockeye was throwing an exception when training or validation data contained empty segments.
With this change we simply skip over them (which included a little bit more logic to make sure parallel readers remain in sync). Overall this also simplified the iterator logic a little bit.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

