### PR TITLE
proper none check for lhuc

### DIFF
--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -129,7 +129,7 @@ class LHUC:
                  prefix: str = "") -> None:
         self.num_hidden = num_hidden
         self.prefix = prefix
-        if not weight:
+        if weight is None:
             self.params = mx.sym.Variable(self.prefix + C.LHUC_NAME,
                                           shape=(self.num_hidden,),
                                           init=mx.init.Uniform(0.1),


### PR DESCRIPTION
This is a change in light of the upcoming mxnet 1.2 release. With mxnet 1.2, the None check in the LHUC class will fail with the following error:
```
sockeye/layers.py:132: in __init__
    if not weight:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Symbol encoder_birnn_forward_l0_lhuc>

    def __bool__(self):
>       raise NotImplementedForSymbol(self.__bool__, 'bool')
E       mxnet.base.NotImplementedForSymbol: Function __bool__ (namely operator "bool") is not implemented for Symbol and only available in NDArray.
```

This change fixes this.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

