### PR TITLE
Fix Sphinx 1.7.4 build (as run by readthedocs.io).

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ def get_version():
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+needs_sphinx = '1.7.4'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -188,6 +188,7 @@ sockeye.transformer module
 
 .. automodule:: sockeye.transformer
     :members:
+    :exclude-members: TransformerConfig
     :show-inheritance:
 
 sockeye.translate module

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,4 +1,4 @@
-sphinx>=1.4
+sphinx>=1.7.4
 sphinx_rtd_theme
 sphinx-autodoc-typehints>=1.3.0
 recommonmark

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -1001,8 +1001,9 @@ class ConvolutionalEmbeddingEncoder(Encoder):
     An encoder developed to map a sequence of character embeddings to a shorter sequence of segment
     embeddings using convolutional, pooling, and highway layers.  More generally, it maps a sequence
     of input embeddings to a sequence of span embeddings.
-        * "Fully Character-Level Neural Machine Translation without Explicit Segmentation"
-          Jason Lee; Kyunghyun Cho; Thomas Hofmann (https://arxiv.org/pdf/1610.03017.pdf)
+
+    * "Fully Character-Level Neural Machine Translation without Explicit Segmentation"
+      Jason Lee; Kyunghyun Cho; Thomas Hofmann (https://arxiv.org/pdf/1610.03017.pdf)
 
     :param config: Convolutional embedding config.
     :param prefix: Name prefix for symbols of this encoder.

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -733,10 +733,9 @@ class TranslatorOutput:
     :param attention_matrix: Attention matrix. Shape: (target_length, source_length).
     :param score: Negative log probability of generated translation.
     :param beam_histories: List of beam histories. The list will contain more than one
-    history if it was split due to exceeding max_length.
+           history if it was split due to exceeding max_length.
     """
-    __slots__ = ('id', 'translation', 'tokens', 'attention_matrix', 'score',
-                 'beam_histories')
+    __slots__ = ('id', 'translation', 'tokens', 'attention_matrix', 'score', 'beam_histories')
 
     def __init__(self,
                  id: int,

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -29,11 +29,11 @@ def activation(data: mx.sym.Symbol, act_type: str) -> mx.sym.Symbol:
     Apply custom or standard activation.
 
     Custom activation types include:
-    - Swish-1, also called Sigmoid-Weighted Linear Unit (SiLU): Ramachandran et
-      al. (https://arxiv.org/pdf/1710.05941.pdf), Elfwing et al.
-      (https://arxiv.org/pdf/1702.03118.pdf)
-    - Gaussian Error Linear Unit (GELU): Hendrycks and Gimpel
-      (https://arxiv.org/pdf/1606.08415.pdf)
+     - Swish-1, also called Sigmoid-Weighted Linear Unit (SiLU): Ramachandran et
+       al. (https://arxiv.org/pdf/1710.05941.pdf), Elfwing et al.
+       (https://arxiv.org/pdf/1702.03118.pdf)
+     - Gaussian Error Linear Unit (GELU): Hendrycks and Gimpel
+       (https://arxiv.org/pdf/1606.08415.pdf)
 
     :param data: input Symbol of any shape.
     :param act_type: Type of activation.

--- a/sockeye/lexicon.py
+++ b/sockeye/lexicon.py
@@ -74,8 +74,8 @@ class Lexicon:
         """
         Given attention/alignment scores, calculates a weighted sum over lexical distributions
         that serve as a bias for the decoder softmax.
-            * https://arxiv.org/pdf/1606.02006.pdf
-            * http://www.aclweb.org/anthology/W/W16/W16-4610.pdf
+        * https://arxiv.org/pdf/1606.02006.pdf
+        * http://www.aclweb.org/anthology/W/W16/W16-4610.pdf
 
         :param source_lexicon: Lexical biases for sentence Shape: (batch_size, target_vocab_size, source_seq_len).
         :param attention_prob_score: Attention score. Shape: (batch_size, source_seq_len).


### PR DESCRIPTION
readthedocs.io runs sphinx 1.7.4 which caused an error with the sphinx-autodoc-typehints extension and type checking. Specifically it was failing with the following error:
```
[...]
    self.object, self.options, args, retann)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sockeye/envs/latest/lib/python3.5/site-packages/sphinx/application.py", line 448, in emit_firstresult
    return self.events.emit_firstresult(event, self, *args)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sockeye/envs/latest/lib/python3.5/site-packages/sphinx/events.py", line 84, in emit_firstresult
    for result in self.emit(name, *args):
  File "/home/docs/checkouts/readthedocs.org/user_builds/sockeye/envs/latest/lib/python3.5/site-packages/sphinx/events.py", line 79, in emit
    results.append(callback(*args))
  File "/home/docs/checkouts/readthedocs.org/user_builds/sockeye/envs/latest/lib/python3.5/site-packages/sphinx_autodoc_typehints.py", line 140, in process_signature
    return formatargspec(obj, *argspec[:-1]), None
  File "/home/docs/checkouts/readthedocs.org/user_builds/sockeye/envs/latest/lib/python3.5/site-packages/sphinx/ext/autodoc/inspector.py", line 134, in formatargspec
    if typing and hasattr(function, '__code__') else {})
  File "/usr/lib/python3.5/typing.py", line 1182, in get_type_hints
    value = _eval_type(value, globalns, localns)
  File "/usr/lib/python3.5/typing.py", line 290, in _eval_type
    return t._eval_type(globalns, localns)
  File "/usr/lib/python3.5/typing.py", line 525, in _eval_type
    for t in self.__union_params__)
  File "/usr/lib/python3.5/typing.py", line 525, in <genexpr>
    for t in self.__union_params__)
  File "/usr/lib/python3.5/typing.py", line 290, in _eval_type
    return t._eval_type(globalns, localns)
  File "/usr/lib/python3.5/typing.py", line 177, in _eval_type
    eval(self.__forward_code__, globalns, localns),
  File "<string>", line 1, in <module>
NameError: name 'encoder' is not defined
```
After some investigation it turns out that the problem is our workaround for a circular import in `transformer.py`, https://github.com/awslabs/sockeye/blob/master/sockeye/transformer.py#L23, and our type annotation of the `conv_config` in `TransformerConfig`.
I fixed this by excluding the documentation generation for `TransformerConfig`.

I also fixed a bunch of rst syntax warnings in some other docstrings.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

