### PR TITLE
Removed summation of gradient arrays when logging gradients. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
 ## [1.18.15]
+### Fixed
+- Removed summation of gradient arrays when logging gradients.
+  This clogged the memory on the primary GPU device over time when many checkpoints were done.
+  Gradient histograms are now logged to Tensorboard separated by device.
+
+## [1.18.15]
 ### Added
 - Added decoding with target-side lexical constraints (documentation in `tutorials/constraints`).
 

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.15'
+__version__ = '1.18.16'

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -197,11 +197,11 @@ class TrainingModel(model.SockeyeModel):
 
     def get_gradients(self) -> Dict[str, List[mx.nd.NDArray]]:
         """
-        Returns a mapping of parameters to gradient arrays, summed across devices.
+        Returns a mapping of parameters names to gradient arrays. Parameter names are prefixed with the device.
         """
-        return {name: mx.nd.add_n(*(exe.grad_arrays[i] for exe in self.executors)) for i, name in
+        return {"dev_%d_%s" % (i, name): exe.grad_arrays[j] for i, exe in enumerate(self.executors) for j, name in
                 enumerate(self.executor_group.arg_names)
-                if name in self.executor_group.param_names and self.executors[0].grad_arrays[i] is not None}
+                if name in self.executor_group.param_names and self.executors[0].grad_arrays[j] is not None}
                 # We may have None if not all parameters are optimized
 
     def get_global_gradient_norm(self) -> float:
@@ -387,7 +387,7 @@ class TrainState:
         self.updates = 0
         self.samples = 0
         self.gradient_norm = None  # type: Optional[float]
-        self.gradients = None  # type: Optional[Dict[str, List[mx.nd.NDArray]]]
+        self.gradients = {}  # type: Dict[str, List[mx.nd.NDArray]]
         # stores dicts of metric names & values for each checkpoint
         self.metrics = []  # type: List[Dict]
         self.start_tic = time.time()


### PR DESCRIPTION
This clogged the memory on the primary GPU device over time when many checkpoints were done. Gradient histograms are now logged to Tensorboard separated by device.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

