### PR TITLE
Added support for config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.13]
+### Added
+- Support for config file in train and translate. Config files are JSON serialized dictionaries (args.json produced by
+  train can be taken as a template). Load config files with the --config command line option.
+
 ## [1.18.12]
 ### Changed
 - All source side sequences now get appended an additional end-of-sentence (EOS) symbol. This change is backwards

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.12'
+__version__ = '1.18.13'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -19,7 +19,7 @@ import os
 import sys
 import types
 import yaml
-from typing import Callable, Optional
+from typing import Any, Callable, Dict, List, Tuple, Optional
 
 from sockeye.lr_scheduler import LearningRateSchedulerFixedStep
 from . import constants as C
@@ -40,8 +40,8 @@ class ConfigArgumentParser(argparse.ArgumentParser):
     """
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.argument_definitions = {}
-        self.argument_actions = []
+        self.argument_definitions = {}  # type: Dict[Tuple, Dict]
+        self.argument_actions = []  # type: List[Any]
         self._overwrite_add_argument(self)
         self.add_argument("--config", help="Config file in YAML format.", type=str)
         # Note: not FileType so that we can get the path here
@@ -65,7 +65,7 @@ class ConfigArgumentParser(argparse.ArgumentParser):
         group = super().add_argument_group(*args, **kwargs)
         return self._overwrite_add_argument(group)
 
-    def parse_args(self, args=None) -> argparse.Namespace:
+    def parse_args(self, args=None, namespace=None) -> argparse.Namespace:
         # Mini argument parser to find the config file
         config_parser = argparse.ArgumentParser(add_help=False)
         config_parser.add_argument("--config", type=regular_file())

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -53,11 +53,11 @@ class ConfigArgumentParser(argparse.ArgumentParser):
         group = super().add_argument_group(*args, **kwargs)
         return self._overwrite_add_argument(group)
 
-    def parse_args(self):
+    def parse_args(self, args=None):
         # Mini argument parser to find the config file
         config_parser = argparse.ArgumentParser(add_help=False)
         config_parser.add_argument("--config", type=argparse.FileType("r"))
-        config_args, rest_command_line = config_parser.parse_known_args()
+        config_args, rest_command_line = config_parser.parse_known_args(args=args)
         loaded_config = {}
         if config_args.config:
             loaded_config = json.load(config_args.config)
@@ -66,7 +66,7 @@ class ConfigArgumentParser(argparse.ArgumentParser):
                 if action.dest in loaded_config:
                     action.required = False
         initial_args = argparse.Namespace(**loaded_config)
-        return super().parse_args(namespace=initial_args)
+        return super().parse_args(args=args, namespace=initial_args)
 
 def regular_file() -> Callable:
     """

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -15,10 +15,10 @@
 Defines commandline arguments for the main CLIs with reasonable defaults.
 """
 import argparse
-import json
 import os
 import sys
 import types
+import yaml
 from typing import Callable, Optional
 
 from sockeye.lr_scheduler import LearningRateSchedulerFixedStep
@@ -30,7 +30,7 @@ class ConfigArgumentParser(argparse.ArgumentParser):
     """
     Extension of argparse.ArgumentParser supporting config files.
 
-    The option --config is added automatically and expects a JSON serialized
+    The option --config is added automatically and expects a YAML serialized
     dictionary, similar to the return value of parse_args(). Command line
     parameters have precendence over config file values. Usage should be
     transparent, just substitute argparse.ArgumentParser with this class.
@@ -43,7 +43,7 @@ class ConfigArgumentParser(argparse.ArgumentParser):
         self.argument_definitions = {}
         self.argument_actions = []
         self._overwrite_add_argument(self)
-        self.add_argument("--config", help="Config file in JSON format.", type=str)
+        self.add_argument("--config", help="Config file in YAML format.", type=str)
         # Note: not FileType so that we can get the path here
 
     def _register_argument(self, _action, *args, **kwargs):
