### PR TITLE
experimental option to override transformer dtype during inference

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1087,6 +1087,11 @@ def add_inference_args(params):
                                type=float,
                                help='Beta factor for the length penalty used in beam search: '
                                     '(beta + len(Y))**alpha/(beta + 1)**alpha. Default: %(default)s')
+    decode_params.add_argument('--override-dtype',
+                               default=None,
+                               type=str,
+                               help='EXPERIMENTAL: may be changed or removed in future. Overrides training dtype of '
+                                    'encoders and decoders during inference. Default: %(default)s')
 
 def add_evaluate_args(params):
     eval_params = params.add_argument_group("Evaluate parameters")

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -338,9 +338,19 @@ LOSS_NORM_VALID = "valid"
 TARGET_MAX_LENGTH_FACTOR = 2
 DEFAULT_NUM_STD_MAX_OUTPUT_LENGTH = 2
 
+DTYPE_FP16 = 'float16'
 DTYPE_FP32 = 'float32'
 LARGE_POSITIVE_VALUE = 99999999.
 LARGE_NEGATIVE_VALUE = -LARGE_POSITIVE_VALUE
+LARGE_VALUES = {
+    # Something at the middle of 32768<x<65519. Will be rounded to a multiple of 32.
+    # https://en.wikipedia.org/wiki/Half-precision_floating-point_format#Precision_limitations_on_integer_values
+    DTYPE_FP16: 49152.0,
+
+    # Will be rounded to 1.0e8.
+    # https://en.wikipedia.org/wiki/Single-precision_floating-point_format#Precision_limits_on_integer_values.
+    DTYPE_FP32: LARGE_POSITIVE_VALUE
+}
 
 LHUC_NAME = "lhuc"
 # lhuc application points

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -87,6 +87,7 @@ class Decoder(ABC):
 
     @abstractmethod
     def __init__(self, dtype):
+        logger.info('{}.{} dtype: {}'.format(self.__module__, self.__class__.__name__, dtype))
         self.dtype = dtype
 
     @abstractmethod

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -352,7 +352,8 @@ def load_models(context: mx.context.Context,
                 softmax_temperature: Optional[float] = None,
                 max_output_length_num_stds: int = C.DEFAULT_NUM_STD_MAX_OUTPUT_LENGTH,
                 decoder_return_logit_inputs: bool = False,
-                cache_output_layer_w_b: bool = False) -> Tuple[List[InferenceModel],
+                cache_output_layer_w_b: bool = False,
+                override_dtype: Optional[str] = None) -> Tuple[List[InferenceModel],
                                                                List[vocab.Vocab],
                                                                vocab.Vocab]:
     """
@@ -371,6 +372,7 @@ def load_models(context: mx.context.Context,
                                         vocabulary.  Used when logits/softmax are handled separately.
     :param cache_output_layer_w_b: Models cache weights and biases for logit computation as NumPy arrays (used with
                                    restrict lexicon).
+    :param override_dtype: Overrides dtype of encoder and decoder defined at training time to a different one.
     :return: List of models, source vocabulary, target vocabulary, source factor vocabularies.
     """
     logger.info("Loading %d model(s) from %s ...", len(model_folders), model_folders)
@@ -392,6 +394,9 @@ def load_models(context: mx.context.Context,
         logger.info("Model version: %s", model_version)
         utils.check_version(model_version)
         model_config = model.SockeyeModel.load_config(os.path.join(model_folder, C.CONFIG_NAME))
+        if override_dtype is not None:
+            model_config.config_encoder.dtype = override_dtype
+            model_config.config_decoder.dtype = override_dtype
 
         if checkpoint is None:
             params_fname = os.path.join(model_folder, C.PARAMS_BEST_NAME)

--- a/sockeye/rnn_attention.py
+++ b/sockeye/rnn_attention.py
@@ -791,7 +791,7 @@ def get_context_and_attention_probs(values: mx.sym.Symbol,
                                  axis=1,
                                  use_sequence_length=True,
                                  sequence_length=length,
-                                 value=np.finfo(dtype).min)
+                                 value=-C.LARGE_VALUES[dtype])
 
     # (batch_size, seq_len, 1)
     probs = mx.sym.softmax(logits, axis=1, name='attention_softmax')

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -291,14 +291,16 @@ class VariableLengthBias(mx.operator.CustomOp):
     def forward(self, is_train, req, in_data, out_data, aux):
         # lengths: (batch_size,)
         lengths = in_data[0]
