### PR TITLE
Fix logic with training resumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
 ## [1.18.12]
+### Fixed
+- Fixed two bugs with training resumption:
+  1. removed overly strict assertion in the data iterator for model states before the first checkpoint.
+  2. removed deletion of Tensorboard log directory.
+
+## [1.18.12]
 ### Changed
 - All source side sequences now get appended an additional end-of-sentence (EOS) symbol. This change is backwards
   compatible meaning that inference with older models will still work without the EOS symbol.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
-## [1.18.12]
+## [1.18.13]
 ### Fixed
 - Fixed two bugs with training resumption:
   1. removed overly strict assertion in the data iterator for model states before the first checkpoint.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.12'
+__version__ = '1.18.13'

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -1537,9 +1537,6 @@ class ParallelSampleIter(BaseParallelSampleIter):
             inverse_data_permutations = np.load(fp)
             data_permutations = np.load(fp)
 
-        # Because of how checkpointing is done (pre-fetching the next batch in
-        # each iteration), curr_idx should always be >= 1
-        assert self.curr_batch_index >= 1
         # Right after loading the iterator state, next() should be called
         self.curr_batch_index -= 1
 

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -1017,9 +1017,6 @@ class TensorboardLogger:
         try:
             import mxboard
             logger.info("Logging training events for Tensorboard at '%s'", self.logdir)
-            if os.path.exists(self.logdir):
-                logger.info("Deleting existing Tensorboard log directory '%s'", self.logdir)
-                shutil.rmtree(self.logdir)
             self.sw = mxboard.SummaryWriter(logdir=self.logdir, flush_secs=60, verbose=False)
         except ImportError:
             logger.info("mxboard not found. Consider 'pip install mxboard' to log events to Tensorboard.")


### PR DESCRIPTION
For cases where training was interrupted before the first checkpoint, the data iterator stated saved to disk could not be loaded without an overly strict assertion to fail. I removed this assertion.

Also, the tensorboard logger was always deleting its logdir when newly created. I removed that.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