@@ -69,10 +69,10 @@ class ConfigArgumentParser(argparse.ArgumentParser):
         # Mini argument parser to find the config file
         config_parser = argparse.ArgumentParser(add_help=False)
         config_parser.add_argument("--config", type=argparse.FileType("r"))
-        config_args, rest_command_line = config_parser.parse_known_args(args=args)
+        config_args, _ = config_parser.parse_known_args(args=args)
         loaded_config = {}
         if config_args.config:
-            loaded_config = json.load(config_args.config)
+            loaded_config = yaml.load(config_args.config)
             # Remove the 'required' flag from options loaded from config file
             for action in self.argument_actions:
                 if action.dest in loaded_config:

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -225,7 +225,7 @@ RNG_STATE_NAME = "rng.pkl"
 TRAINING_STATE_NAME = "training.pkl"
 SCHEDULER_STATE_NAME = "scheduler.pkl"
 TRAINING_STATE_PARAMS_NAME = "params"
-ARGS_STATE_NAME = "args.json"
+ARGS_STATE_NAME = "args.yaml"
 
 # Arguments that may differ and still resume training
 ARGS_MAY_DIFFER = ["overwrite_output", "use-tensorboard", "quiet",

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -15,11 +15,11 @@
 Simple Training CLI.
 """
 import argparse
-import json
 import os
 import shutil
 import sys
 import tempfile
+import yaml
 from contextlib import ExitStack
 from typing import Any, cast, Optional, Dict, List, Tuple
 
@@ -125,7 +125,7 @@ def check_resume(args: argparse.Namespace, output_folder: str) -> bool:
             os.makedirs(output_folder)
         elif os.path.exists(training_state_dir):
             with open(os.path.join(output_folder, C.ARGS_STATE_NAME), "r") as fp:
-                old_args = json.load(fp)
+                old_args = yaml.load(fp)
             arg_diffs = _dict_difference(vars(args), old_args) | _dict_difference(old_args, vars(args))
             # Remove args that may differ without affecting the training.
             arg_diffs -= set(C.ARGS_MAY_DIFFER)
@@ -770,7 +770,7 @@ def train(args: argparse.Namespace):
                                console=not args.quiet, path=os.path.join(output_folder, C.LOG_NAME))
     utils.log_basic_info(args)
     with open(os.path.join(output_folder, C.ARGS_STATE_NAME), "w") as fp:
-        json.dump(vars(args), fp, indent=2)
+        yaml.dump(vars(args), fp, indent=2)
         fp.write("\n")
 
     max_seq_len_source, max_seq_len_target = args.max_seq_len

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -744,7 +744,7 @@ def create_optimizer_config(args: argparse.Namespace, source_vocab_sizes: List[i
 
 
 def main():
-    params = argparse.ArgumentParser(description='Train Sockeye sequence-to-sequence models.')
+    params = arguments.ConfigArgumentParser(description='Train Sockeye sequence-to-sequence models.')
     arguments.add_train_cli_args(params)
     args = params.parse_args()
     train(args)
@@ -770,7 +770,8 @@ def train(args: argparse.Namespace):
                                console=not args.quiet, path=os.path.join(output_folder, C.LOG_NAME))
     utils.log_basic_info(args)
     with open(os.path.join(output_folder, C.ARGS_STATE_NAME), "w") as fp:
-        json.dump(vars(args), fp)
+        json.dump(vars(args), fp, indent=2)
+        fp.write("\n")
 
     max_seq_len_source, max_seq_len_target = args.max_seq_len
     # The maximum length is the length before we add the BOS/EOS symbols

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -36,7 +36,7 @@ logger = setup_main_logger(__name__, file_logging=False)
 
 
 def main():
-    params = argparse.ArgumentParser(description='Translate CLI')
+    params = arguments.ConfigArgumentParser(description='Translate CLI')
     arguments.add_translate_cli_args(params)
     args = params.parse_args()
     run_translate(args)

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -485,7 +485,7 @@ def test_config_file_required(config_command_line, config_contents):
     config_file_argparse.add_argument("-e", type=int)
 
     # The option '--config <file>' will be added automaticall to config_command_line
-    with pytest.raises(SystemExit): # argparse does not have finer regularity excpetions
+    with pytest.raises(SystemExit): # argparse does not have finer regularity exceptions
         with tempfile.NamedTemporaryFile("w") as fp:
             arguments.save_args(argparse.Namespace(**config_contents), fp.name)
             fp.flush()

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -12,10 +12,10 @@
 # permissions and limitations under the License.
 
 import argparse
-import json
 import pytest
 import tempfile
 import os
+import yaml
 
 import sockeye.arguments as arguments
 import sockeye.constants as C
@@ -455,7 +455,7 @@ def test_config_file(plain_command_line, config_command_line, config_contents):
 
     # The option '--config <file>' will be added automaticall to config_command_line
     with tempfile.NamedTemporaryFile("w") as fp:
-        json.dump(config_contents, fp)
+        yaml.dump(config_contents, fp)
         fp.flush()
 
         # Parse args and cast to dicts directly
@@ -487,7 +487,7 @@ def test_config_file_required(config_command_line, config_contents):
     # The option '--config <file>' will be added automaticall to config_command_line
     with pytest.raises(SystemExit): # argparse does not have finer regularity excpetions
         with tempfile.NamedTemporaryFile("w") as fp:
-            json.dump(config_contents, fp)
+            yaml.dump(config_contents, fp)
             fp.flush()
 
             # Parse args and cast to dicts directly

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -442,7 +442,8 @@ def _test_args_subset(test_params, expected_params, expected_params_present, arg
     ("-a 1 -b 2 -C 3 -D 4 -e 5", "-a 1 -b 2 -e 5", dict(C=3, D=4)),
     ("-C 3 -D 4", "-C 3 -D 4", {}),
     ("-C 3 -D 4", "-C 3", dict(D=4)),
-    ("-a 1 -C 3 -D 4", "", dict(a=1, C=3, D=4))
+    ("-a 1 -C 3 -D 4", "", dict(a=1, C=3, D=4)),
+    ("-a 1 -b 2 -C 3 -D 4 -e 5", "-a 1 -b 2 -C 3", dict(a=10, b=20, C=30, D=4, e=5))
 ])
 def test_config_file(plain_command_line, config_command_line, config_contents):
     config_file_argparse = arguments.ConfigArgumentParser()

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -12,7 +12,9 @@
 # permissions and limitations under the License.
 
 import argparse
+import json
 import pytest
+import tempfile
 import os
 
 import sockeye.arguments as arguments
@@ -432,3 +434,62 @@ def _test_args_subset(test_params, expected_params, expected_params_present, arg
     assert parsed_params_subset == expected_params
     for expected_param_present in expected_params_present:
         assert expected_param_present in parsed_params, "Expected param %s to be present." % expected_param_present
+
+
+# Test that config file and command line are equivalent
+@pytest.mark.parametrize("plain_command_line, config_command_line, config_contents", [
+    ("-a 1 -b 2 -C 3 -D 4 -e 5", "", dict(a=1, b=2, C=3, D=4, e=5)),
+    ("-a 1 -b 2 -C 3 -D 4 -e 5", "-a 1 -b 2 -e 5", dict(C=3, D=4)),
+    ("-C 3 -D 4", "-C 3 -D 4", {}),
+    ("-C 3 -D 4", "-C 3", dict(D=4)),
+    ("-a 1 -C 3 -D 4", "", dict(a=1, C=3, D=4))
+])
+def test_config_file(plain_command_line, config_command_line, config_contents):
+    config_file_argparse = arguments.ConfigArgumentParser()
+    # Capital letter arguments are required
+    config_file_argparse.add_argument("-a", type=int)
+    config_file_argparse.add_argument("-b", type=int)
+    config_file_argparse.add_argument("-C", type=int, required=True)
+    config_file_argparse.add_argument("-D", type=int, required=True)
+    config_file_argparse.add_argument("-e", type=int)
+
+    # The option '--config <file>' will be added automaticall to config_command_line
+    with tempfile.NamedTemporaryFile("w") as fp:
+        json.dump(config_contents, fp)
+        fp.flush()
+
+        # Parse args and cast to dicts directly
+        args_command_line = vars(config_file_argparse.parse_args(args=plain_command_line.split()))
+        args_config = vars(config_file_argparse.parse_args(
+            args=(config_command_line + (" --config %s" % fp.name)).split()))
+
+        # Remove the config entry
+        del args_command_line["config"]
+        del args_config["config"]
+
+        assert args_command_line == args_config
+
+
+# Test that required options are still required if not specified in the config file
+@pytest.mark.parametrize("config_command_line, config_contents", [
+    ("", dict(a=1, b=2, C=3, e=5)),
+    ("-C 3", dict(a=1))
+])
+def test_config_file_required(config_command_line, config_contents):
+    config_file_argparse = arguments.ConfigArgumentParser()
+    # Capital letter arguments are required
+    config_file_argparse.add_argument("-a", type=int)
+    config_file_argparse.add_argument("-b", type=int)
+    config_file_argparse.add_argument("-C", type=int, required=True)
+    config_file_argparse.add_argument("-D", type=int, required=True)
+    config_file_argparse.add_argument("-e", type=int)
+
+    # The option '--config <file>' will be added automaticall to config_command_line
+    with pytest.raises(SystemExit): # argparse does not have finer regularity excpetions
+        with tempfile.NamedTemporaryFile("w") as fp:
+            json.dump(config_contents, fp)
+            fp.flush()
+
+            # Parse args and cast to dicts directly
+            args_config = vars(config_file_argparse.parse_args(
+                args=(config_command_line + (" --config %s" % fp.name)).split()))


### PR DESCRIPTION
**Update:**

As per comments, I updated the format to YAML. The corresponding updated example for the config file is now:

```
source: /Users/dvilar/corpora/iwslt/tokenize/de-en/train.tags.de-en.de
target: /Users/dvilar/corpora/iwslt/tokenize/de-en/train.tags.de-en.en
validation_source: /Users/dvilar/corpora/iwslt/tokenize/de-en/IWSLT16.TED.dev2010.de-en.de.txt
validation_target: /Users/dvilar/corpora/iwslt/tokenize/de-en/IWSLT16.TED.dev2010.de-en.en.txt
output: out
use_cpu: true
```

Fun fact: the original json config file is also correctly parse as yaml :-)

**Original description:**

Specify a config file with --config. Command line parameters have precedence over the values read from the config file, as expected.

The config file is a json serialization of the namespace returned by argparse, casted to a dictionary. The file args.json produced by the training can be used as config file.

The config file does not need to be complete. Missing parameters will be read from the command line or will take default values.

Minimal working example (`python -m sockeye.train --config config.json` starts a training, cpu activated):
```
{
  "source": "/Users/dvilar/corpora/iwslt/tokenize/de-en/train.tags.de-en.de",
  "target": "/Users/dvilar/corpora/iwslt/tokenize/de-en/train.tags.de-en.en",
  "validation_source": "/Users/dvilar/corpora/iwslt/tokenize/de-en/IWSLT16.TED.dev2010.de-en.de.txt",
  "validation_target": "/Users/dvilar/corpora/iwslt/tokenize/de-en/IWSLT16.TED.dev2010.de-en.en.txt",
  "output": "out",
  "use_cpu": true
}
```

Additionally the functionality introduced in 5a3bf5f8 has been reimplemented, accessing the argument_definitions member of ConfigArgumentParser.

### Note about the PR ###
This PR includes two commits. The first one mainly reverts arguments.py to pre-5a3bf5f8. The second one is the actual "meat" of this PR. Looking at the commits separately probably will provide a better overview.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

