### PR TITLE
Adding an end of sentence symbol to the source side.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.12]
+### Changed
+- All source side sequences now get appended an additional end-of-sentence (EOS) symbol. This change is backwards
+  compatible meaning that inference with older models will still work without the EOS symbol.
+
 ## [1.18.11]
 ### Changed
 - Default training parameters have been changed to reflect the setup used in our arXiv paper. Specifically, the default

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.11'
+__version__ = '1.18.12'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -335,8 +335,7 @@ def add_bucketing_args(params):
     params.add_argument('--max-seq-len',
                         type=multiple_values(num_values=2, greater_or_equal=1),
                         default=(100, 100),
-                        help='Maximum sequence length in tokens. Note that the target side will be extended by '
-                             'the <BOS> (beginning of sentence) token, increasing the effective target length. '
+                        help='Maximum sequence length in tokens.'
                              'Use "x:x" to specify separate values for src&tgt. Default: %(default)s.')
 
 

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -334,7 +334,7 @@ def add_bucketing_args(params):
 
     params.add_argument('--max-seq-len',
                         type=multiple_values(num_values=2, greater_or_equal=1),
-                        default=(100, 100),
+                        default=(99, 99),
                         help='Maximum sequence length in tokens.'
                              'Use "x:x" to specify separate values for src&tgt. Default: %(default)s.')
 

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -24,6 +24,8 @@ PAD_SYMBOL = "<pad>"
 PAD_ID = 0
 TOKEN_SEPARATOR = " "
 VOCAB_SYMBOLS = [PAD_SYMBOL, UNK_SYMBOL, BOS_SYMBOL, EOS_SYMBOL]
+# reserve extra space for the EOS or BOS symbol that is added to both source and target
+SPACE_FOR_XOS = 1
 
 ARG_SEPARATOR = ":"
 

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -1036,7 +1036,18 @@ class SequenceReader(Iterable):
             yield sequence
 
 
-def create_sequence_readers(sources, target, vocab_sources, vocab_target):
+def create_sequence_readers(sources: List[str], target: str,
+                            vocab_sources: List[vocab.Vocab],
+                            vocab_target: vocab.Vocab) -> Tuple[List[SequenceReader], SequenceReader]:
+    """
+    Create source readers with EOS and target readers with BOS.
+
+    :param sources: The file names of source data and factors.
+    :param target: The file name of the target data.
+    :param vocab_sources: The source vocabularies.
+    :param vocab_target: The target vocabularies.
+    :return: The source sequence readers and the target reader.
+    """
     source_sequence_readers = [SequenceReader(source, vocab, add_eos=True) for source, vocab in
                                zip(sources, vocab_sources)]
     target_sequence_reader = SequenceReader(target, vocab_target, add_bos=True)

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -999,21 +999,21 @@ class SequenceReader(Iterable):
 
     def __init__(self,
                  path: str,
-                 vocab: Optional[vocab.Vocab] = None,
+                 vocabulary: Optional[vocab.Vocab] = None,
                  add_bos: bool = False,
                  add_eos: bool = False,
                  limit: Optional[int] = None) -> None:
         self.path = path
-        self.vocab = vocab
+        self.vocab = vocabulary
         self.bos_id = None
         self.eos_id = None
-        if vocab is not None:
-            assert C.UNK_SYMBOL in vocab
-            assert vocab[C.PAD_SYMBOL] == C.PAD_ID
-            assert C.BOS_SYMBOL in vocab
-            assert C.EOS_SYMBOL in vocab
-            self.bos_id = vocab[C.BOS_SYMBOL]
-            self.eos_id = vocab[C.EOS_SYMBOL]
+        if vocabulary is not None:
+            assert C.UNK_SYMBOL in vocabulary
+            assert vocabulary[C.PAD_SYMBOL] == C.PAD_ID
+            assert C.BOS_SYMBOL in vocabulary
+            assert C.EOS_SYMBOL in vocabulary
+            self.bos_id = vocabulary[C.BOS_SYMBOL]
+            self.eos_id = vocabulary[C.EOS_SYMBOL]
         else:
             check_condition(not add_bos and not add_eos, "Adding a BOS or EOS symbol requires a vocabulary")
         self.add_bos = add_bos

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017, 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -556,7 +556,8 @@ def prepare_data(source_fnames: List[str],
     config_data = DataConfig(data_statistics=data_statistics,
                              max_seq_len_source=max_seq_len_source,
                              max_seq_len_target=max_seq_len_target,
-                             num_source_factors=len(source_fnames))
+                             num_source_factors=len(source_fnames),
+                             source_with_eos=True)
     config_data_fname = os.path.join(output_prefix, C.DATA_CONFIG)
     logger.info("Writing data config to '%s'", config_data_fname)
     config_data.save(config_data_fname)
