### PR TITLE
Remove overly restrictive check to support early stopping with BLEU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.10]
+### Fixed
+- Re-allow early stopping w.r.t BLEU
+
 ## [1.18.9]
 ### Fixed
 - Fixed a problem with lhuc boolean flags passed as None.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.9'
+__version__ = '1.18.10'

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -880,7 +880,6 @@ class EarlyStoppingTrainer:
         """
         Helper function that checks various configuration compatibilities.
         """
-        utils.check_condition(early_stopping_metric in metrics, "Early stopping metric must be tracked.")
         utils.check_condition(len(metrics) > 0, "At least one metric must be provided.")
         for metric in metrics:
             utils.check_condition(metric in C.METRICS, "Unknown metric to track during training: %s" % metric)


### PR DESCRIPTION
Removes an overly restrictive check introduced with the train refactoring.
Re-allows early stopping w.r.t BLEU.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