+        dtype = lengths.dtype
+        dtype_str = np.dtype(dtype).name
 
         # (batch_size, max_length)
-        data = mx.nd.zeros((lengths.shape[0], self.max_length), ctx=lengths.context)
+        data = mx.nd.zeros((lengths.shape[0], self.max_length), dtype=dtype, ctx=lengths.context)
         data = mx.nd.SequenceMask(data=data,
                                   use_sequence_length=True,
                                   sequence_length=lengths,
                                   axis=1,
-                                  value=C.LARGE_NEGATIVE_VALUE)
+                                  value=-C.LARGE_VALUES[dtype_str])
         self.assign(out_data[0], req[0], data)
 
     def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
@@ -323,7 +325,7 @@ class VariableLengthBiasProp(mx.operator.CustomOpProp):
         return in_shape, [(batch_size, self.max_length)], []
 
     def infer_type(self, in_type):
-        return in_type, [np.float32], []
+        return in_type, in_type, []
 
     def create_operator(self, ctx, shapes, dtypes):
         return VariableLengthBias(max_length=self.max_length)
@@ -377,16 +379,16 @@ class AutoRegressiveBias(mx.operator.CustomOp):
     0 0 0 0
     """
 
-    def __init__(self, length: int, ctx: mx.Context) -> None:
+    def __init__(self, length: int, dtype:str, ctx: mx.Context) -> None:
         super().__init__()
-        self.bias = self.get_bias(length, ctx)
+        self.bias = self.get_bias(length, dtype, ctx)
 
     @staticmethod
-    def get_bias(length: int, ctx: mx.Context):
+    def get_bias(length: int, dtype: str, ctx: mx.Context):
         # matrix with lower triangle and main diagonal set to 0, upper triangle set to 1
-        upper_triangle = np.triu(np.ones((length, length)), k=1)
+        upper_triangle = np.triu(np.ones((length, length), dtype=dtype), k=1)
         # (1, length, length)
-        bias = C.LARGE_NEGATIVE_VALUE * np.reshape(upper_triangle, (1, length, length))
+        bias = -C.LARGE_VALUES[dtype] * np.reshape(upper_triangle, (1, length, length))
         return mx.nd.array(bias, ctx=ctx)
 
     def forward(self, is_train, req, in_data, out_data, aux):
@@ -399,9 +401,10 @@ class AutoRegressiveBias(mx.operator.CustomOp):
 @mx.operator.register("auto_regressive_bias")
 class AutoRegressiveBiasProp(mx.operator.CustomOpProp):
 
-    def __init__(self, length: str) -> None:
+    def __init__(self, length: str, dtype: str = C.DTYPE_FP32) -> None:
         super().__init__()
         self.length = int(length)
+        self.dtype = dtype
 
     def list_arguments(self):
         return []
@@ -413,7 +416,7 @@ class AutoRegressiveBiasProp(mx.operator.CustomOpProp):
         return [], [(1, self.length, self.length)], []
 
     def infer_type(self, in_type):
-        return [], [np.float32], []
+        return [], [np.dtype(self.dtype).type], []
 
     def create_operator(self, ctx, shapes, dtypes):
-        return AutoRegressiveBias(length=self.length, ctx=ctx)
+        return AutoRegressiveBias(length=self.length, dtype=self.dtype, ctx=ctx)

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -63,6 +63,11 @@ def main():
     with ExitStack() as exit_stack:
         context = _setup_context(args, exit_stack)
 
+        if args.override_dtype == C.DTYPE_FP16:
+            logger.warning('Experimental feature \'--override-dtype float16\' has been used. '
+                           'This feature may be removed or change its behaviour in future. '
+                           'DO NOT USE IT IN PRODUCTION!')
+
         models, source_vocabs, target_vocab = inference.load_models(
             context=context,
             max_input_len=args.max_input_len,
@@ -73,7 +78,8 @@ def main():
             softmax_temperature=args.softmax_temperature,
             max_output_length_num_stds=args.max_output_length_num_stds,
             decoder_return_logit_inputs=args.restrict_lexicon is not None,
-            cache_output_layer_w_b=args.restrict_lexicon is not None)
+            cache_output_layer_w_b=args.restrict_lexicon is not None,
+            override_dtype=args.override_dtype)
         restrict_lexicon = None  # type: Optional[TopKLexicon]
         if args.restrict_lexicon:
             restrict_lexicon = TopKLexicon(source_vocabs[0], target_vocab)

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -826,3 +826,31 @@ def cleanup_params_files(output_folder: str, max_to_keep: int, checkpoint: int, 
             param_fname_n = params_name_with_dir % n
             if param_fname_n in existing_files:
                 os.remove(param_fname_n)
+
+
+def cast_conditionally(data: mx.sym.Symbol, dtype: str) -> mx.sym.Symbol:
+    """
+    Workaround until no-op cast will be fixed in MXNet codebase.
+    Creates cast symbol only if dtype is different from default one, i.e. float32.
+
+    :param data: Input symbol.
+    :param dtype: Target dtype.
+    :return: Cast symbol or just data symbol.
+    """
+    if dtype != C.DTYPE_FP32:
+        return mx.sym.cast(data=data, dtype=dtype)
+    return data
+
+
+def uncast_conditionally(data: mx.sym.Symbol, dtype: str) -> mx.sym.Symbol:
+    """
+    Workaround until no-op cast will be fixed in MXNet codebase.
+    Creates cast to float32 symbol only if dtype is different from default one, i.e. float32.
+
+    :param data: Input symbol.
+    :param dtype: Input symbol dtype.
+    :return: Cast symbol or just data symbol.
+    """
+    if dtype != C.DTYPE_FP32:
+        return mx.sym.cast(data=data, dtype=C.DTYPE_FP32)
+    return data

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -209,7 +209,8 @@ def test_training_arg(test_params, expected_params):
                       beam_search_stop='all',
                       length_penalty_alpha=1.0,
                       length_penalty_beta=0.0,
-                      strip_unknown_words=False)),
+                      strip_unknown_words=False,
+                      override_dtype=None)),
 ])
 def test_inference_args(test_params, expected_params):
     _test_args(test_params, expected_params, arguments.add_inference_args)

--- a/test/unit/test_operator.py
+++ b/test/unit/test_operator.py
@@ -1,0 +1,64 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import mxnet as mx
+import numpy as np
+
+import sockeye.constants as C
+import sockeye.transformer
+
+
+def test_auto_regressive_bias_op():
+    bias = mx.nd.Custom(op_type='auto_regressive_bias', length=2)
+
+    assert bias.dtype == np.float32
+
+    expected = np.array([[0.0, -1.0e8], [0.0, 0.0]]).reshape((1, 2, 2))
+    np.testing.assert_array_equal(bias.asnumpy(), expected)
+
+
+def test_auto_regressive_bias_op_float16():
+    bias = mx.nd.Custom(op_type='auto_regressive_bias', length=2, dtype=C.DTYPE_FP16)
+
+    assert bias.dtype == np.float16
+
+    expected = np.array([[0.0, -49152.0], [0.0, 0.0]]).reshape((1, 2, 2))
+    np.testing.assert_array_equal(bias.asnumpy(), expected)
+
+
+def test_auto_regressive_bias_sym():
+    bias = mx.sym.Custom(op_type='auto_regressive_bias', length=2)
+
+    arg_types, out_types, aux_types = bias.infer_type()
+    assert out_types[0] == np.float32
+
+    out = bias.eval()[0]
+
+    assert out.dtype == np.float32
+
+    expected = np.array([[0.0, -1.0e8], [0.0, 0.0]]).reshape((1, 2, 2))
+    np.testing.assert_array_equal(out.asnumpy(), expected)
+
+
+def test_auto_regressive_bias_sym_float16():
+    bias = mx.sym.Custom(op_type='auto_regressive_bias', length=2, dtype=C.DTYPE_FP16)
+
+    arg_types, out_types, aux_types = bias.infer_type()
+    assert out_types[0] == np.float16
+
+    out = bias.eval()[0]
+
+    assert out.dtype == np.float16
+
+    expected = np.array([[0.0, -49152.0], [0.0, 0.0]]).reshape((1, 2, 2))
+    np.testing.assert_array_equal(out.asnumpy(), expected)


### PR DESCRIPTION
First functional change to override transformer dtype. Marked cli option as experimental.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

