### PR TITLE
Word based batching clarification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.7]
+### Fixed
+- Word based batching with very small batch sizes.
+
 ## [1.18.6]
 ### Fixed
 - Fixed a problem with learning rate scheduler not properly being loaded when resuming training.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.6'
+__version__ = '1.18.7'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -660,7 +660,8 @@ def add_training_args(params):
                               default=C.BATCH_TYPE_SENTENCE,
                               choices=[C.BATCH_TYPE_SENTENCE, C.BATCH_TYPE_WORD],
                               help="Sentence: each batch contains X sentences, number of words varies. Word: each batch"
-                                   " contains (approximately) X words, number of sentences varies. Default: %(default)s.")
+                                   " contains (approximately) X target words, number of sentences varies. "
+                                   "Default: %(default)s.")
 
     train_params.add_argument('--fill-up',
                               type=str,

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -159,14 +159,14 @@ def define_bucket_batch_sizes(buckets: List[Tuple[int, int]],
                                                           " buckets: (%d > %d)" % (padded_seq_len, batch_size))
             # Multiple of number of devices (int) closest to target number of words, assuming each sentence is of
             # average length
-            batch_size_seq = batch_num_devices * round((batch_size / average_seq_len) / batch_num_devices)
+            batch_size_seq = batch_num_devices * max(1, round((batch_size / average_seq_len) / batch_num_devices))
             batch_size_word = batch_size_seq * average_seq_len
         else:
             batch_size_seq = batch_size
             batch_size_word = batch_size_seq * average_seq_len
         bucket_batch_sizes.append(BucketBatchSize(bucket, batch_size_seq, batch_size_word))
-        # Track largest number of word samples in a batch
-        largest_total_num_words = max(largest_total_num_words, batch_size_seq * max(*bucket))
+        # Track largest number of target word samples in a batch
+        largest_total_num_words = max(largest_total_num_words, batch_size_seq * padded_seq_len)
 
     # Final step: guarantee that largest bucket by sequence length also has largest total batch size.
     # When batching by sentences, this will already be the case.


### PR DESCRIPTION
* Making it clear on the CLI that word based batching refers to the target side
* Fixing edge case with small badge sizes and word based batching, in which the batch size could be 0.
* Calculating `largest_total_num_words` based on target length (like everything else in `define_bucket_batch_sizes`).

