### PR TITLE
Merge in Sockeye Autopilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.14]
+
+### Added
+- Introduced Sockeye Autopilot for single-command end-to-end system building.
+See the [Autopilot documentation]((https://github.com/awslabs/sockeye/tree/master/contrib/autopilot)) and run with: `sockeye-autopilot`.
+
 ## [1.18.13]
 
 ### Fixed
@@ -20,7 +26,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ### Added
 - Added support for config files. Command line parameters have precedence over the values read from the config file.
   Minimal working example:
-  `python -m sockeye.train --config config.yaml` with contents of `config.yaml` as follows: 
+  `python -m sockeye.train --config config.yaml` with contents of `config.yaml` as follows:
   ```yaml
   source: source.txt
   target: target.txt
@@ -92,7 +98,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ### Changed
 - Removed combined linear projection of keys & values in source attention transformer layers for
   performance improvements.
-- The topk operator is performed in a single operation during batch decoding instead of running in a loop over each 
+- The topk operator is performed in a single operation during batch decoding instead of running in a loop over each
 sentence, bringing speed benefits in batch decoding.
 
 ## [1.18.1]
@@ -167,7 +173,7 @@ For each metric the mean and standard deviation will be reported across files.
      and `--input-factors` a list of files containing token-parallel factors.
    At test time, an exception is raised if the number of expected factors does not
    match the factors passed along with the input.
-   
+
  - Removed bias parameters from multi-head attention layers of the transformer.
 
 ## [1.16.6]
@@ -225,7 +231,7 @@ features, benefitting the beam search implementation.
  - New CLI `sockeye.prepare_data` for preprocessing the training data only once before training,
  potentially splitting large datasets into shards. At training time only one shard is loaded into memory at a time,
  limiting the maximum memory usage.
- 
+
 ### Changed
  - Instead of using the ```--source``` and ```--target``` arguments ```sockeye.train``` now accepts a
  ```--prepared-data``` argument pointing to the folder containing the preprocessed and sharded data. Using the raw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
 ## [1.18.14]
-
 ### Added
 - Introduced Sockeye Autopilot for single-command end-to-end system building.
 See the [Autopilot documentation]((https://github.com/awslabs/sockeye/tree/master/contrib/autopilot)) and run with: `sockeye-autopilot`.
+Autopilot is a `contrib` module with its own tests that are run periodically.
+It is not included in the comprehensive tests run for every commit.
 
 ## [1.18.13]
-
 ### Fixed
 - Fixed two bugs with training resumption:
   1. removed overly strict assertion in the data iterator for model states before the first checkpoint.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This package contains the Sockeye project,
 a sequence-to-sequence framework for Neural Machine Translation based on Apache MXNet Incubating.
-It implements state-of-the-art encoder-decoder architectures, such as 
+It implements state-of-the-art encoder-decoder architectures, such as
 - Deep Recurrent Neural Networks with Attention [[Bahdanau, '14](https://arxiv.org/abs/1409.0473)]
 - Transformer Models with self-attention [[Vaswani et al, '17](https://arxiv.org/abs/1706.03762)]
 - Fully convolutional sequence-to-sequence models [[Gehring et al, '17](https://arxiv.org/abs/1705.03122)]
@@ -112,7 +112,7 @@ where `${CUDA_VERSION}` can be `75` (7.5), `80` (8.0), `90` (9.0), or `91` (9.1)
 In order to write training statistics to a Tensorboard event file for visualization, you can optionally install mxboard
  (````pip install mxboard````). To visualize these, run the Tensorboard tool (`pip install tensorboard tensorflow`) with
  the logging directory pointed to the training output folder: `tensorboard --logdir <model>`
- 
+
 If you want to create alignment plots you will need to install matplotlib (````pip install matplotlib````).
 
 In general you can install all optional dependencies from the Sockeye source folder using:
@@ -130,6 +130,9 @@ For example *sockeye-train* can also be invoked as
 ```
 
 ## First Steps
+
+For easily training popular model types on known data sets, see the [Sockeye Autopilot documentation](https://github.com/awslabs/sockeye/tree/master/contrib/autopilot).
+For manually training and running translation models on your data, read on.
 
 ### Train
 

--- a/contrib/autopilot/README.md
+++ b/contrib/autopilot/README.md
@@ -1,0 +1,132 @@
+# Sockeye Autopilot
+
+This module provides automated end-to-end system building for popular model types on public data sets.
+These capabilities can also be used independently: users can provide their own data for model training or use Autopilot to download and pre-process public data for other use.
+All intermediate files are preserved as plain text and commands are recorded, letting users take over at any point for further experimentation.
+
+## Quick Start
+
+If Sockeye is installed via pip or source, Autopilot can be run directly:
+
+```bash
+> sockeye-autopilot
+```
+
+This is equivalent to:
+
+```bash
+> python -m contrib.autopilot.autopilot
+```
+
+With a single command, Autopilot can download and pre-process training data, then train and evaluate a translation model.
+For example, to build a transformer model on the WMT14 English-German benchmark, run:
+
+```bash
+> sockeye-autopilot --task wmt14_en_de --model transformer
+```
+
+By default, systems are built under `$HOME/sockeye_autopilot`.
+The `--workspace` argument can specify a different location.
+Also by default, a single GPU is used for training and decoding.
+The `--gpus` argument can specify a larger number of GPUs for parallel training or `0` for CPU mode only.
+
+Autopilot populates the following sub-directories in a workspace:
+
+- cache: raw downloaded files from public data sets.
+- third_party: downloaded third party tools for data pre-processing (currently [Moses tokenizer](https://github.com/moses-smt/mosesdecoder/tree/master/scripts/tokenizer) and [subword-nmt](https://github.com/rsennrich/subword-nmt))
+- logs: log files for various steps.
+- systems: contains a single directory for each task, such as "wmt14_en_de".  Task directories contain (after a successful build):
+  - data: raw, tokenized, and byte-pair encoded data for train, dev, and test sets.
+  - model.bpe: byte-pair encoding model
+  - model.*: directory for each Sockeye model built, such as "model.transformer"
+  - results: decoding output and BLEU scores.  When starting with raw data, the .sacrebleu file contains a score that can be compared against official WMT results.
+
+### Custom Data
+
+Models can be built using custom data with any level of pre-processing.
+For example, to use custom German-English raw data, run:
+
+```bash
+> sockeye-autopilot --model transformer \
+    --custom-task my_task \
+    --custom-text-type raw \
+    --custom-lang de en \
+    --custom-train train.de train.en \
+    --custom-dev dev.de dev.en \
+    --custom-test test.de test.en \
+```
+
+Pre-tokenized or byte-pair encoded data can be used with `--custom-text-type tok` and `--custom-text-type bpe`.
+The `--custom-task` argument is used for directory naming.
+A custom number of BPE operations can be specified with `--custom-bpe-op`.
+
+### Data Preparation Only
+
+To use Autopilot for data preparation only, simply provide `none` as the model type:
+
+```bash
+> sockeye-autopilot --task wmt14_en_de --model none
+```
+
+## Automation Steps
+
+This section describes the steps Autopilot runs as part of each system build.
+Builds can be stopped and re-started (CTRL+C).
+Some steps are atomic while others (such as translation model training) can be resumed.
+Each completed step records its success so a re-started build can pick up from the last finished step.
+
+### Checkout Third Party Tools
+
+If the task requires tokenization, check out the [Moses tokenizer](https://github.com/moses-smt/mosesdecoder/tree/master/scripts/tokenizer).
+If the task requires byte-pair encoding, check out the [subword-nmt](https://github.com/rsennrich/subword-nmt)) module.
+Store git checkouts of these tools in the third_party directory for re-use with future tasks in the same workspace.
+
+NOTE: These tools have different open source licenses than Sockeye.
+See the included license files for more information.
+
+### Download Data
+
+Download to the cache directory all raw files referenced by the current task (if not already present).
+See `RAW_FILES` and `TASKS` in `tasks.py` for examples of tasks referencing various publicly available data files.
+
+### Populate Input Files
+
+For known tasks, populate parallel train, dev, and test files under "data/raw" by extracting lines from raw files downloaded in the previous step.
+For custom tasks, copy the user-provided data.
+Train and dev files are concatenated while test sets are preserved as separate files.
+
+This step includes Unicode whitespace normalization to ensure that only ASCII newlines are considered as line breaks (spurious Unicode newlines are a known issue in some noisy public data).
+
+### Tokenize Data
+
+If data is not pre-tokenized, run the Moses tokenizer and store the results in "data/tok".
+For known tasks, use the listed `src_lang` and `trg_lang` (see `TASKS` in `tasks.py`).
+For custom tasks, use the provided `--custom-lang` arguments.
+
+### Byte-Pair Encode Data
+
+If the data is not already byte-pair encoded, learn a BPE model "model.bpe" and apply it to the data, storing the results in "data/bpe".
+For known tasks, use the listed number of operations `bpe_op`.
+For custom tasks, use the provided `--custom-bpe-op` argument.
+
+### Train Translation Model
+
+Run `sockeye.train` and `sockeye.average` to learn a translation model on the byte-pair encoded data.
+Use the arguments listed for the provided `--model` argument and specify "model.MODEL" (e.g., "model.transformer") as the model directory.
+See `MODELS` in `models.py` for examples of training arguments.
+
+This step can take several days and progress can be checked via the log file or tensorboard.
+This step also supports resuming from a partially trained model.
+
+### Translate Test Sets
+
+Run `sockeye.translate` to decode each test set using the specified settings.
+See `DECODE_ARGS` in `models.py` for decoding settings.
+
+### Evaluate Translations
+
+Provide the following outputs to the user under "results":
+
+- test.N.MODEL.SETTINGS.bpe.bleu: BLEU score of raw decoder output against byte-pair encoded references
+- test.N.MODEL.SETTINGS.tok.bleu: BLEU score of word-level decoder output against tokenized references
+- test.N.MODEL.SETTINGS.detok.sacrebleu: BLEU score of detokenized decoder output against raw references using [SacreBLEU](https://github.com/awslabs/sockeye/tree/master/contrib/sacrebleu).  These scores are directly comparable to those reported in WMT evaluations.

--- a/contrib/autopilot/__init__.py
+++ b/contrib/autopilot/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from contrib.autopilot import autopilot
+from contrib.autopilot import tasks
+from contrib.autopilot import models
+from contrib.autopilot import third_party

--- a/contrib/autopilot/autopilot.py
+++ b/contrib/autopilot/autopilot.py
@@ -1,0 +1,902 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import argparse
+import gzip
+import hashlib
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from typing import Iterable, List, Tuple
+import urllib.request
+import zipfile
+
+# Make sure sockeye is on the system path
+try:
+    from sockeye import constants as C
+    from sockeye import utils
+except ImportError:
+    SOCKEYE_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    raise RuntimeError("Please install the sockeye module or add the sockeye root directory to your Python path. Ex: export PYTHONPATH=%s"
+                       % SOCKEYE_ROOT)
+
+from contrib.autopilot.tasks import ARCHIVE_NONE, ARCHIVE_TAR, ARCHIVE_ZIP
+from contrib.autopilot.tasks import TEXT_UTF8_RAW, TEXT_UTF8_RAW_SGML, TEXT_UTF8_RAW_BITEXT
+from contrib.autopilot.tasks import TEXT_UTF8_RAW_BITEXT_REVERSE, TEXT_REQUIRES_TOKENIZATION
+from contrib.autopilot.tasks import TEXT_UTF8_TOKENIZED
+from contrib.autopilot.tasks import RAW_FILES
+from contrib.autopilot.tasks import Task, TASKS
+from contrib.autopilot.models import MODELS, MODEL_NONE
+from contrib.autopilot.models import DECODE_ARGS, DECODE_STANDARD
+from contrib.autopilot import third_party
+
+
+# Formats for custom files
+CUSTOM_UTF8_RAW = "raw"
+CUSTOM_UTF8_TOK = "tok"
+CUSTOM_UTF8_BPE = "bpe"
+CUSTOM_TEXT_TYPES = [CUSTOM_UTF8_RAW, CUSTOM_UTF8_TOK, CUSTOM_UTF8_BPE]
+
+# Special file names
+DIR_SOCKEYE_AUTOPILOT = "sockeye_autopilot"
+FILE_WORKSPACE = ".workspace"
+FILE_COMPLETE = ".complete"
+
+# Sub-task directory and file names
+DIR_CACHE = "cache"
+DIR_LOGS = "logs"
+DIR_SYSTEMS = "systems"
+DIR_DATA = "data"
+DIR_RAW = "raw"
+DIR_TOK = "tok"
+DIR_BPE = "bpe"
+PREFIX_TRAIN = "train."
+PREFIX_DEV = "dev."
+PREFIX_TEST = "test."
+DATA_SRC = "src"
+DATA_TRG = "trg"
+SUFFIX_SRC_GZ = DATA_SRC + ".gz"
+SUFFIX_TRG_GZ = DATA_TRG + ".gz"
+DIR_BPE_MODEL = "model.bpe"
+FILE_BPE_CODES = "codes"
+DIR_PREFIX_MODEL = "model."
+DIR_RESULTS = "results"
+FILE_COMMAND = "command.{}.sh"
+SUFFIX_COMMAND = "command.sh"
+SUFFIX_BPE = "bpe"
+SUFFIX_TOK = "tok"
+SUFFIX_DETOK = "detok"
+SUFFIX_BLEU = "bleu"
+SUFFIX_SACREBLEU = "sacrebleu"
+SUFFIX_TEST = ".test"
+
+# Reasonable defaults for model averaging
+AVERAGE_NUM_CHECKPOINTS = 8
+AVERAGE_METRIC = "perplexity"
+AVERAGE_STRATEGY = "best"
+PARAMS_BEST_SINGLE = "params.best.single"
+PARAMS_AVERAGE = "params.average"
+
+
+def identify_raw_files(task: Task, test_mode: bool = False) -> List[str]:
+    """
+    Identify raw files that need to be downloaded for a given task.
+
+    :param task: Sequence-to-sequence task.
+    :param test_mode: Run in test mode, only downloading test data.
+    :return: List of raw file names.
+    """
+    raw_files = set()
+    all_sets = (task.test,) if test_mode else (task.train, task.dev, task.test)
+    for file_sets in all_sets:
+        for file_set in file_sets:
+            for fname in file_set[:2]:
+                raw_file = fname.split("/", 1)[0]
+                if raw_file not in RAW_FILES:
+                    raise RuntimeError("Unknown raw file %s found in path %s" % (raw_file, fname))
+                raw_files.add(raw_file)
+    return sorted(raw_files)
+
+
+def download_extract_raw_files(names: List[str], cache_dir: str, dest_dir: str):
+    """
+    Download and extract raw files, making use of a cache directory.
+    - Downloaded files are verified by MD5 sum.
+    - Extraction overwrites existing files.
+
+    :param names: List of raw file names in RAW_FILES.
+    :param cache_dir: Cache directory for downloading raw files.
+    :param dest_dir: Destination directory for extracting raw files.
+    """
+
+    for name in names:
+        raw_file = RAW_FILES[name]
+        local_dir = os.path.join(cache_dir, name)
+        local_fname = os.path.join(local_dir, os.path.basename(raw_file.url))
+
+        # Download file if not present
+        if not os.path.exists(local_dir):
+            logging.info("Create: %s", local_dir)
+            os.makedirs(local_dir)
+        if not os.path.exists(local_fname):
+            logging.info("Download: %s -> %s", raw_file.url, local_fname)
+            urllib.request.urlretrieve(raw_file.url, local_fname)
+
+        # Check MD5 sum, attempt one re-download on mismatch
+        md5 = md5sum(local_fname)
+        if not md5 == raw_file.md5:
+            logging.info("MD5 mismatch for %s, attempt re-download %s", local_fname, raw_file.url)
+            urllib.request.urlretrieve(raw_file.url, local_fname)
+            md5 = md5sum(local_fname)
+            if not md5 == raw_file.md5:
+                raise RuntimeError("MD5 mismatch for %s after re-download.  Check validity of %s"
+                                   % (local_fname, raw_file.url))
+        logging.info("Confirmed MD5: %s (%s)", local_fname, md5)
+
+        # Extract file(s), overwriting directory if exists
+        extract_path = os.path.join(dest_dir, name)
+        if os.path.exists(extract_path):
+            shutil.rmtree(extract_path)
+        os.makedirs(extract_path)
+        logging.info("Extract: %s -> %s", local_fname, extract_path)
+        if raw_file.archive_type == ARCHIVE_NONE:
+            os.symlink(local_fname, os.path.join(extract_path, os.path.basename(local_fname)))
+        elif raw_file.archive_type == ARCHIVE_TAR:
+            tar = tarfile.open(local_fname)
+            tar.extractall(path=extract_path)
+        elif raw_file.archive_type == ARCHIVE_ZIP:
+            zipf = zipfile.ZipFile(local_fname, "r")
+            zipf.extractall(path=extract_path)
+        else:
+            raise RuntimeError("Unknown archive type: %s" % raw_file.archive_type)
+
+
+def md5sum(fname: str) -> str:
+    """Compute MD5 sum of file."""
+    with open(fname, "rb") as inp:
+        md5 = hashlib.md5(inp.read()).hexdigest()
+    return md5
+
+
+def populate_parallel_text(extract_dir: str,
+                           file_sets: List[Tuple[str, str, str]],
+                           dest_prefix: str,
+                           keep_separate: bool,
+                           head_n: int = 0):
+    """
+    Create raw parallel train, dev, or test files with a given prefix.
+
+    :param extract_dir: Directory where raw files (inputs) are extracted.
+    :param file_sets: Sets of files to use.
+    :param dest_prefix: Prefix for output files.
+    :param keep_separate: True if each file set (source-target pair) should have
+                          its own file (used for test sets).
+    :param head_n: If N>0, use only the first N lines (used in test mode).
+    """
+    source_out = None
+    target_out = None
+    lines_written = 0
+    # Single output file for each side
+    if not keep_separate:
+        source_dest = dest_prefix + SUFFIX_SRC_GZ
+        target_dest = dest_prefix + SUFFIX_TRG_GZ
+        logging.info("Populate: %s %s", source_dest, target_dest)
+        source_out = gzip.open(source_dest, "wt", encoding="utf-8")
+        target_out = gzip.open(target_dest, "wt", encoding="utf-8")
+    for i, (source_fname, target_fname, text_type) in enumerate(file_sets):
+        # One output file per input file for each side
+        if keep_separate:
+            if source_out:
+                source_out.close()
+            if target_out:
+                target_out.close()
+            source_dest = dest_prefix + str(i) + "." + SUFFIX_SRC_GZ
+            target_dest = dest_prefix + str(i) + "." + SUFFIX_TRG_GZ
+            logging.info("Populate: %s %s", source_dest, target_dest)
+            source_out = gzip.open(source_dest, "wt", encoding="utf-8")
+            target_out = gzip.open(target_dest, "wt", encoding="utf-8")
+        for source_line, target_line in zip(
+                plain_text_iter(os.path.join(extract_dir, source_fname), text_type, DATA_SRC),
+                plain_text_iter(os.path.join(extract_dir, target_fname), text_type, DATA_TRG)):
+            # Only write N lines total if requested, but reset per file when
+            # keeping files separate
+            if head_n > 0 and lines_written >= head_n:
+                if keep_separate:
+                    lines_written = 0
+                break
+            source_out.write("{}\n".format(source_line))
+            target_out.write("{}\n".format(target_line))
+            lines_written += 1
+    source_out.close()
+    target_out.close()
+
+
+def copy_parallel_text(file_list: List[str], dest_prefix: str):
+    """
+    Copy pre-compiled raw parallel files with a given prefix.  Perform
+    whitespace character normalization to ensure that only ASCII newlines are
+    considered line breaks.
+
+    :param file_list: List of file pairs to use.
+    :param dest_prefix: Prefix for output files.
+    """
+    # Group files into source-target pairs
+    file_sets = []
+    for i in range(0, len(file_list), 2):
+        file_sets.append((file_list[i], file_list[i + 1]))
+    multiple_sets = len(file_sets) > 1
+    for i, (source_fname, target_fname) in enumerate(file_sets):
+        if multiple_sets:
+            source_dest = dest_prefix + str(i) + "." + SUFFIX_SRC_GZ
+            target_dest = dest_prefix + str(i) + "." + SUFFIX_TRG_GZ
+        else:
+            source_dest = dest_prefix + SUFFIX_SRC_GZ
+            target_dest = dest_prefix + SUFFIX_TRG_GZ
+        logging.info("Populate: %s %s", source_dest, target_dest)
+        with gzip.open(source_dest, "wb") as source_out, gzip.open(target_dest, "wb") as target_out:
+            with third_party.bin_open(source_fname) as inp:
+                for line in inp:
+                    line = (re.sub(r"\s", " ", line.decode("utf-8"))).encode("utf-8") + b"\n"
+                    source_out.write(line)
+            with third_party.bin_open(target_fname) as inp:
+                for line in inp:
+                    line = (re.sub(r"\s", " ", line.decode("utf-8"))).encode("utf-8") + b"\n"
+                    target_out.write(line)
+
+
+def plain_text_iter(fname: str, text_type: str, data_side: str) -> Iterable[str]:
+    """
+    Extract plain text from file as iterable.  Also take steps to ensure that
+    whitespace characters (including unicode newlines) are normalized and
+    outputs are line-parallel with inputs considering ASCII newlines only.
+
+    :param fname: Path of possibly gzipped input file.
+    :param text_type: One of TEXT_*, indicating data format.
+    :param data_side: DATA_SRC or DATA_TRG.
+    """
+    if text_type in (TEXT_UTF8_RAW, TEXT_UTF8_TOKENIZED):
+        with third_party.bin_open(fname) as inp:
+            for line in inp:
+                line = re.sub(r"\s", " ", line.decode("utf-8"))
+                yield line.strip()
+    elif text_type == TEXT_UTF8_RAW_SGML:
+        with third_party.bin_open(fname) as inp:
+            for line in inp:
+                line = re.sub(r"\s", " ", line.decode("utf-8"))
+                if line.startswith("<seg "):
+                    # Extract segment text
+                    text = re.sub(r"<seg.*?>(.*)</seg>.*?", "\\1", line)
+                    text = re.sub(r"\s+", " ", text.strip())
+                    # Unescape XML entities
+                    text = text.replace("&quot;", "\"")
+                    text = text.replace("&apos;", "'")
+                    text = text.replace("&lt;", "<")
+                    text = text.replace("&gt;", ">")
+                    text = text.replace("&amp;", "&")
+                    yield text
+    elif text_type in (TEXT_UTF8_RAW_BITEXT, TEXT_UTF8_RAW_BITEXT_REVERSE):
+        # Select source or target field, reversing if needed
+        if text_type == TEXT_UTF8_RAW_BITEXT:
+            field_id = 0 if data_side == DATA_SRC else 1
+        else:
+            field_id = 1 if data_side == DATA_SRC else 0
+        with third_party.bin_open(fname) as inp:
+            for line in inp:
+                line = re.sub(r"\s", " ", line.decode("utf-8"))
+                fields = line.split("|||")
+                yield fields[field_id].strip()
+    else:
+        raise RuntimeError("Unknown text type: %s" % text_type)
+
+
+def touch_file(fname: str):
+    """Create a file if not present, update access time."""
+    # Reference not needed since there will be no reads or writes
+    with open(fname, "a"):
+        os.utime(fname, None)
+
+
+def renew_step_dir(step_dir: str):
+    """Delete step directory if exists and create, reporting actions."""
+    if os.path.exists(step_dir):
+        logging.info("Remove unfinished step %s", step_dir)
+        shutil.rmtree(step_dir)
+    logging.info("Create: %s", step_dir)
+    os.makedirs(step_dir)
+
+
+def call_sockeye_train(args: List[str],
+                       bpe_dir: str,
+                       model_dir: str,
+                       log_fname: str,
+                       num_gpus: int,
+                       test_mode: bool = False):
+    """
+    Call sockeye.train with specified arguments on prepared inputs.  Will resume
+    partial training or skip training if model is already finished.  Record
+    command for future use.
+
+    :param args: Command line arguments for sockeye.train.
+    :param bpe_dir: Directory of BPE-encoded input data.
+    :param model_dir: Model output directory.
+    :param log_fname: Location to write log file.
+    :param num_gpus: Number of GPUs to use for training (0 for CPU).
+    :param test_mode: Run in test mode, stopping after a small number of
+                      updates.
+    """
+    # Inputs and outputs
+    fnames = ["--source={}".format(os.path.join(bpe_dir, PREFIX_TRAIN + SUFFIX_SRC_GZ)),
+              "--target={}".format(os.path.join(bpe_dir, PREFIX_TRAIN + SUFFIX_TRG_GZ)),
+              "--validation-source={}".format(os.path.join(bpe_dir, PREFIX_DEV + SUFFIX_SRC_GZ)),
+              "--validation-target={}".format(os.path.join(bpe_dir, PREFIX_DEV + SUFFIX_TRG_GZ)),
+              "--output={}".format(model_dir)]
+    # Assemble command
+    command = [sys.executable, "-m", "sockeye.train"] + fnames + args
+    # Request GPUs or specify CPU
+    if num_gpus > 0:
+        command.append("--device-ids=-{}".format(num_gpus))
+    else:
+        command.append("--use-cpu")
+    # Test mode stops after a small number of updates
+    if test_mode:
+        command.append("--max-updates=10")
+        command.append("--checkpoint-frequency=5")
+    command_fname = os.path.join(model_dir, FILE_COMMAND.format("sockeye.train"))
+    # Run unless training already finished
+    if not os.path.exists(command_fname):
+        # Call Sockeye training
+        with open(log_fname, "wb") as log:
+            logging.info("sockeye.train: %s", model_dir)
+            logging.info("Log: %s", log_fname)
+            logging.info("(This step can take several days. See log file or TensorBoard for progress)")
+            subprocess.check_call(command, stderr=log)
+        # Record successful command
+        logging.info("Command: %s", command_fname)
+        print_command(command, command_fname)
+
+
+def call_sockeye_average(model_dir: str, log_fname: str):
+    """
+    Call sockeye.average with reasonable defaults.
+
+    :param model_dir: Trained model directory.
+    :param log_fname: Location to write log file.
+    """
+    params_best_fname = os.path.join(model_dir, C.PARAMS_BEST_NAME)
+    params_best_single_fname = os.path.join(model_dir, PARAMS_BEST_SINGLE)
+    params_average_fname = os.path.join(model_dir, PARAMS_AVERAGE)
+    command = [sys.executable,
+               "-m",
+               "sockeye.average",
+               "--metric={}".format(AVERAGE_METRIC),
+               "-n",
+               str(AVERAGE_NUM_CHECKPOINTS),
+               "--output={}".format(params_average_fname),
+               "--strategy={}".format(AVERAGE_STRATEGY),
+               model_dir]
+    command_fname = os.path.join(model_dir, FILE_COMMAND.format("sockeye.average"))
+    # Run average if not previously run
+    if not os.path.exists(command_fname):
+        # Re-link best point to best single point
+        os.symlink(os.path.basename(os.path.realpath(params_best_fname)), params_best_single_fname)
+        os.remove(params_best_fname)
+        # Call Sockeye average
+        with open(log_fname, "wb") as log:
+            logging.info("sockeye.average: %s", os.path.join(model_dir, params_best_fname))
+            logging.info("Log: %s", log_fname)
+            subprocess.check_call(command, stderr=log)
+        # Link averaged point as new best
+        os.symlink(PARAMS_AVERAGE, params_best_fname)
+        # Record successful command
+        logging.info("Command: %s", command_fname)
+        print_command(command, command_fname)
+
+
+def call_sockeye_translate(args: List[str],
+                           input_fname: str,
+                           output_fname: str,
+                           model_dir: str,
+                           log_fname: str,
+                           use_cpu: bool):
+    """
+    Call sockeye.translate with specified arguments using a trained model.
+
+    :param args: Command line arguments for sockeye.translate.
+    :param input_fname: Input file (byte-pair encoded).
+    :param output_fname: Raw decoder output file.
+    :param model_dir: Model output directory.
+    :param log_fname: Location to write log file.
+    :param use_cpu: Use CPU instead of GPU for decoding.
+    """
+    # Inputs and outputs
+    fnames = ["--input={}".format(input_fname),
+              "--output={}".format(output_fname),
+              "--models={}".format(model_dir)]
+    # Assemble command
+    command = [sys.executable, "-m", "sockeye.translate"] + fnames + args
+    # Request GPUs or specify CPU
+    if use_cpu:
+        command.append("--use-cpu")
+    command_fname = output_fname + "." + SUFFIX_COMMAND
+    # Run unless translate already finished
+    if not os.path.exists(command_fname):
+        # Call Sockeye translate
+        with open(log_fname, "wb") as log:
+            logging.info("sockeye.translate: %s -> %s", input_fname, output_fname)
+            logging.info("Log: %s", log_fname)
+            subprocess.check_call(command, stderr=log)
+        # Cleanup redundant log file
+        try:
+            os.remove(output_fname + ".log")
+        except FileNotFoundError:
+            pass
+
+        # Record successful command
+        logging.info("Command: %s", command_fname)
+        print_command(command, command_fname)
+
+
+def call_sacrebleu(input_fname: str, ref_fname: str, output_fname: str, log_fname: str, tokenized: bool = False):
+    """
+    Call contrib.sacrebleu.sacrebleu on tokenized or detokenized inputs.
+
+    :param input_fname: Input translation file.
+    :param ref_fname: Reference translation file.
+    :param output_fname: Output score file.
+    :param log_fname: Location to write log file.
+    :param tokenized: Whether inputs are tokenized (or byte-pair encoded).
+    """
+    # Assemble command
+    command = [sys.executable,
+               "-m",
+               "contrib.sacrebleu.sacrebleu",
+               "--score-only",
+               "--input={}".format(input_fname),
+               ref_fname]
+    # Already tokenized?
+    if tokenized:
+        command.append("--tokenize=none")
+    # Call sacrebleu
+    with open(log_fname, "wb") as log:
+        logging.info("contrib.sacrebleu.sacrebleu: %s -> %s", input_fname, output_fname)
+        logging.info("Log: %s", log_fname)
+        score = subprocess.check_output(command, stderr=log)
+    # Record successful score
+    with open(output_fname, "wb") as out:
+        out.write(score)
+
+
+def print_command(command: List[str], fname: str):
+    """
+    Format and print command to file.
+
+    :param command: Command in args list form.
+    :param fname: File name to write out.
+    """
+    with open(fname, "w", encoding="utf-8") as out:
+        print(" \\\n".join(command), file=out)
+
+
+def run_steps(args: argparse.Namespace):
+    """Run all steps required to complete task.  Called directly from main."""
+
+    logging.basicConfig(level=logging.INFO, format="sockeye.autopilot: %(message)s")
+
+    # (1) Establish task
+
+    logging.info("=== Start Autopilot ===")
+    # Listed task
+    if args.task:
+        task = TASKS[args.task]
+        logging.info("Task: %s", task.description)
+        logging.info("URL: %s", task.url)
+
+        def report_data(file_sets):
+            for file_set in file_sets:
+                for fname in file_set[:2]:
+                    logging.info("    %s", fname)
+
+        logging.info("  Train:")
+        report_data(task.train)
+        logging.info("  Dev:")
+        report_data(task.dev)
+        logging.info("  Test:")
+        report_data(task.test)
+    # Custom task
+    else:
+        logging.info("Task: custom")
+    # Source and target language codes
+    lang_codes = (task.src_lang, task.trg_lang) if args.task else args.custom_lang
+
+    # (2) Establish workspace and task directories
+
+    logging.info("=== Establish working directories ===")
+    logging.info("Workspace: %s", args.workspace)
+    special_fname = os.path.join(args.workspace, FILE_WORKSPACE)
+    if not os.path.exists(args.workspace):
+        logging.info("Create: %s", args.workspace)
+        os.makedirs(args.workspace)
+        touch_file(special_fname)
+    else:
+        if not os.path.exists(special_fname):
+            raise RuntimeError("Directory %s exists but %s does not, stopping to avoid overwriting files in non-workspace directory"
+                            % (args.workspace, special_fname))
+
+    dir_third_party = os.path.join(args.workspace, third_party.DIR_THIRD_PARTY)
+    dir_cache = os.path.join(args.workspace, DIR_CACHE)
+    dir_logs = os.path.join(args.workspace, DIR_LOGS)
+    dir_systems = os.path.join(args.workspace, DIR_SYSTEMS)
+    task_name = args.task if args.task else args.custom_task
+    if args.test:
+        task_name += SUFFIX_TEST
+    dir_task = os.path.join(dir_systems, task_name)
+    for dirname in (dir_third_party, dir_cache, dir_logs, dir_systems, dir_task):
+        if os.path.exists(dirname):
+            logging.info("Exists: %s", dirname)
+        else:
+            logging.info("Create: %s", dirname)
+            os.makedirs(dirname)
+
+    # (3) Checkout necessary tools
+
+    logging.info("=== Checkout third-party tools ===")
+    # Requires tokenization?
+    if args.task or args.custom_text_type == CUSTOM_UTF8_RAW:
+        third_party.checkout_moses_tokenizer(args.workspace)
+    # Requires byte-pair encoding?
+    if args.task or args.custom_text_type in (CUSTOM_UTF8_RAW, CUSTOM_UTF8_TOK):
+        third_party.checkout_subword_nmt(args.workspace)
+
+    # (4) Populate train/dev/test data
+
+    # This step also normalizes whitespace on data population or copy, ensuring
+    # that for all input data, only ASCII newlines are considered line breaks.
+    logging.info("=== Populate train/dev/test data ===")
+    step_dir_raw = os.path.join(dir_task, DIR_DATA, DIR_RAW)
+    complete_fname = os.path.join(step_dir_raw, FILE_COMPLETE)
+    if os.path.exists(complete_fname):
+        logging.info("Re-use completed step: %s", step_dir_raw)
+    else:
+        # Listed task
+        if args.task:
+            raw_files = identify_raw_files(task, test_mode=args.test)
+            with tempfile.TemporaryDirectory(prefix="raw.", dir=dir_task) as raw_dir:
+                # Download (or locate in cache) and extract raw files to temp directory
+                logging.info("=== Download and extract raw files ===")
+                download_extract_raw_files(raw_files, dir_cache, raw_dir)
+                # Copy required files to train/dev/test
+                logging.info("=== Create input data files ===")
+                renew_step_dir(step_dir_raw)
+                # Test mode uses the full test set as training data and the
+                # first line of the test set as dev and test data
+                populate_parallel_text(raw_dir,
+                                       task.test if args.test else task.train,
+                                       os.path.join(step_dir_raw, PREFIX_TRAIN),
+                                       False)
+                populate_parallel_text(raw_dir,
+                                       task.test if args.test else task.dev,
+                                       os.path.join(step_dir_raw, PREFIX_DEV),
+                                       False,
+                                       head_n=1 if args.test else 0)
+                populate_parallel_text(raw_dir,
+                                       task.test,
+                                       os.path.join(step_dir_raw, PREFIX_TEST),
+                                       True,
+                                       head_n=1 if args.test else 0)
+        # Custom task
+        else:
+            logging.info("=== Copy input data files ===")
+            renew_step_dir(step_dir_raw)
+            copy_parallel_text(args.custom_train, os.path.join(step_dir_raw, PREFIX_TRAIN))
+            copy_parallel_text(args.custom_dev, os.path.join(step_dir_raw, PREFIX_DEV))
+            copy_parallel_text(args.custom_test, os.path.join(step_dir_raw, PREFIX_TEST))
+        # Record success
+        touch_file(complete_fname)
+        logging.info("Step complete: %s", step_dir_raw)
+
+    # (5) Tokenize train/dev/test data
+
+    # Task requires tokenization if _any_ raw file is not already tokenized
+    requires_tokenization = False
+    if args.task:
+        for file_sets in (task.train, task.dev, task.test):
+            for _, _, text_type in file_sets:
+                if text_type in TEXT_REQUIRES_TOKENIZATION:
+                    requires_tokenization = True
+    else:
+        if args.custom_text_type == CUSTOM_UTF8_RAW:
+            requires_tokenization = True
+    logging.info("=== Tokenize train/dev/test data ===")
+    step_dir_tok = os.path.join(dir_task, DIR_DATA, DIR_TOK)
+    complete_fname = os.path.join(step_dir_tok, FILE_COMPLETE)
+    if os.path.exists(complete_fname):
+        logging.info("Re-use completed step: %s", step_dir_tok)
+    else:
+        renew_step_dir(step_dir_tok)
+
+        # Tokenize each data file using the appropriate language code OR link
+        # raw file if already tokenized.
+        for fname in os.listdir(step_dir_raw):
+            if fname.startswith("."):
+                continue
+            input_fname = os.path.join(step_dir_raw, fname)
+            output_fname = os.path.join(step_dir_tok, fname)
+            if requires_tokenization:
+                lang_code = lang_codes[0] if fname.endswith(SUFFIX_SRC_GZ) else lang_codes[1]
+                logging.info("Tokenize (%s): %s -> %s", lang_code, input_fname, output_fname)
+                third_party.call_moses_tokenizer(workspace_dir=args.workspace,
+                                                 input_fname=input_fname,
+                                                 output_fname=output_fname,
+                                                 lang_code=lang_code)
+            else:
+                logging.info("Link pre-tokenized: %s -> %s", input_fname, output_fname)
+                os.symlink(os.path.join("..", DIR_RAW, fname), output_fname)
+        # Record success
+        touch_file(complete_fname)
+        logging.info("Step complete: %s", step_dir_tok)
+
+    # (6) Learn byte-pair encoding model
+
+    # Task requires byte-pair encoding unless using pre-encoded custom data
+    skip_bpe = (not args.task) and args.custom_text_type == CUSTOM_UTF8_BPE
+    logging.info("=== Learn byte-pair encoding model ===")
+    step_dir_bpe_model = os.path.join(dir_task, DIR_BPE_MODEL)
+    complete_fname = os.path.join(step_dir_bpe_model, FILE_COMPLETE)
+    if os.path.exists(complete_fname):
+        logging.info("Re-use completed step: %s", step_dir_bpe_model)
+    else:
+        renew_step_dir(step_dir_bpe_model)
+        if skip_bpe:
+            logging.info("BPE model not required for pre-encoded data")
+        else:
+            source_fname = os.path.join(step_dir_tok, PREFIX_TRAIN + SUFFIX_SRC_GZ)
+            target_fname = os.path.join(step_dir_tok, PREFIX_TRAIN + SUFFIX_TRG_GZ)
+            codes_fname = os.path.join(step_dir_bpe_model, FILE_BPE_CODES)
+            num_ops = task.bpe_op if args.task else args.custom_bpe_op
+            logging.info("BPE Learn (%s): %s + %s -> %s", num_ops, source_fname, target_fname, codes_fname)
+            third_party.call_learn_bpe(workspace_dir=args.workspace,
+                                       source_fname=source_fname,
+                                       target_fname=target_fname,
+                                       model_fname=codes_fname,
+                                       num_ops=num_ops)
+        # Record success
+        touch_file(complete_fname)
+        logging.info("Step complete: %s", step_dir_bpe_model)
+
+    # (7) Byte-pair encode data
+
+    logging.info("=== Byte-pair encode train/dev/test data ===")
+    step_dir_bpe = os.path.join(dir_task, DIR_DATA, DIR_BPE)
+    complete_fname = os.path.join(step_dir_bpe, FILE_COMPLETE)
+    if os.path.exists(complete_fname):
+        logging.info("Re-use completed step: %s", step_dir_bpe)
+    else:
+        renew_step_dir(step_dir_bpe)
+        # Encode each data file
+        for fname in os.listdir(step_dir_tok):
+            if fname.startswith("."):
+                continue
+            input_fname = os.path.join(step_dir_tok, fname)
+            output_fname = os.path.join(step_dir_bpe, fname)
+            if skip_bpe:
+                logging.info("Link pre-encoded: %s -> %s", input_fname, output_fname)
+                os.symlink(os.path.join("..", DIR_TOK, fname), output_fname)
+            else:
+                codes_fname = os.path.join(step_dir_bpe_model, FILE_BPE_CODES)
+                logging.info("BPE: %s -> %s", input_fname, output_fname)
+                third_party.call_apply_bpe(workspace_dir=args.workspace,
+                                           input_fname=input_fname,
+                                           output_fname=output_fname,
+                                           model_fname=codes_fname)
+        # Record success
+        touch_file(complete_fname)
+        logging.info("Step complete: %s", step_dir_bpe)
+
+    # Done if only running data preparation steps
+    if args.model == MODEL_NONE:
+        return
+
+    # (8) Run Sockeye training
+
+    logging.info("=== Train translation model ===")
+    logging.info("Model: %s", args.model)
+    step_dir_model = os.path.join(dir_task, DIR_PREFIX_MODEL + args.model)
+    complete_fname = os.path.join(step_dir_model, FILE_COMPLETE)
+    if os.path.exists(complete_fname):
+        logging.info("Re-use completed step: %s", step_dir_model)
+    else:
+        log_fname = os.path.join(args.workspace,
+                                 DIR_LOGS,
+                                 "sockeye.{{}}.{}.{}.{}.log".format(task_name, args.model, os.getpid()))
+        call_sockeye_train(MODELS[args.model],
+                           step_dir_bpe,
+                           step_dir_model,
+                           log_fname.format("train"),
+                           args.gpus,
+                           test_mode=args.test)
+        call_sockeye_average(step_dir_model, log_fname.format("average"))
+        # Record success
+        touch_file(complete_fname)
+        logging.info("Step complete: %s", step_dir_model)
+
+    # (9) Decode test sets
+
+    logging.info("=== Decode test sets ===")
+    logging.info("Settings: %s", args.decode_settings)
+    step_dir_results = os.path.join(dir_task, DIR_RESULTS)
+    if not os.path.exists(step_dir_results):
+        logging.info("Create: %s", step_dir_results)
+        os.makedirs(step_dir_results)
+    # To collect BPE output names
+    output_fnames_bpe = []
+    # For each test file
+    for fname in os.listdir(step_dir_bpe):
+        if fname.startswith(PREFIX_TEST) and fname.endswith(SUFFIX_SRC_GZ):
+            input_fname = os.path.join(step_dir_bpe, fname)
+            # /path/to/results/test[.N].<model>.<settings>
+            output_fname = os.path.join(step_dir_results, "{}.{}.{}.{}".format(args.model,
+                                                                               args.decode_settings,
+                                                                               fname[:-len(SUFFIX_SRC_GZ) - 1],
+                                                                               SUFFIX_BPE))
+            output_fnames_bpe.append(output_fname)
+            # For the shared results directory, a command file indicates that
+            # the step has completed successfully.
+            command_fname = output_fname + "." + SUFFIX_COMMAND
+            if os.path.exists(command_fname):
+                logging.info("Re-use output: %s", output_fname)
+            else:
+                log_fname = os.path.join(args.workspace,
+                                 DIR_LOGS,
+                                 "sockeye.translate.{}.{}.{}.{}.log".format(task_name,
+                                                                            args.model,
+                                                                            fname[:-len(SUFFIX_SRC_GZ) - 1],
+                                                                            os.getpid()))
+                call_sockeye_translate(args=DECODE_ARGS[args.decode_settings],
+                                       input_fname=input_fname,
+                                       output_fname=output_fname,
+                                       model_dir=step_dir_model,
+                                       log_fname=log_fname,
+                                       use_cpu=(args.gpus == 0))
+
+    # (10) Evaluate test sets (bpe/tok/detok)
+
+    lang_code = lang_codes[1] if lang_codes else None
+    logging.info("=== Score outputs ===")
+    # For each output file
+    for fname_bpe in output_fnames_bpe:
+        # Score byte-pair encoded
+        fname_base = os.path.basename(fname_bpe)[:-len(SUFFIX_BPE)].split(".", 2)[2]
+        fname_ref_bpe = os.path.join(step_dir_bpe, fname_base + SUFFIX_TRG_GZ)
+        fname_bleu_bpe = fname_bpe + "." + SUFFIX_BLEU
+        if os.path.exists(fname_bleu_bpe):
+            logging.info("Re-use output: %s", fname_bleu_bpe)
+        else:
+            fname_log = os.path.join(args.workspace,
+                         DIR_LOGS,
+                         "contrib.sacrebleu.sacrebleu.{}.{}.{}.{}.log".format(task_name,
+                                                                              args.model,
+                                                                              fname_base + SUFFIX_BPE,
+                                                                              os.getpid()))
+            call_sacrebleu(input_fname=fname_bpe,
+                           ref_fname=fname_ref_bpe,
+                           output_fname=fname_bleu_bpe,
+                           log_fname=fname_log,
+                           tokenized=True)
+        # Score tokenized
+        fname_tok = fname_bpe[:-len(SUFFIX_BPE)] + SUFFIX_TOK
+        fname_ref_tok = os.path.join(step_dir_tok, fname_base + SUFFIX_TRG_GZ)
+        fname_bleu_tok = fname_tok + "." + SUFFIX_BLEU
+        if os.path.exists(fname_bleu_tok):
+            logging.info("Re-use output: %s", fname_bleu_tok)
+        else:
+            # Merge BPE
+            logging.info("Merge BPE: %s -> %s", fname_bpe, fname_tok)
+            third_party.merge_bpe(input_fname=fname_bpe, output_fname=fname_tok)
+            fname_log = os.path.join(args.workspace,
+                         DIR_LOGS,
+                         "contrib.sacrebleu.sacrebleu.{}.{}.{}.{}.log".format(task_name,
+                                                                              args.model,
+                                                                              fname_base + SUFFIX_TOK,
+                                                                              os.getpid()))
+            call_sacrebleu(input_fname=fname_tok,
+                           ref_fname=fname_ref_tok,
+                           output_fname=fname_bleu_tok,
+                           log_fname=fname_log,
+                           tokenized=True)
+        # Score detokenized (WMT-compatible BLEU)
+        fname_detok = fname_bpe[:-len(SUFFIX_BPE)] + SUFFIX_DETOK
+        fname_ref_raw = os.path.join(step_dir_raw, fname_base + SUFFIX_TRG_GZ)
+        fname_bleu_detok = fname_detok + "." + SUFFIX_SACREBLEU
+        if os.path.exists(fname_bleu_detok):
+            logging.info("Re-use output: %s", fname_bleu_detok)
+        else:
+            if not requires_tokenization:
+                logging.info("WARNING: Task uses pre-tokenized data, cannot reliably detokenize to compute WMT-compatible scores")
+                continue
+            # Detokenize
+            logging.info("Detokenize (%s): %s -> %s", lang_code, fname_tok, fname_detok)
+            third_party.call_moses_detokenizer(workspace_dir=args.workspace,
+                                               input_fname=fname_tok,
+                                               output_fname=fname_detok,
+                                               lang_code=lang_code)
+            fname_log = os.path.join(args.workspace,
+                         DIR_LOGS,
+                         "contrib.sacrebleu.sacrebleu.{}.{}.{}.{}.log".format(task_name,
+                                                                              args.model,
+                                                                              fname_base + SUFFIX_DETOK,
+                                                                              os.getpid()))
+            call_sacrebleu(input_fname=fname_detok,
+                           ref_fname=fname_ref_raw,
+                           output_fname=fname_bleu_detok,
+                           log_fname=fname_log,
+                           tokenized=False)
+
+
+def main():
+    default_workspace = os.path.join(os.path.expanduser("~"), DIR_SOCKEYE_AUTOPILOT)
+
+    arg_parser = argparse.ArgumentParser(description="Sockeye Autopilot: end-to-end model training and evaluation.")
+    arg_parser.add_argument("--workspace", type=str, metavar="DIR", default=default_workspace,
+                            help="Base directory to use for building systems (download files, train models, etc.). Default: %(default)s.")
+    arg_parser.add_argument("--task", type=str, choices=sorted(TASKS.keys()),
+                            help="Pre-defined data set for model training.")
+    arg_parser.add_argument("--model", type=str, choices=sorted(MODELS.keys()),
+                            help="Type of translation model to train.")
+    arg_parser.add_argument("--decode-settings", type=str, choices=sorted(DECODE_ARGS.keys()), default=DECODE_STANDARD,
+                            help="Decoding settings. Default: %(default)s.")
+    arg_parser.add_argument("--custom-task", type=str, metavar="NAME",
+                            help="Name of custom task (used for directory naming).")
+    arg_parser.add_argument("--custom-train", type=str, nargs=2, metavar=("SRC", "TRG"),
+                            help="Custom training data (source and target).")
+    arg_parser.add_argument("--custom-dev", type=str, nargs=2, metavar=("SRC", "TRG"),
+                            help="Custom development data (source and target).")
+    arg_parser.add_argument("--custom-test", type=str, nargs="+", metavar="SRC TRG",
+                            help="Custom test data (pairs of source and target).")
+    arg_parser.add_argument("--custom-text-type", type=str, choices=CUSTOM_TEXT_TYPES, default=CUSTOM_UTF8_RAW,
+                            help="Level of pre-processing already applied to data for custom task: none (raw), tokenization, or byte-pair encoding. Default: %(default)s.")
+    arg_parser.add_argument("--custom-lang", type=str, nargs=2, metavar=("SRC", "TRG"),
+                            help="Source and target language codes for custom task (en, fr, de, etc.).")
+    arg_parser.add_argument("--custom-bpe-op", type=int, default=32000,
+                            help="Number of byte-pair encoding operations for custom task. Default: %(default)s.")
+    arg_parser.add_argument("--gpus", type=int, metavar="N", default=1,
+                            help="Number of GPUs to use. 0 for CPU only. Default: %(default)s.")
+    arg_parser.add_argument("--test", action="store_true", default=False,
+                            help="Run in test mode (much abbreviated system build).")
+
+    args = arg_parser.parse_args()
+
+    # Listed task or fully specified custom task
+    utils.check_condition(args.task or all((args.custom_train, args.custom_dev, args.custom_test)),
+            "Please specify --task or all of: --custom-task --custom-train --custom-dev --custom-test")
+
+    # Required args for different custom tasks
+    if not args.task:
+        if args.custom_text_type == CUSTOM_UTF8_RAW:
+            utils.check_condition(args.custom_lang, "Please specify --custom-lang for source and target tokenization")
+
+    # Require explicit request to not train model
+    if not args.model:
+        raise RuntimeError("Please specify --model.  Use --model %s to run data preparation steps only" % MODEL_NONE)
+
+    run_steps(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/autopilot/autopilot.py
+++ b/contrib/autopilot/autopilot.py
@@ -24,7 +24,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-from typing import Iterable, List, Tuple
+from typing import Any, IO, Iterable, List, Optional, Tuple
 import urllib.request
 import zipfile
 
@@ -104,7 +104,7 @@ def identify_raw_files(task: Task, test_mode: bool = False) -> List[str]:
     :return: List of raw file names.
     """
     raw_files = set()
-    all_sets = (task.test,) if test_mode else (task.train, task.dev, task.test)
+    all_sets = [task.test,] if test_mode else [task.train, task.dev, task.test]
     for file_sets in all_sets:
         for file_set in file_sets:
             for fname in file_set[:2]:
@@ -190,8 +190,8 @@ def populate_parallel_text(extract_dir: str,
                           its own file (used for test sets).
     :param head_n: If N>0, use only the first N lines (used in test mode).
     """
-    source_out = None
-    target_out = None
+    source_out = None  # type: IO[Any]
+    target_out = None  # type: IO[Any]
     lines_written = 0
     # Single output file for each side
     if not keep_separate:

--- a/contrib/autopilot/models.py
+++ b/contrib/autopilot/models.py
@@ -1,0 +1,75 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Names model types
+MODEL_NONE = "none"
+MODEL_TRANSFORMER = "transformer"
+
+# Named decoding settings
+DECODE_STANDARD = "standard"
+
+# Model configurations (architecture, training recipe, etc.)
+MODELS = {
+
+    MODEL_NONE: [],
+
+    MODEL_TRANSFORMER: [
+        "--encoder=transformer",
+        "--decoder=transformer",
+        "--num-layers=6:6",
+        "--transformer-model-size=512",
+        "--transformer-attention-heads=8",
+        "--transformer-feed-forward-num-hidden=2048",
+        "--transformer-positional-embedding-type=fixed",
+        "--transformer-preprocess=n",
+        "--transformer-postprocess=dr",
+        "--transformer-dropout-attention=0.1",
+        "--transformer-dropout-act=0.1",
+        "--transformer-dropout-prepost=0.1",
+        "--weight-tying",
+        "--weight-tying-type=src_trg_softmax",
+        "--weight-init=xavier",
+        "--weight-init-scale=3.0",
+        "--weight-init-xavier-factor-type=avg",
+        "--num-embed=512:512",
+        "--optimizer=adam",
+        "--optimized-metric=perplexity",
+        "--label-smoothing=0.1",
+        "--gradient-clipping-threshold=-1",
+        "--initial-learning-rate=0.0002",
+        "--learning-rate-reduce-num-not-improved=8",
+        "--learning-rate-reduce-factor=0.9",
+        "--learning-rate-scheduler-type=plateau-reduce",
+        "--learning-rate-decay-optimizer-states-reset=best",
+        "--learning-rate-decay-param-reset",
+        "--max-num-checkpoint-not-improved=32",
+        "--batch-type=word",
+        "--batch-size=4096",
+        "--checkpoint-frequency=2000",
+        "--decode-and-evaluate=500",
+        "--keep-last-params=60",
+    ],
+}
+
+# Decoding configurations
+DECODE_ARGS = {
+    DECODE_STANDARD: [
+        "--beam-size=5",
+        "--batch-size=32",
+        "--chunk-size=1000",
+        "--length-penalty-alpha=0.1",
+        "--length-penalty-beta=0.0",
+        "--max-output-length-num-stds=2",
+        "--bucket-width=10",
+    ]
+}

--- a/contrib/autopilot/models.py
+++ b/contrib/autopilot/models.py
@@ -59,7 +59,7 @@ MODELS = {
         "--decode-and-evaluate=500",
         "--keep-last-params=60",
     ],
-}
+}  # type: Dict[str, List[str]]
 
 # Decoding configurations
 DECODE_ARGS = {

--- a/contrib/autopilot/tasks.py
+++ b/contrib/autopilot/tasks.py
@@ -1,0 +1,544 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from typing import List, NamedTuple, Tuple
+
+
+# Archive types
+ARCHIVE_NONE = "none"
+ARCHIVE_TAR = "tar"
+ARCHIVE_ZIP = "zip"
+
+# Formats for known files
+# Note: we currently assume that all data files will be UTF-8 encoded.  If this
+#       changes, review the third party tools to make sure everything is
+#       converted to UTF-8 immediately after extraction, prior to creating raw
+#       train/dev/test files.
+TEXT_UTF8_RAW = "utf8_raw"
+TEXT_UTF8_RAW_SGML = "utf8_raw_sgml"
+TEXT_UTF8_RAW_BITEXT = "utf8_raw_bitext"  # Triple-pipe delimited: source ||| target
+TEXT_UTF8_RAW_BITEXT_REVERSE = "utf8_raw_bitext_reverse"  # Same as above, but used
+                                                          # for reverse direction
+# All TEXT_* types above require tokenization and should appear in this list
+TEXT_REQUIRES_TOKENIZATION = [TEXT_UTF8_RAW, TEXT_UTF8_RAW_SGML, TEXT_UTF8_RAW_BITEXT, TEXT_UTF8_RAW_BITEXT_REVERSE]
+TEXT_UTF8_TOKENIZED = "utf8_tokenized"
+
+
+RawFile = NamedTuple("RawFile", [("description", str),
+                                 ("url", str),
+                                 ("md5", str),
+                                 ("archive_type", str)])
+"""
+Known raw file that provides input data for a sequence-to-sequence task.
+
+:param description: Short description of data contained in raw file.
+:param url: Download url.
+:param md5: Reference MD5 sum.
+:param archive_type: Type of archive, one of ARCHIVE_*.
+"""
+
+
+# Known raw files that provide data for sequence-to-sequence tasks.  Individual
+# files may be referenced in multiple tasks.
+RAW_FILES = {
+    # WMT training data
+    "europarl_v7": RawFile("Europarl v7",
+                           "http://www.statmt.org/wmt13/training-parallel-europarl-v7.tgz",
+                           "c52404583294a1b609e56d45b2ed06f5",
+                           ARCHIVE_TAR),
+    "europarl_v8": RawFile("Europarl v8",
+                           "http://data.statmt.org/wmt17/translation-task/training-parallel-ep-v8.tgz",
+                           "07b77f254d189a5bfb7b43b7fc489716",
+                           ARCHIVE_TAR),
+    "common_crawl_wmt13": RawFile("Common Crawl corpus (WMT13 release)",
+                                  "http://www.statmt.org/wmt13/training-parallel-commoncrawl.tgz",
+                                  "7e0acbe86b0d7816300e14650f5b2bd4",
+                                  ARCHIVE_TAR),
+    "un_wmt13": RawFile("UN corpus (WMT13 release)",
+                        "http://www.statmt.org/wmt13/training-parallel-un.tgz",
+                        "bb25a213ba9140023e4cc82c778bef53",
+                        ARCHIVE_TAR),
+    "news_commentary_v9": RawFile("News Commentary v9",
+                                  "http://www.statmt.org/wmt14/training-parallel-nc-v9.tgz",
+                                  "92e42b68f9d3c2ae9722e6d1c2623e21",
+                                  ARCHIVE_TAR),
+    "news_commentary_v12": RawFile("News Commentary v12",
+                                   "http://data.statmt.org/wmt17/translation-task/training-parallel-nc-v12.tgz",
+                                   "fc6b83b809347e64f511d291e4bc8731",
+                                   ARCHIVE_TAR),
+    "giga_fren_wmt10": RawFile("10^9 French-English corpus",
+                               "http://www.statmt.org/wmt10/training-giga-fren.tar",
+                               "0b12e20027d5b5f0dfcca290c72c8953",
+                               ARCHIVE_TAR),
+    "wiki_headlines_wmt15": RawFile("Wiki Headlines (WMT15 release)",
+                                    "http://www.statmt.org/wmt15/wiki-titles.tgz",
+                                    "f74eef43032766d55884a5073ed8ce27",
+                                    ARCHIVE_TAR),
+    "rapid_eu_2016": RawFile("Rapid corpus of EU press releases (2016)",
+                             "http://data.statmt.org/wmt17/translation-task/rapid2016.tgz",
+                             "17a3a1846433ad26acb95da02f93af93",
+                             ARCHIVE_TAR),
+    "leta_v1": RawFile("LETA translated news v1",
+                       "http://data.statmt.org/wmt17/translation-task/leta.v1.tgz",
+                       "3f367e86924f910cb1e969de57caf63c",
+                       ARCHIVE_TAR),
+    "dcep_lv_en_v1": RawFile("Digital Corpus of European Parliament v1",
+                             "http://data.statmt.org/wmt17/translation-task/dcep.lv-en.v1.tgz",
+                             "0f949102e8501dfb3c99d3e3f545b4f9",
+                             ARCHIVE_TAR),
+    "books_lv_en_v1": RawFile("Online Books v1",
+                              "http://data.statmt.org/wmt17/translation-task/books.lv-en.v1.tgz",
+                              "7073092421b1259158446870990a9ca5",
+                              ARCHIVE_TAR),
+    "setimes2_en_tr": RawFile("SETIMES2 English-Turkish",
+                              "http://opus.nlpl.eu/download.php?f=SETIMES2/en-tr.txt.zip",
+                              "544cec8a631f7820afab6a05451c13a7",
+                              ARCHIVE_ZIP),
+    # WMT dev and test sets
+    "wmt14_dev": RawFile("WMT17 development sets",
+                         "http://www.statmt.org/wmt14/dev.tgz",
+                         "88ba3fc60b2278d59277122e1c7dd6e7",
+                         ARCHIVE_TAR),
+    "wmt17_dev": RawFile("WMT17 development sets",
+                         "http://data.statmt.org/wmt17/translation-task/dev.tgz",
+                         "9b1aa63c1cf49dccdd20b962fe313989",
+                         ARCHIVE_TAR),
+    "wmt14_test": RawFile("WMT14 test sets",
+                          "http://www.statmt.org/wmt14/test-filtered.tgz",
+                          "84c597844c1542e29c2aff23aaee4310",
+                          ARCHIVE_TAR),
+    "wmt17_test": RawFile("WMT17 test sets",
+                          "http://data.statmt.org/wmt17/translation-task/test.tgz",
+                          "86a1724c276004aa25455ae2a04cef26",
+                          ARCHIVE_TAR),
+    # Stanford NLP pre-processed data
+    "stanford_wmt14_train_en": RawFile("Stanford pre-processed WMT14 English training data",
+                                       "https://nlp.stanford.edu/projects/nmt/data/wmt14.en-de/train.en",
+                                       "7ac0d46a8f6db6dfce476c2a8e54121b",
+                                       ARCHIVE_NONE),
+    "stanford_wmt14_train_de": RawFile("Stanford pre-processed WMT14 German training data",
+                                       "https://nlp.stanford.edu/projects/nmt/data/wmt14.en-de/train.de",
+                                       "5873aae4fe517aad42bb29d607b5d2a0",
+                                       ARCHIVE_NONE),
+    "stanford_wmt14_test2013_en": RawFile("Stanford pre-processed WMT14 English news test 2013",
+                                          "https://nlp.stanford.edu/projects/nmt/data/wmt14.en-de/newstest2013.en",
+                                          "f3ce7816bb0acbd2de0364795e9688b1",
+                                          ARCHIVE_NONE),
+    "stanford_wmt14_test2013_de": RawFile("Stanford pre-processed WMT14 German news test 2013",
+                                          "https://nlp.stanford.edu/projects/nmt/data/wmt14.en-de/newstest2013.de",
+                                          "5d48c9300649bfad1300e53ad1334aec",
+                                          ARCHIVE_NONE),
+    "stanford_wmt14_test2014_en": RawFile("Stanford pre-processed WMT14 English news test 2014",
+                                          "https://nlp.stanford.edu/projects/nmt/data/wmt14.en-de/newstest2014.en",
+                                          "4e4663b8de25d19c5fc1c4dab8d61703",
+                                          ARCHIVE_NONE),
+    "stanford_wmt14_test2014_de": RawFile("Stanford pre-processed WMT14 German news test 2014",
+                                          "https://nlp.stanford.edu/projects/nmt/data/wmt14.en-de/newstest2014.de",
+                                          "06e8840abe90cbfbd45cf2729807605d",
+                                          ARCHIVE_NONE),
+    "stanford_wmt14_test2015_en": RawFile("Stanford pre-processed WMT14 English news test 2015",
+                                          "https://nlp.stanford.edu/projects/nmt/data/wmt14.en-de/newstest2015.en",
+                                          "081a724a6a1942eb900d75852f9f5974",
+                                          ARCHIVE_NONE),
+    "stanford_wmt14_test2015_de": RawFile("Stanford pre-processed WMT14 German news test 2015",
+                                          "https://nlp.stanford.edu/projects/nmt/data/wmt14.en-de/newstest2015.de",
+                                          "40b6f52962fa630091d8e6a143423385",
+                                          ARCHIVE_NONE),
+}
+
+
+Task = NamedTuple("Task", [("description", str),
+                           ("url", str),
+                           ("src_lang", str),
+                           ("trg_lang", str),
+                           ("bpe_op", int),
+                           ("train", List[Tuple[str, str, str]]),
+                           ("dev", List[Tuple[str, str, str]]),
+                           ("test", List[Tuple[str, str, str]])])
+"""
+Sequence-to-sequence task that uses data from known raw files.  Train, dev, and
+test files are specified in triples of (source, target, text_type).  The format
+for source and target is "raw_file_name/path/to/data/file" and text_type is one
+of TEXT_*.  Multiple train and dev sets are concatenated while multiple test
+sets are evaluated individually.
+
+:param description: Short description of task.
+:param url: URL of task information page.
+:param src_lang: Source language code (used for tokenization only).
+:param trg_lang: Target language code (used for tokenization only).
+:param bpe_op: Number of byte-pair encoding operations for sub-word vocabulary.
+:param train: List of training file sets.
+:param dev: List of dev/validation file sets.
+:param test: List of test/evaluation file sets.
+"""
+
+
+# Known sequence-to-sequence tasks that specify train, dev, and test sets.
+TASKS = {
+    # WMT14 common benchmarks
+    "wmt14_de_en": Task(description="WMT14 German-English news",
+                        url="http://www.statmt.org/wmt14/translation-task.html",
+                        src_lang="de",
+                        trg_lang="en",
+                        bpe_op=32000,
+                        train=[
+                            ("europarl_v7/training/europarl-v7.de-en.de",
+                             "europarl_v7/training/europarl-v7.de-en.en",
+                             TEXT_UTF8_RAW),
+                            ("common_crawl_wmt13/commoncrawl.de-en.de",
+                             "common_crawl_wmt13/commoncrawl.de-en.en",
+                             TEXT_UTF8_RAW),
+                            ("news_commentary_v9/training/news-commentary-v9.de-en.de",
+                             "news_commentary_v9/training/news-commentary-v9.de-en.en",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt14_dev/dev/newstest2013-src.de.sgm",
+                             "wmt14_dev/dev/newstest2013-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt14_test/test/newstest2014-deen-src.de.sgm",
+                             "wmt14_test/test/newstest2014-deen-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    "wmt14_fr_en": Task(description="WMT14 French-English news",
+                        url="http://www.statmt.org/wmt14/translation-task.html",
+                        src_lang="fr",
+                        trg_lang="en",
+                        bpe_op=32000,
+                        train=[
+                            ("europarl_v7/training/europarl-v7.fr-en.fr",
+                             "europarl_v7/training/europarl-v7.fr-en.en",
+                             TEXT_UTF8_RAW),
+                            ("common_crawl_wmt13/commoncrawl.fr-en.fr",
+                             "common_crawl_wmt13/commoncrawl.fr-en.en",
+                             TEXT_UTF8_RAW),
+                            ("un_wmt13/un/undoc.2000.fr-en.fr",
+                             "un_wmt13/un/undoc.2000.fr-en.en",
+                             TEXT_UTF8_RAW),
+                            ("news_commentary_v9/training/news-commentary-v9.fr-en.fr",
+                             "news_commentary_v9/training/news-commentary-v9.fr-en.en",
+                             TEXT_UTF8_RAW),
+                            ("giga_fren_wmt10/giga-fren.release2.fixed.fr.gz",
+                             "giga_fren_wmt10/giga-fren.release2.fixed.en.gz",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt14_dev/dev/newstest2013-src.fr.sgm",
+                             "wmt14_dev/dev/newstest2013-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt14_test/test/newstest2014-fren-src.fr.sgm",
+                             "wmt14_test/test/newstest2014-fren-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    "wmt14_en_de": Task(description="WMT14 English-German news",
+                        url="http://www.statmt.org/wmt14/translation-task.html",
+                        src_lang="en",
+                        trg_lang="de",
+                        bpe_op=32000,
+                        train=[
+                            ("europarl_v7/training/europarl-v7.de-en.en",
+                             "europarl_v7/training/europarl-v7.de-en.de",
+                             TEXT_UTF8_RAW),
+                            ("common_crawl_wmt13/commoncrawl.de-en.en",
+                             "common_crawl_wmt13/commoncrawl.de-en.de",
+                             TEXT_UTF8_RAW),
+                            ("news_commentary_v9/training/news-commentary-v9.de-en.en",
+                             "news_commentary_v9/training/news-commentary-v9.de-en.de",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt14_dev/dev/newstest2013-src.en.sgm",
+                             "wmt14_dev/dev/newstest2013-ref.de.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt14_test/test/newstest2014-deen-src.en.sgm",
+                             "wmt14_test/test/newstest2014-deen-ref.de.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    "wmt14_en_fr": Task(description="WMT14 English-French news",
+                        url="http://www.statmt.org/wmt14/translation-task.html",
+                        src_lang="en",
+                        trg_lang="fr",
+                        bpe_op=32000,
+                        train=[
+                            ("europarl_v7/training/europarl-v7.fr-en.en",
+                             "europarl_v7/training/europarl-v7.fr-en.fr",
+                             TEXT_UTF8_RAW),
+                            ("common_crawl_wmt13/commoncrawl.fr-en.en",
+                             "common_crawl_wmt13/commoncrawl.fr-en.fr",
+                             TEXT_UTF8_RAW),
+                            ("un_wmt13/un/undoc.2000.fr-en.en",
+                             "un_wmt13/un/undoc.2000.fr-en.fr",
+                             TEXT_UTF8_RAW),
+                            ("news_commentary_v9/training/news-commentary-v9.fr-en.en",
+                             "news_commentary_v9/training/news-commentary-v9.fr-en.fr",
+                             TEXT_UTF8_RAW),
+                            ("giga_fren_wmt10/giga-fren.release2.fixed.en.gz",
+                             "giga_fren_wmt10/giga-fren.release2.fixed.fr.gz",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt14_dev/dev/newstest2013-src.en.sgm",
+                             "wmt14_dev/dev/newstest2013-ref.fr.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt14_test/test/newstest2014-fren-src.en.sgm",
+                             "wmt14_test/test/newstest2014-fren-ref.fr.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    # WMT17 tasks using 100% publicly available data
+    "wmt17_de_en": Task(description="WMT17 German-English news",
+                        url="http://www.statmt.org/wmt17/translation-task.html",
+                        src_lang="de",
+                        trg_lang="en",
+                        bpe_op=32000,
+                        train=[
+                            ("europarl_v7/training/europarl-v7.de-en.de",
+                             "europarl_v7/training/europarl-v7.de-en.en",
+                             TEXT_UTF8_RAW),
+                            ("common_crawl_wmt13/commoncrawl.de-en.de",
+                             "common_crawl_wmt13/commoncrawl.de-en.en",
+                             TEXT_UTF8_RAW),
+                            ("news_commentary_v12/training/news-commentary-v12.de-en.de",
+                             "news_commentary_v12/training/news-commentary-v12.de-en.en",
+                             TEXT_UTF8_RAW),
+                            ("rapid_eu_2016/rapid2016.de-en.de",
+                             "rapid_eu_2016/rapid2016.de-en.en",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt17_dev/dev/newstest2016-deen-src.de.sgm",
+                             "wmt17_dev/dev/newstest2016-deen-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt17_test/test/newstest2017-deen-src.de.sgm",
+                             "wmt17_test/test/newstest2017-deen-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    "wmt17_fi_en": Task(description="WMT17 Finnish-English news",
+                        url="http://www.statmt.org/wmt17/translation-task.html",
+                        src_lang="fi",
+                        trg_lang="en",
+                        bpe_op=32000,
+                        train=[
+                            ("europarl_v8/training/europarl-v8.fi-en.fi",
+                             "europarl_v8/training/europarl-v8.fi-en.en",
+                             TEXT_UTF8_RAW),
+                            ("wiki_headlines_wmt15/wiki/fi-en/titles.fi-en",
+                             "wiki_headlines_wmt15/wiki/fi-en/titles.fi-en",
+                             TEXT_UTF8_RAW_BITEXT),
+                            ("rapid_eu_2016/rapid2016.en-fi.fi",
+                             "rapid_eu_2016/rapid2016.en-fi.en",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt17_dev/dev/newstest2016-fien-src.fi.sgm",
+                             "wmt17_dev/dev/newstest2016-fien-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt17_test/test/newstest2017-fien-src.fi.sgm",
+                             "wmt17_test/test/newstest2017-fien-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    "wmt17_lv_en": Task(description="WMT17 Latvian-English news",
+                        url="http://www.statmt.org/wmt17/translation-task.html",
+                        src_lang="lv",
+                        trg_lang="en",
+                        bpe_op=32000,
+                        train=[
+                            ("europarl_v8/training/europarl-v8.lv-en.lv",
+                             "europarl_v8/training/europarl-v8.lv-en.en",
+                             TEXT_UTF8_RAW),
+                            ("rapid_eu_2016/rapid2016.en-lv.lv",
+                             "rapid_eu_2016/rapid2016.en-lv.en",
+                             TEXT_UTF8_RAW),
+                            ("leta_v1/LETA-lv-en/leta.lv",
+                             "leta_v1/LETA-lv-en/leta.en",
+                             TEXT_UTF8_RAW),
+                            ("dcep_lv_en_v1/dcep.en-lv/dcep.lv",
+                             "dcep_lv_en_v1/dcep.en-lv/dcep.en",
+                             TEXT_UTF8_RAW),
+                            ("books_lv_en_v1/farewell/farewell.lv",
+                             "books_lv_en_v1/farewell/farewell.en",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt17_dev/dev/newsdev2017-lven-src.lv.sgm",
+                             "wmt17_dev/dev/newsdev2017-lven-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt17_test/test/newstest2017-lven-src.lv.sgm",
+                             "wmt17_test/test/newstest2017-lven-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    "wmt17_tr_en": Task(description="WMT17 Turkish-English news",
+                        url="http://www.statmt.org/wmt17/translation-task.html",
+                        src_lang="tr",
+                        trg_lang="en",
+                        bpe_op=16000,
+                        train=[
+                            ("setimes2_en_tr/SETIMES2.en-tr.tr",
+                             "setimes2_en_tr/SETIMES2.en-tr.en",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt17_dev/dev/newstest2016-tren-src.tr.sgm",
+                             "wmt17_dev/dev/newstest2016-tren-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt17_test/test/newstest2017-tren-src.tr.sgm",
+                             "wmt17_test/test/newstest2017-tren-ref.en.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    "wmt17_en_de": Task(description="WMT17 English-German news",
+                        url="http://www.statmt.org/wmt17/translation-task.html",
+                        src_lang="en",
+                        trg_lang="de",
+                        bpe_op=32000,
+                        train=[
+                            ("europarl_v7/training/europarl-v7.de-en.en",
+                             "europarl_v7/training/europarl-v7.de-en.de",
+                             TEXT_UTF8_RAW),
+                            ("common_crawl_wmt13/commoncrawl.de-en.en",
+                             "common_crawl_wmt13/commoncrawl.de-en.de",
+                             TEXT_UTF8_RAW),
+                            ("news_commentary_v12/training/news-commentary-v12.de-en.en",
+                             "news_commentary_v12/training/news-commentary-v12.de-en.de",
+                             TEXT_UTF8_RAW),
+                            ("rapid_eu_2016/rapid2016.de-en.en",
+                             "rapid_eu_2016/rapid2016.de-en.de",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt17_dev/dev/newstest2016-ende-src.en.sgm",
+                             "wmt17_dev/dev/newstest2016-ende-ref.de.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt17_test/test/newstest2017-ende-src.en.sgm",
+                             "wmt17_test/test/newstest2017-ende-ref.de.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    "wmt17_en_fi": Task(description="WMT17 English-Finnish news",
+                        url="http://www.statmt.org/wmt17/translation-task.html",
+                        src_lang="en",
+                        trg_lang="fi",
+                        bpe_op=32000,
+                        train=[
+                            ("europarl_v8/training/europarl-v8.fi-en.en",
+                             "europarl_v8/training/europarl-v8.fi-en.fi",
+                             TEXT_UTF8_RAW),
+                            ("wiki_headlines_wmt15/wiki/fi-en/titles.fi-en",
+                             "wiki_headlines_wmt15/wiki/fi-en/titles.fi-en",
+                             TEXT_UTF8_RAW_BITEXT_REVERSE),
+                            ("rapid_eu_2016/rapid2016.en-fi.en",
+                             "rapid_eu_2016/rapid2016.en-fi.fi",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt17_dev/dev/newstest2016-enfi-src.en.sgm",
+                             "wmt17_dev/dev/newstest2016-enfi-ref.fi.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt17_test/test/newstest2017-enfi-src.en.sgm",
+                             "wmt17_test/test/newstest2017-enfi-ref.fi.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    "wmt17_en_lv": Task(description="WMT17 English-Latvian news",
+                        url="http://www.statmt.org/wmt17/translation-task.html",
+                        src_lang="en",
+                        trg_lang="lv",
+                        bpe_op=32000,
+                        train=[
+                            ("europarl_v8/training/europarl-v8.lv-en.en",
+                             "europarl_v8/training/europarl-v8.lv-en.lv",
+                             TEXT_UTF8_RAW),
+                            ("rapid_eu_2016/rapid2016.en-lv.en",
+                             "rapid_eu_2016/rapid2016.en-lv.lv",
+                             TEXT_UTF8_RAW),
+                            ("leta_v1/LETA-lv-en/leta.en",
+                             "leta_v1/LETA-lv-en/leta.lv",
+                             TEXT_UTF8_RAW),
+                            ("dcep_lv_en_v1/dcep.en-lv/dcep.en",
+                             "dcep_lv_en_v1/dcep.en-lv/dcep.lv",
+                             TEXT_UTF8_RAW),
+                            ("books_lv_en_v1/farewell/farewell.en",
+                             "books_lv_en_v1/farewell/farewell.lv",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt17_dev/dev/newsdev2017-enlv-src.en.sgm",
+                             "wmt17_dev/dev/newsdev2017-enlv-ref.lv.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt17_test/test/newstest2017-enlv-src.en.sgm",
+                             "wmt17_test/test/newstest2017-enlv-ref.lv.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    "wmt17_en_tr": Task(description="WMT17 English-Turkish news",
+                        url="http://www.statmt.org/wmt17/translation-task.html",
+                        src_lang="en",
+                        trg_lang="tr",
+                        bpe_op=16000,
+                        train=[
+                            ("setimes2_en_tr/SETIMES2.en-tr.en",
+                             "setimes2_en_tr/SETIMES2.en-tr.tr",
+                             TEXT_UTF8_RAW),
+                        ],
+                        dev=[
+                            ("wmt17_dev/dev/newstest2016-entr-src.en.sgm",
+                             "wmt17_dev/dev/newstest2016-entr-ref.tr.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ],
+                        test=[
+                            ("wmt17_test/test/newstest2017-entr-src.en.sgm",
+                             "wmt17_test/test/newstest2017-entr-ref.tr.sgm",
+                             TEXT_UTF8_RAW_SGML),
+                        ]),
+    # WNMT18 shared task
+    "wnmt18_en_de": Task(description="WNMT18 English-German (WMT14 news pre-processed)",
+                         url="https://sites.google.com/site/wnmt18/shared-task",
+                         src_lang="en",
+                         trg_lang="de",
+                         bpe_op=32000,
+                         train=[
+                             ("stanford_wmt14_train_en/train.en",
+                              "stanford_wmt14_train_de/train.de",
+                              TEXT_UTF8_TOKENIZED),
+                         ],
+                         dev=[
+                             ("stanford_wmt14_test2013_en/newstest2013.en",
+                              "stanford_wmt14_test2013_de/newstest2013.de",
+                              TEXT_UTF8_TOKENIZED),
+                         ],
+                         test=[
+                             ("stanford_wmt14_test2014_en/newstest2014.en",
+                              "stanford_wmt14_test2014_de/newstest2014.de",
+                              TEXT_UTF8_TOKENIZED),
+                             ("stanford_wmt14_test2015_en/newstest2015.en",
+                              "stanford_wmt14_test2015_de/newstest2015.de",
+                              TEXT_UTF8_TOKENIZED),
+                         ]),
+}

--- a/contrib/autopilot/test.py
+++ b/contrib/autopilot/test.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import os
+import subprocess
+import sys
+import tempfile
+
+# Make sure the version of sockeye being tested is first on the system path
+try:
+    import contrib.autopilot.autopilot as autopilot
+except ImportError:
+    SOCKEYE_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    PYTHONPATH = "PYTHONPATH"
+    if os.environ.get(PYTHONPATH, None):
+        os.environ[PYTHONPATH] += os.pathsep + SOCKEYE_ROOT
+    else:
+        os.environ[PYTHONPATH] = SOCKEYE_ROOT
+    sys.path.append(SOCKEYE_ROOT)
+    import contrib.autopilot.autopilot as autopilot
+
+
+# Test-specific constants
+WNMT_TASK = "wnmt18_en_de"
+DATA_ONLY_TASK = "wmt14_fr_en"
+WMT_TASK = "wmt14_de_en"
+WMT_SRC = "de"
+WMT_TRG = "en"
+WMT_BPE = 32000
+PREFIX_ZERO = "0."
+
+
+def main():
+    """
+    Build test systems with different types of pre-defined data and custom data
+    with all levels of pre-processing.
+    """
+    with tempfile.TemporaryDirectory(prefix="sockeye.autopilot.") as tmp_dir:
+        work_dir = os.path.join(tmp_dir, "workspace")
+
+        # WNMT task with pre-tokenized data
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--workspace={}".format(work_dir),
+                   "--task={}".format(WNMT_TASK),
+                   "--model=transformer",
+                   "--gpus=0",
+                   "--test"]
+        subprocess.check_call(command)
+
+        # WMT task, prepare data only
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--workspace={}".format(work_dir),
+                   "--task={}".format(DATA_ONLY_TASK),
+                   "--model=none",
+                   "--gpus=0",
+                   "--test"]
+        subprocess.check_call(command)
+
+        # WMT task with raw data
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--workspace={}".format(work_dir),
+                   "--task={}".format(WMT_TASK),
+                   "--model=transformer",
+                   "--gpus=0",
+                   "--test"]
+        subprocess.check_call(command)
+
+        # Custom task (raw data)
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--workspace={}".format(work_dir),
+                   "--custom-task=custom_raw",
+                   "--custom-train",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-dev",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_DEV + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_DEV + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-test",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-lang",
+                   WMT_SRC,
+                   WMT_TRG,
+                   "--custom-bpe-op={}".format(WMT_BPE),
+                   "--model=transformer",
+                   "--gpus=0",
+                   "--test"]
+        subprocess.check_call(command)
+
+        # Custom task (tokenized data)
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--workspace={}".format(work_dir),
+                   "--custom-task=custom_tok",
+                   "--custom-train",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-dev",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_DEV + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_DEV + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-test",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-text-type=tok",
+                   "--custom-bpe-op={}".format(WMT_BPE),
+                   "--model=transformer",
+                   "--gpus=0",
+                   "--test"]
+        subprocess.check_call(command)
+
+        # Custom task (byte-pair encoded data)
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--workspace={}".format(work_dir),
+                   "--custom-task=custom_bpe",
+                   "--custom-train",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-dev",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_DEV + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_DEV + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-test",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-text-type=bpe",
+                   "--model=transformer",
+                   "--gpus=0",
+                   "--test"]
+        subprocess.check_call(command)
+
+if __name__ == "__main__":
+    main()

--- a/contrib/autopilot/third_party.py
+++ b/contrib/autopilot/third_party.py
@@ -294,7 +294,7 @@ def merge_bpe(input_fname: str, output_fname: str):
             out.write(merged)
 
 
-def copy_out(source: Iterable[str], dest: io.TextIOWrapper, use_placeholders: bool = False):
+def copy_out(source: Iterable[bytes], dest: io.BytesIO, use_placeholders: bool = False):
     """
     Copy lines from source to destination.
 

--- a/contrib/autopilot/third_party.py
+++ b/contrib/autopilot/third_party.py
@@ -1,0 +1,315 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import io
+import gzip
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import threading
+from typing import Iterable, Optional
+
+from sockeye import utils
+
+
+DIR_THIRD_PARTY = "third_party"
+DIR_LOGS = "logs"
+
+# Moses, which contains the Moses tokenizer
+# License: LGPL-2.1
+MOSES_REPO = "https://github.com/moses-smt/mosesdecoder.git"
+# Paths to include in sparse checkout
+MOSES_SPARSE_CHECKOUT = ["COPYING", "scripts/share", "scripts/tokenizer"]
+MOSES_DEST = "mosesdecoder"
+MOSES_COMMIT = "686034488aad6ccee564e262aef9e07a85c1b784"
+
+# Subword-nmt, which contains a byte-pair encoding implementation
+# License: MIT
+SUBWORD_NMT_REPO = "https://github.com/rsennrich/subword-nmt.git"
+SUBWORD_NMT_DEST = "subword-nmt"
+SUBWORD_NMT_COMMIT = "9a95f9f7400a3a891a9d8168186229a54347fc0b"
+SUBWORD_SPECIAL = "@@"
+
+# Unicode underscore
+PLACEHOLDER = "▁".encode("utf-8")
+
+
+def bin_open(fname: str):
+    """
+    Returns a file descriptor for a plain text or gzipped file, binary read mode
+    for subprocess interaction.
+
+    :param fname: The filename to open.
+    :return: File descriptor in binary read mode.
+    """
+    if fname.endswith(".gz"):
+        return gzip.open(fname, "rb")
+    return open(fname, "rb")
+
+
+def check_git():
+    """Check if git command is available."""
+    try:
+        with open(os.devnull, "wb") as devnull:
+            subprocess.check_call(["git", "--version"], stdout=devnull, stderr=devnull)
+    except:
+        raise RuntimeError("Please make sure git is installed and on your path.")
+
+
+def check_perl():
+    """Check if perl command is available."""
+    try:
+        with open(os.devnull, "wb") as devnull:
+            subprocess.check_call(["perl", "--version"], stdout=devnull, stderr=devnull)
+    except:
+        raise RuntimeError("Please make sure perl is installed and on your path.")
+
+
+def checkout_moses_tokenizer(workspace_dir: str):
+    """
+    Checkout Moses tokenizer (sparse checkout of Moses).
+
+    :param workspace_dir: Workspace directory.
+    """
+    # Prerequisites
+    check_git()
+    check_perl()
+    # Check cache
+    dest = os.path.join(workspace_dir, DIR_THIRD_PARTY, MOSES_DEST)
+    if confirm_checkout(dest, MOSES_COMMIT):
+        logging.info("Usable: %s", dest)
+        return
+    # Need to (re-)checkout
+    if os.path.exists(dest):
+        shutil.rmtree(dest)
+    logging.info("Checkout: %s -> %s", MOSES_REPO, dest)
+    os.makedirs(dest)
+    log_fname = os.path.join(workspace_dir, DIR_LOGS, "checkout.{}.{}.log".format(MOSES_DEST, os.getpid()))
+    with open(log_fname, "wb") as log:
+        logging.info("Log: %s", log_fname)
+        subprocess.call(["git", "init"], cwd=dest, stdout=log, stderr=log)
+        subprocess.call(["git", "remote", "add", "origin", MOSES_REPO], cwd=dest, stdout=log, stderr=log)
+        subprocess.call(["git", "config", "core.sparsecheckout", "true"], cwd=dest, stdout=log, stderr=log)
+        with open(os.path.join(dest, ".git", "info", "sparse-checkout"), "w") as out:
+            for path in MOSES_SPARSE_CHECKOUT:
+                print(path, file=out)
+        subprocess.call(["git", "pull", "origin", "master"], cwd=dest, stdout=log, stderr=log)
+        subprocess.call(["git", "checkout", MOSES_COMMIT], cwd=dest, stdout=log, stderr=log)
+
+
+def checkout_subword_nmt(workspace_dir: str):
+    """
+    Checkout subword-nmt implementation of byte-pair encoding.
+
+    :param workspace_dir: Workspace third-party directory.
+    """
+    # Prerequisites
+    check_git()
+    # Check cache
+    dest = os.path.join(workspace_dir, DIR_THIRD_PARTY, SUBWORD_NMT_DEST)
+    if confirm_checkout(dest, SUBWORD_NMT_COMMIT):
+        logging.info("Usable: %s", dest)
+        return
+    # Need to (re-)checkout
+    if os.path.exists(dest):
+        shutil.rmtree(dest)
+    logging.info("Checkout: %s -> %s", SUBWORD_NMT_REPO, dest)
+    log_fname = os.path.join(workspace_dir, DIR_LOGS, "checkout.{}.{}.log".format(SUBWORD_NMT_DEST, os.getpid()))
+    with open(log_fname, "wb") as log:
+        logging.info("Log: %s", log_fname)
+        subprocess.call(["git", "clone", SUBWORD_NMT_REPO, dest], stdout=log, stderr=log)
+        subprocess.call(["git", "checkout", SUBWORD_NMT_COMMIT], cwd=dest, stdout=log, stderr=log)
+
+
+def confirm_checkout(dest: str, commit: str) -> bool:
+    """
+    Confirm that git repository is checked out.
+
+    :param dest: Local directory for checkout.
+    :param commit: Git commit.
+    :return: True if checkout is usable.
+    """
+    usable = False
+    if os.path.exists(dest):
+        try:
+            rev = subprocess.check_output(["git", "rev-parse", "--verify", "HEAD"], cwd=dest).decode("utf-8").strip()
+            usable = (rev == commit)
+        except subprocess.CalledProcessError:
+            pass
+        if not usable:
+            logging.info("Problem with %s, requires new checkout.", dest)
+    return usable
+
+
+def call_moses_tokenizer(workspace_dir: str,
+                         input_fname: str,
+                         output_fname: str,
+                         lang_code: str,
+                         num_threads: int = 4):
+    """
+    Call Moses tokenizer.
+
+    :param workspace_dir: Workspace third-party directory where Moses
+                            tokenizer is checked out.
+    :param input_fname: Path of raw input file, plain text or gzipped.
+    :param output_fname: Path of tokenized output file, gzipped.
+    :param lang_code: Language code for rules and non-breaking prefixes.
+    :param num_threads: Number of threads to use.
+    """
+    tokenizer_fname = os.path.join(workspace_dir,
+                                   DIR_THIRD_PARTY,
+                                   MOSES_DEST,
+                                   "scripts",
+                                   "tokenizer",
+                                   "tokenizer.perl")
+    with bin_open(input_fname) as inp, gzip.open(output_fname, "wb") as out, open(os.devnull, "wb") as devnull:
+        tokenizer = subprocess.Popen(["perl", tokenizer_fname, "-l", lang_code, "-threads", str(num_threads)],
+                                     stdin=subprocess.PIPE,
+                                     stdout=subprocess.PIPE,
+                                     stderr=devnull)
+        tokenizer_thread = threading.Thread(target=copy_out, args=(tokenizer.stdout, out))
+        tokenizer_thread.start()
+        for line in inp:
+            tokenizer.stdin.write(line)
+        tokenizer.stdin.close()
+        tokenizer_thread.join()
+        tokenizer.wait()
+
+
+def call_moses_detokenizer(workspace_dir: str, input_fname: str, output_fname: str, lang_code: Optional[str] = None):
+    """
+    Call Moses detokenizer.
+
+    :param workspace_dir: Workspace third-party directory where Moses
+                          tokenizer is checked out.
+    :param input_fname: Path of tokenized input file, plain text or gzipped.
+    :param output_fname: Path of tokenized output file, plain text.
+    :param lang_code: Language code for rules and non-breaking prefixes.  Can be
+                      None if unknown (using pre-tokenized data), which will
+                      cause the tokenizer to default to English.
+    """
+    detokenizer_fname = os.path.join(workspace_dir,
+                                     DIR_THIRD_PARTY,
+                                     MOSES_DEST,
+                                     "scripts",
+                                     "tokenizer",
+                                     "detokenizer.perl")
+    with bin_open(input_fname) as inp, open(output_fname, "wb") as out, open(os.devnull, "wb") as devnull:
+        command = ["perl", detokenizer_fname]
+        if lang_code:
+            command.append("-l")
+            command.append(lang_code)
+        detokenizer = subprocess.Popen(command,
+                                       stdin=subprocess.PIPE,
+                                       stdout=subprocess.PIPE,
+                                       stderr=devnull)
+        detokenizer_thread = threading.Thread(target=copy_out, args=(detokenizer.stdout, out))
+        detokenizer_thread.start()
+        for line in inp:
+            detokenizer.stdin.write(line)
+        detokenizer.stdin.close()
+        detokenizer_thread.join()
+        detokenizer.wait()
+
+
+def call_learn_bpe(workspace_dir: str, source_fname: str, target_fname: str, model_fname: str, num_ops: int = 32000):
+    """
+    Call script to learn byte-pair encoding model.
+
+    :param workspace_dir: Workspace third-party directory where subword-nmt is
+                            checked out.
+    :param source_fname: Path of source corpus file, plain text or gzipped.
+    :param target_fname: Path of target corpus file, plain text or gzipped.
+    :param model_fname: Path to write out model.
+    :param num_ops: Number of operations.
+    """
+    learn_bpe_fname = os.path.join(workspace_dir, DIR_THIRD_PARTY, SUBWORD_NMT_DEST, "learn_bpe.py")
+    with bin_open(source_fname) as src_in, bin_open(target_fname) as trg_in, open(model_fname, "wb") as out:
+        learn_bpe = subprocess.Popen([sys.executable, learn_bpe_fname, "-s", str(num_ops)],
+                                     stdin=subprocess.PIPE,
+                                     stdout=subprocess.PIPE)
+        learn_bpe_thread = threading.Thread(target=copy_out, args=(learn_bpe.stdout, out))
+        learn_bpe_thread.start()
+        for inp in (src_in, trg_in):
+            for line in inp:
+                learn_bpe.stdin.write(line)
+        learn_bpe.stdin.close()
+        learn_bpe_thread.join()
+        learn_bpe.wait()
+
+
+def call_apply_bpe(workspace_dir: str, input_fname: str, output_fname: str, model_fname: str):
+    """
+    Call BPE apply script.
+
+    :param workspace_dir: Workspace directory where subword-nmt is checked out.
+    :param input_fname: Path of tokenized input file, plain text or gzipped.
+    :param output_fname: Path of byte-pair encoded output file, gzipped.
+    :param model_fname: Path of BPE model file (codes).
+    """
+    apply_bpe_fname = os.path.join(workspace_dir, DIR_THIRD_PARTY, SUBWORD_NMT_DEST, "apply_bpe.py")
+    with bin_open(input_fname) as inp, gzip.open(output_fname, "wb") as out:
+        apply_bpe = subprocess.Popen([sys.executable, apply_bpe_fname, "-c", model_fname],
+                                     stdin=subprocess.PIPE,
+                                     stdout=subprocess.PIPE)
+        apply_bpe_thread = threading.Thread(target=copy_out, args=(apply_bpe.stdout, out, True))
+        apply_bpe_thread.start()
+        for line in inp:
+            # Use an empty line placeholder to avoid blank line duplication
+            # issues with BPE script
+            if not line.strip():
+                line = PLACEHOLDER + b"\n"
+            apply_bpe.stdin.write(line)
+        apply_bpe.stdin.close()
+        apply_bpe_thread.join()
+        apply_bpe.wait()
+
+
+def merge_bpe(input_fname: str, output_fname: str):
+    """
+    Merge byte-pair encoded sub-words.
+
+    :param input_fname: Path of byte-pair encoded input file, plain text or
+                        gzipped.
+    :param output_fname: Path of tokenized output file, plain text.
+    """
+    with utils.smart_open(input_fname, "r") as inp, open(output_fname, "w", encoding="utf-8") as out:
+        for line in inp:
+            # Merge on special markers and strip stray markers (end of line)
+            merged = line.replace(SUBWORD_SPECIAL + " ", "").replace(SUBWORD_SPECIAL, "")
+            out.write(merged)
+
+
+def copy_out(source: Iterable[str], dest: io.TextIOWrapper, use_placeholders: bool = False):
+    """
+    Copy lines from source to destination.
+
+    :param source: Source line iterable.
+    :param dest: Destination open file.
+    :param use_placeholders: When true, convert lines containing placeholders to
+                             empty lines and drop true empty lines (assume to be
+                             spuriously generated).
+    """
+    for line in source:
+        if use_placeholders:
+            # True empty lines are assumed to be spurious as the placeholder
+            # should be passed through
+            if not line.strip():
+                continue
+            if line.startswith(PLACEHOLDER):
+                line = b"\n"
+        dest.write(line)

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ else:
 
 entry_points={
     'console_scripts': [
+        'sockeye-autopilot = contrib.autopilot.autopilot:main',
         'sockeye-average = sockeye.average:main',
         'sockeye-embeddings = sockeye.embeddings:main',
         'sockeye-evaluate = sockeye.evaluate:main',
@@ -102,7 +103,7 @@ args = dict(
     maintainer_email='sockeye-dev@amazon.com',
 
     license='Apache License 2.0',
-    
+
     python_requires='>=3',
 
     packages=find_packages(exclude=("test",)),

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.13'
+__version__ = '1.18.14'


### PR DESCRIPTION
This merges in Sockeye Autopilot, a module that provides single-command end-to-end NMT system building.  See [`contrib/autopilot/README.md`](https://github.com/awslabs/sockeye/tree/autopilot/contrib/autopilot/README.md) for a full description.

This is a `contrib` module that depends on but does not change the `sockeye` module.  Required third-party tools are downloaded at runtime, removing the need to check these tools into the Sockeye repository.  Autopilot passes the same checks as the core code and has its own system tests, `contrib/test.py`.  Any feedback is welcome, though this probably doesn't require the same level of detailed review as core Sockeye code.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] `contrib/autopilot/test.py` passes
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

