### PR TITLE
Update Autopilot tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then python -m pytest -k "Copy:transformer:transformer" --maxfail=1 test/system; fi
   - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then python -m pytest -k "Copy:cnn:cnn" --maxfail=1 test/system; fi
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then python -m pytest --maxfail=1 test/system; fi
+  - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then python -m contrib.autopilot.test; fi
 
 # Deploy all tagged versions to PyPI
 deploy:

--- a/contrib/autopilot/autopilot.py
+++ b/contrib/autopilot/autopilot.py
@@ -94,6 +94,9 @@ AVERAGE_STRATEGY = "best"
 PARAMS_BEST_SINGLE = "params.best.single"
 PARAMS_AVERAGE = "params.average"
 
+# Scaled down settings for test mode
+TEST_BPE_OPS = 1024
+
 
 def identify_raw_files(task: Task, test_mode: bool = False) -> List[str]:
     """
@@ -356,8 +359,11 @@ def call_sockeye_train(args: List[str],
         command.append("--use-cpu")
     # Test mode stops after a small number of updates
     if test_mode:
-        command.append("--max-updates=10")
-        command.append("--checkpoint-frequency=5")
+        command.append("--num-words=64:64")
+        command.append("--batch-type=sentence")
+        command.append("--batch-size=1")
+        command.append("--max-updates=4")
+        command.append("--checkpoint-frequency=2")
     command_fname = os.path.join(model_dir, FILE_COMMAND.format("sockeye.train"))
     # Run unless training already finished
     if not os.path.exists(command_fname):
@@ -670,6 +676,8 @@ def run_steps(args: argparse.Namespace):
             target_fname = os.path.join(step_dir_tok, PREFIX_TRAIN + SUFFIX_TRG_GZ)
             codes_fname = os.path.join(step_dir_bpe_model, FILE_BPE_CODES)
             num_ops = task.bpe_op if args.task else args.custom_bpe_op
+            if args.test:
+                num_ops = TEST_BPE_OPS
             logging.info("BPE Learn (%s): %s + %s -> %s", num_ops, source_fname, target_fname, codes_fname)
             third_party.call_learn_bpe(workspace_dir=args.workspace,
                                        source_fname=source_fname,


### PR DESCRIPTION
This updates and automates testing for Autopilot.  Tests now run in around 12 minutes on a MacBook Pro and use about 1.2G of disk space (bottlenecked on training and storing 2 parameter files for averaging).  If any test fails, the relevant log is printed to stderr.

There's also a line adding this to Travis as a cron test.  If the disk space is an issue we can further reduce the model size, though the goal is to run at least a few updates on something very close to the actual models we'll be training.

Nothing changes from the user perspective, but we could also update the version/changelog if we want to be super detailed.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Autopilot tests pass (` python -m contrib.autopilot.test`)
- [x] Passed code style checking (`./style-check.sh`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