@@ -796,7 +797,8 @@ def get_training_data_iters(sources: List[str],
     config_data = DataConfig(data_statistics=data_statistics,
                              max_seq_len_source=max_seq_len_source,
                              max_seq_len_target=max_seq_len_target,
-                             num_source_factors=len(sources))
+                             num_source_factors=len(sources),
+                             source_with_eos=True)
 
     train_iter = ParallelSampleIter(data=training_data,
                                     buckets=buckets,
@@ -925,12 +927,14 @@ class DataConfig(config.Config):
                  data_statistics: DataStatistics,
                  max_seq_len_source: int,
                  max_seq_len_target: int,
-                 num_source_factors: int) -> None:
+                 num_source_factors: int,
+                 source_with_eos: bool = False) -> None:
         super().__init__()
         self.data_statistics = data_statistics
         self.max_seq_len_source = max_seq_len_source
         self.max_seq_len_target = max_seq_len_target
         self.num_source_factors = num_source_factors
+        self.source_with_eos = source_with_eos
 
 
 def read_content(path: str, limit: Optional[int] = None) -> Iterator[List[str]]:

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -429,7 +429,7 @@ def load_models(context: mx.context.Context,
 
     source_with_eos = models[0].source_with_eos
     utils.check_condition(all(source_with_eos == m.source_with_eos for m in models),
-                          "All models must match either take an additional EOS symbol on the source side or not. "
+                          "All models must agree on using source-side EOS symbols or not. "
                           "Did you try combining models trained with different versions?")
 
     # set a common max_output length for all models.
@@ -600,7 +600,10 @@ class TranslatorInput:
                                   factors=factors,
                                   chunk_id=chunk_id)
 
