### PR TITLE
fix system test Copy:lstm:pruning after default value changes.

### DIFF
--- a/test/system/test_seq_copy_sys.py
+++ b/test/system/test_seq_copy_sys.py
@@ -16,10 +16,10 @@ import random
 
 import pytest
 
-logger = logging.getLogger(__name__)
-
 import sockeye.constants as C
 from test.common import tmp_digits_dataset, run_train_translate
+
+logger = logging.getLogger(__name__)
 
 _TRAIN_LINE_COUNT = 10000
 _DEV_LINE_COUNT = 100
@@ -41,6 +41,7 @@ COMMON_TRAINING_PARAMS = " --checkpoint-frequency 1000 --optimizer adam --initia
                          " --decode-and-evaluate 0 --label-smoothing 0.0" \
                          " --optimized-metric perplexity --loss cross-entropy"
 
+
 @pytest.mark.parametrize("name, train_params, translate_params, use_prepared_data, perplexity_thresh, bleu_thresh", [
     ("Copy:lstm:lstm",
      "--encoder rnn --decoder rnn "
@@ -55,11 +56,11 @@ COMMON_TRAINING_PARAMS = " --checkpoint-frequency 1000 --optimizer adam --initia
      1.03,
      0.98),
     ("Copy:lstm:pruning",
-     "--encoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
-     " --rnn-attention-num-hidden 32 --batch-size 16 --loss cross-entropy --optimized-metric perplexity"
-     " --checkpoint-frequency 1000 --optimizer adam --initial-learning-rate 0.001"
+     "--encoder rnn --decoder rnn "
+     " --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 --rnn-attention-type mlp"
+     " --rnn-attention-num-hidden 32 --batch-size 16"
      " --rnn-dropout-states 0.0:0.1 --embed-dropout 0.1:0.0 --max-updates 4000 --weight-normalization"
-     " --gradient-clipping-type norm --gradient-clipping-threshold 10",
+     " --gradient-clipping-type norm --gradient-clipping-threshold 10" + COMMON_TRAINING_PARAMS,
      "--beam-size 5 --batch-size 2 --beam-prune 1",
      True,
      1.03,


### PR DESCRIPTION
travis' CRON job failed due to this system test and the recent default arg change. This fixes it.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

