### PR TITLE
Further trim down Autopilot tests for Travis cron.

### DIFF
--- a/contrib/autopilot/autopilot.py
+++ b/contrib/autopilot/autopilot.py
@@ -43,7 +43,7 @@ from contrib.autopilot.tasks import TEXT_UTF8_RAW_BITEXT_REVERSE, TEXT_REQUIRES_
 from contrib.autopilot.tasks import TEXT_UTF8_TOKENIZED
 from contrib.autopilot.tasks import RAW_FILES
 from contrib.autopilot.tasks import Task, TASKS
-from contrib.autopilot.models import MODELS, MODEL_NONE
+from contrib.autopilot.models import MODELS, MODEL_NONE, MODEL_TEST_ARGS
 from contrib.autopilot.models import DECODE_ARGS, DECODE_STANDARD
 from contrib.autopilot import third_party
 
@@ -357,13 +357,9 @@ def call_sockeye_train(args: List[str],
         command.append("--device-ids=-{}".format(num_gpus))
     else:
         command.append("--use-cpu")
-    # Test mode stops after a small number of updates
+    # Test mode trains a smaller model for a small number of steps
     if test_mode:
-        command.append("--num-words=64:64")
-        command.append("--batch-type=sentence")
-        command.append("--batch-size=1")
-        command.append("--max-updates=4")
-        command.append("--checkpoint-frequency=2")
+        command += MODEL_TEST_ARGS
     command_fname = os.path.join(model_dir, FILE_COMMAND.format("sockeye.train"))
     # Run unless training already finished
     if not os.path.exists(command_fname):

--- a/contrib/autopilot/models.py
+++ b/contrib/autopilot/models.py
@@ -61,6 +61,21 @@ MODELS = {
     ],
 }  # type: Dict[str, List[str]]
 
+# Arguments added to the end of any model in test mode to train a smaller
+# version quickly for system tests.  When multiple versions of the same argument
+# exist, the last version to appear (this list) takes precedence.
+MODEL_TEST_ARGS = [
+    "--num-layers=1:1",
+    "--transformer-model-size=16",
+    "--transformer-feed-forward-num-hidden=16",
+    "--num-embed=16:16",
+    "--num-words=16:16",
+    "--batch-type=sentence",
+    "--batch-size=1",
+    "--max-updates=4",
+    "--checkpoint-frequency=2",
+]
+
 # Decoding configurations
 DECODE_ARGS = {
     DECODE_STANDARD: [


### PR DESCRIPTION
It looks like the previous version was still timing out.  This update adds special test args to training to reduce number of layers, layer size, etc.  This wasn't the first choice since we want to test something as close to an actual model as possible, but this is still testing that all of the components run together end-to-end to produce some output with some model.

The full set of tests should now run in 2-3 minutes total.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