-    def with_eos(self):
+    def with_eos(self) -> 'TranslatorInput':
+        """
+        :return: A new translator input with EOS appended to the tokens and factors.
+        """
         return TranslatorInput(self.sentence_id,
                                self.tokens + [C.EOS_SYMBOL],
                                [factor + [C.EOS_SYMBOL] for factor in self.factors]

--- a/sockeye/prepare_data.py
+++ b/sockeye/prepare_data.py
@@ -55,7 +55,6 @@ def main():
     logger.info("Adjusting maximum length to reserve space for a BOS/EOS marker. New maximum length: (%d, %d)",
                 max_seq_len_source, max_seq_len_target)
 
-
     source_vocabs, target_vocab = vocab.load_or_create_vocabs(
         source_paths=source_paths,
         target_path=args.target,

--- a/sockeye/prepare_data.py
+++ b/sockeye/prepare_data.py
@@ -48,7 +48,13 @@ def main():
 
     num_words_source, num_words_target = args.num_words
     word_min_count_source, word_min_count_target = args.word_min_count
-    max_len_source, max_len_target = args.max_seq_len
+    max_seq_len_source, max_seq_len_target = args.max_seq_len
+    # The maximum length is the length before we add the BOS/EOS symbols
+    max_seq_len_source = max_seq_len_source + C.SPACE_FOR_XOS
+    max_seq_len_target = max_seq_len_target + C.SPACE_FOR_XOS
+    logger.info("Adjusting maximum length to reserve space for a BOS/EOS marker. New maximum length: (%d, %d)",
+                max_seq_len_source, max_seq_len_target)
+
 
     source_vocabs, target_vocab = vocab.load_or_create_vocabs(
         source_paths=source_paths,
@@ -68,8 +74,8 @@ def main():
                          source_vocab_paths=source_vocab_paths,
                          target_vocab_path=args.target_vocab,
                          shared_vocab=args.shared_vocab,
-                         max_seq_len_source=max_len_source,
-                         max_seq_len_target=max_len_target,
+                         max_seq_len_source=max_seq_len_source,
+                         max_seq_len_target=max_seq_len_target,
                          bucketing=bucketing,
                          bucket_width=bucket_width,
                          samples_per_shard=samples_per_shard,

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -264,6 +264,10 @@ def create_data_iters_and_vocabs(args: argparse.Namespace,
     :return: The data iterators (train, validation, config_data) as well as the source and target vocabularies.
     """
     max_seq_len_source, max_seq_len_target = args.max_seq_len
+    # The maximum length is the length before we add the BOS/EOS symbols
+    max_seq_len_source = max_seq_len_source + C.SPACE_FOR_XOS
+    max_seq_len_target = max_seq_len_target + C.SPACE_FOR_XOS
+
     num_words_source, num_words_target = args.num_words
     word_min_count_source, word_min_count_target = args.word_min_count
     batch_num_devices = 1 if args.use_cpu else sum(-di if di < 0 else 1 for di in args.device_ids)

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -263,7 +263,6 @@ def create_data_iters_and_vocabs(args: argparse.Namespace,
     :param max_seq_len_source: Source maximum sequence length.
     :param max_seq_len_target: Target maximum sequence length.
     :param shared_vocab: Whether to create a shared vocabulary.
-    :param shared_vocab: Whether to create a shared vocabulary.
     :param resume_training: Whether to resume training.
     :param output_folder: Output folder.
     :return: The data iterators (train, validation, config_data) as well as the source and target vocabularies.

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -13,6 +13,7 @@
 
 import pytest
 
+import sockeye.constants as C
 from test.common import run_train_translate, tmp_digits_dataset
 
 _TRAIN_LINE_COUNT = 100
@@ -151,7 +152,7 @@ def test_seq_copy(train_params: str,
                             train_source_factor_paths=train_source_factor_paths,
                             dev_source_factor_paths=dev_source_factor_paths,
                             test_source_factor_paths=test_source_factor_paths,
-                            max_seq_len=_LINE_MAX_LENGTH + 1,
+                            max_seq_len=_LINE_MAX_LENGTH + C.SPACE_FOR_XOS,
                             restrict_lexicon=restrict_lexicon,
                             work_dir=data['work_dir'],
                             use_prepared_data=use_prepared_data)

--- a/test/system/test_seq_copy_sys.py
+++ b/test/system/test_seq_copy_sys.py
@@ -18,6 +18,7 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
+import sockeye.constants as C
 from test.common import tmp_digits_dataset, run_train_translate
 
 _TRAIN_LINE_COUNT = 10000
@@ -141,7 +142,7 @@ def test_seq_copy(name, train_params, translate_params, use_prepared_data, perpl
                                                                     test_source_path=data['test_source'],
                                                                     test_target_path=data['test_target'],
                                                                     use_prepared_data=use_prepared_data,
-                                                                    max_seq_len=_LINE_MAX_LENGTH + 1,
+                                                                    max_seq_len=_LINE_MAX_LENGTH + C.SPACE_FOR_XOS,
                                                                     restrict_lexicon=True,
                                                                     work_dir=data['work_dir'],
                                                                     seed=seed)
@@ -256,7 +257,7 @@ def test_seq_sort(name, train_params, translate_params, use_prepared_data,
                                                                     test_source_factor_paths=data.get(
                                                                         'test_source_factors'),
                                                                     use_prepared_data=use_prepared_data,
-                                                                    max_seq_len=_LINE_MAX_LENGTH + 1,
+                                                                    max_seq_len=_LINE_MAX_LENGTH + C.SPACE_FOR_XOS,
                                                                     restrict_lexicon=True,
                                                                     work_dir=data['work_dir'],
                                                                     seed=seed)

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -34,7 +34,7 @@ from itertools import zip_longest
           validation_source_factors=[],
           output='test_output', overwrite_output=False,
           source_vocab=None, target_vocab=None, shared_vocab=False, num_words=(50000, 50000), word_min_count=(1, 1),
-          no_bucketing=False, bucket_width=10, max_seq_len=(100, 100),
+          no_bucketing=False, bucket_width=10, max_seq_len=(99, 99),
           monitor_pattern=None, monitor_stat_func='mx_default')),
 
     # short parameters
@@ -48,7 +48,7 @@ from itertools import zip_longest
           validation_source_factors=[],
           output='test_output', overwrite_output=False,
           source_vocab=None, target_vocab=None, shared_vocab=False, num_words=(50000, 50000), word_min_count=(1, 1),
-          no_bucketing=False, bucket_width=10, max_seq_len=(100, 100),
+          no_bucketing=False, bucket_width=10, max_seq_len=(99, 99),
           monitor_pattern=None, monitor_stat_func='mx_default'))
 ])
 def test_io_args(test_params, expected_params):
@@ -356,7 +356,7 @@ def test_tutorial_prepare_data_cli_args(test_params, expected_params):
           word_min_count=(1, 1),
           no_bucketing=False,
           bucket_width=10,
-          max_seq_len=(100, 100),
+          max_seq_len=(99, 99),
           min_num_shards=1,
           num_samples_per_shard=1000000,
           seed=13,

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -334,7 +334,7 @@ def test_tutorial_averaging_args(test_params, expected_params, expected_params_p
           word_min_count=(1, 1),
           no_bucketing=False,
           bucket_width=10,
-          max_seq_len=(100, 100),
+          max_seq_len=(99, 99),
           min_num_shards=1,
           num_samples_per_shard=1000000,
           seed=13,

--- a/test/unit/test_data_io.py
+++ b/test/unit/test_data_io.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017, 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -105,14 +105,14 @@ def test_ids2strids(ids, expected_string):
     assert string == expected_string
 
 
-sequence_reader_tests = [(["1 2 3", "2", "", "2 2 2"], False, False),
-                         (["a b c", "c"], True, False),
-                         (["a b c", ""], True, False),
-                         (["a b c", "c"], True, True)]
+sequence_reader_tests = [(["1 2 3", "2", "", "2 2 2"], False, False, False),
+                         (["a b c", "c"], True, False, False),
+                         (["a b c", ""], True, False, False),
+                         (["a b c", "c"], True, True, True)]
 
 
-@pytest.mark.parametrize("sequences, use_vocab, add_bos", sequence_reader_tests)
-def test_sequence_reader(sequences, use_vocab, add_bos):
+@pytest.mark.parametrize("sequences, use_vocab, add_bos, add_eos", sequence_reader_tests)
+def test_sequence_reader(sequences, use_vocab, add_bos, add_eos):
     with TemporaryDirectory() as work_dir:
         path = os.path.join(work_dir, 'input')
         with open(path, 'w') as f:
@@ -121,7 +121,7 @@ def test_sequence_reader(sequences, use_vocab, add_bos):
 
         vocabulary = vocab.build_vocab(sequences) if use_vocab else None
 
-        reader = data_io.SequenceReader(path, vocab=vocabulary, add_bos=add_bos)
+        reader = data_io.SequenceReader(path, vocab=vocabulary, add_bos=add_bos, add_eos=add_eos)
 
         read_sequences = [s for s in reader]
         assert len(read_sequences) == len(sequences)
@@ -129,7 +129,7 @@ def test_sequence_reader(sequences, use_vocab, add_bos):
         if vocabulary is None:
             with pytest.raises(SockeyeError) as e:
                 _ = data_io.SequenceReader(path, vocab=vocabulary, add_bos=True)
-            assert str(e.value) == "Adding a BOS symbol requires a vocabulary"
+            assert str(e.value) == "Adding a BOS or EOS symbol requires a vocabulary"
 
             expected_sequences = [data_io.strids2ids(get_tokens(s)) if s else None for s in sequences]
             assert read_sequences == expected_sequences
@@ -137,6 +137,8 @@ def test_sequence_reader(sequences, use_vocab, add_bos):
             expected_sequences = [data_io.tokens2ids(get_tokens(s), vocabulary) if s else None for s in sequences]
             if add_bos:
                 expected_sequences = [[vocabulary[C.BOS_SYMBOL]] + s if s else None for s in expected_sequences]
+            if add_eos:
+                expected_sequences = [s + [vocabulary[C.EOS_SYMBOL]]  if s else None for s in expected_sequences]
             assert read_sequences == expected_sequences
 
 
@@ -448,30 +450,33 @@ def test_get_training_data_iters():
     test_max_length = 30
     batch_size = 5
     with tmp_digits_dataset("tmp_corpus",
-                            train_line_count, train_max_length, dev_line_count, dev_max_length,
-                            test_line_count, test_line_count_empty, test_max_length) as data:
+                            train_line_count, train_max_length - C.SPACE_FOR_XOS,
+                            dev_line_count, dev_max_length - C.SPACE_FOR_XOS,
+                            test_line_count, test_line_count_empty,
+                            test_max_length - C.SPACE_FOR_XOS) as data:
         # tmp common vocab
         vcb = vocab.build_from_paths([data['source'], data['target']])
 
-        train_iter, val_iter, config_data, data_info = data_io.get_training_data_iters(sources=[data['source']],
-                                                                                       target=data['target'],
-                                                                                       validation_sources=[
-                                                                                           data['validation_source']],
-                                                                                       validation_target=data[
-                                                                                           'validation_target'],
-                                                                                       source_vocabs=[vcb],
-                                                                                       target_vocab=vcb,
-                                                                                       source_vocab_paths=[None],
-                                                                                       target_vocab_path=None,
-                                                                                       shared_vocab=True,
-                                                                                       batch_size=batch_size,
-                                                                                       batch_by_words=False,
-                                                                                       batch_num_devices=1,
-                                                                                       fill_up="replicate",
-                                                                                       max_seq_len_source=train_max_length,
-                                                                                       max_seq_len_target=train_max_length,
-                                                                                       bucketing=True,
-                                                                                       bucket_width=10)
+        train_iter, val_iter, config_data, data_info = data_io.get_training_data_iters(
+            sources=[data['source']],
+            target=data['target'],
+            validation_sources=[
+                data['validation_source']],
+            validation_target=data[
+                'validation_target'],
+            source_vocabs=[vcb],
+            target_vocab=vcb,
+            source_vocab_paths=[None],
+            target_vocab_path=None,
+            shared_vocab=True,
+            batch_size=batch_size,
+            batch_by_words=False,
+            batch_num_devices=1,
+            fill_up="replicate",
+            max_seq_len_source=train_max_length,
+            max_seq_len_target=train_max_length,
+            bucketing=True,
+            bucket_width=10)
         assert isinstance(train_iter, data_io.ParallelSampleIter)
         assert isinstance(val_iter, data_io.ParallelSampleIter)
         assert isinstance(config_data, data_io.DataConfig)
@@ -479,7 +484,7 @@ def test_get_training_data_iters():
         assert data_info.target == data['target']
         assert data_info.source_vocabs == [None]
         assert data_info.target_vocab is None
-        assert config_data.data_statistics.max_observed_len_source == train_max_length - 1
+        assert config_data.data_statistics.max_observed_len_source == train_max_length
         assert config_data.data_statistics.max_observed_len_target == train_max_length
         assert np.isclose(config_data.data_statistics.length_ratio_mean, expected_mean)
         assert np.isclose(config_data.data_statistics.length_ratio_std, expected_std)
@@ -492,6 +497,7 @@ def test_get_training_data_iters():
 
         # test some batches
         bos_id = vcb[C.BOS_SYMBOL]
+        eos_id = vcb[C.EOS_SYMBOL]
         expected_first_target_symbols = np.full((batch_size,), bos_id, dtype='float32')
         for epoch in range(2):
             while train_iter.iter_next():
@@ -504,11 +510,13 @@ def test_get_training_data_iters():
                 label = batch.label[0].asnumpy()
                 assert source.shape[0] == target.shape[0] == label.shape[0] == batch_size
                 # target first symbol should be BOS
+                # each source sequence contains one EOS symbol
+                assert np.sum(source == eos_id) == batch_size
                 assert np.array_equal(target[:, 0], expected_first_target_symbols)
                 # label first symbol should be 2nd target symbol
                 assert np.array_equal(label[:, 0], target[:, 1])
                 # each label sequence contains one EOS symbol
-                assert np.sum(label == vcb[C.EOS_SYMBOL]) == batch_size
+                assert np.sum(label == eos_id) == batch_size
             train_iter.reset()
 
 

--- a/test/unit/test_data_io.py
+++ b/test/unit/test_data_io.py
@@ -121,14 +121,14 @@ def test_sequence_reader(sequences, use_vocab, add_bos, add_eos):
 
         vocabulary = vocab.build_vocab(sequences) if use_vocab else None
 
-        reader = data_io.SequenceReader(path, vocab=vocabulary, add_bos=add_bos, add_eos=add_eos)
+        reader = data_io.SequenceReader(path, vocabulary=vocabulary, add_bos=add_bos, add_eos=add_eos)
 
         read_sequences = [s for s in reader]
         assert len(read_sequences) == len(sequences)
 
         if vocabulary is None:
             with pytest.raises(SockeyeError) as e:
-                _ = data_io.SequenceReader(path, vocab=vocabulary, add_bos=True)
+                _ = data_io.SequenceReader(path, vocabulary=vocabulary, add_bos=True)
             assert str(e.value) == "Adding a BOS or EOS symbol requires a vocabulary"
 
             expected_sequences = [data_io.strids2ids(get_tokens(s)) if s else None for s in sequences]


### PR DESCRIPTION
With this change we add an additional EOS symbol on the source side. From the CLI/user perspective the `--max-seq-len` is the maximum length of the raw tokens without special symbols. Internally lengths are now based on the lengths including the special symbols like EOS. The change is backwards compatible in that the inference logic for existing models did not change.

System tests are currently running.

#### Pull Request Checklist ##
- [X] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [X] Unit tests pass (`pytest`)
- [X] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [X] System tests pass (`pytest test/system`)
- [X] Passed code style checking (`./style-check.sh`)
- [X] You have considered writing a test
- [X] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [X] Updated CHANGELOG.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

