### PR TITLE
Inference mypy fix

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,7 +3,7 @@ pytest-cov
 pillow
 check-manifest
 matplotlib
-mypy>=0.6
+mypy==0.610
 pylint
 setuptools>=38.6.0
 twine>=1.11.0

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -562,7 +562,7 @@ def get_max_input_output_length(supported_max_seq_len_source: Optional[int],
     return max_input_len, get_max_output_length
 
 
-BeamHistory = Dict[str, Union[int, List]]
+BeamHistory = Dict[str, List]
 Tokens = List[str]
 
 
@@ -1622,8 +1622,8 @@ class Translator:
         sequence = sequence[:length].asnumpy().tolist()
         attention_matrix = np.stack(attention_lists.asnumpy()[:length, :], axis=0)
         score = seq_score.asscalar()
-        beam_history = [beam_history] if beam_history is not None else []
-        return Translation(sequence, attention_matrix, score, beam_history)
+        beam_history_list = [beam_history] if beam_history is not None else []
+        return Translation(sequence, attention_matrix, score, beam_history_list)
 
     def _print_beam(self,
                     sequences: mx.nd.NDArray,

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -562,7 +562,7 @@ def get_max_input_output_length(supported_max_seq_len_source: Optional[int],
     return max_input_len, get_max_output_length
 
 
-BeamHistory = Dict[str, List]
+BeamHistory = Dict[str, Union[int, List]]
 Tokens = List[str]
 
 
@@ -796,17 +796,17 @@ TokenIds = List[int]
 
 
 class Translation:
-    __slots__ = ('target_ids', 'attention_matrix', 'score', 'beam_history')
+    __slots__ = ('target_ids', 'attention_matrix', 'score', 'beam_histories')
 
     def __init__(self,
                  target_ids: TokenIds,
                  attention_matrix: np.ndarray,
                  score: float,
-                 beam_history: List[Optional[BeamHistory]] = None) -> None:
+                 beam_history: List[BeamHistory] = None) -> None:
         self.target_ids = target_ids
         self.attention_matrix = attention_matrix
         self.score = score
-        self.beam_history = beam_history
+        self.beam_histories = beam_history if beam_history is not None else []
 
 
 def empty_translation() -> Translation:
@@ -907,9 +907,7 @@ def _concat_translations(translations: List[Translation], start_id: int, stop_id
             else:
                 target_ids.extend(translation.target_ids[1:])
                 attention_matrices.append(translation.attention_matrix[1:, :])
-        if translation.beam_history:
-            # Make a list of the individual beam histories
-            beam_histories.append(translation.beam_history[0])
+        beam_histories.extend(translation.beam_histories)
 
     # Combine attention matrices:
     attention_shapes = [attention_matrix.shape for attention_matrix in attention_matrices]
@@ -1218,17 +1216,12 @@ class Translator:
             tok for target_id, tok in zip(target_ids, target_tokens) if target_id not in self.strip_ids)
         attention_matrix = attention_matrix[:, :len(trans_input.tokens)]
 
-        if isinstance(translation.beam_history, list):
-            beam_histories = translation.beam_history
-        else:
-            beam_histories = [translation.beam_history]
-
         return TranslatorOutput(id=trans_input.sentence_id,
                                 translation=target_string,
                                 tokens=target_tokens,
                                 attention_matrix=attention_matrix,
                                 score=translation.score,
-                                beam_histories=beam_histories)
+                                beam_histories=translation.beam_histories)
 
     def _concat_translations(self, translations: List[Translation]) -> Translation:
         """
@@ -1611,7 +1604,7 @@ class Translator:
                               length: mx.nd.NDArray,
                               attention_lists: mx.nd.NDArray,
                               seq_score: mx.nd.NDArray,
-                              beam_history: List[Optional[BeamHistory]]) -> Translation:
+                              beam_history: Optional[BeamHistory]) -> Translation:
         """
         Takes a set of data pertaining to a single translated item, performs slightly different
         processing on each, and merges it into a Translation object.
@@ -1629,6 +1622,7 @@ class Translator:
         sequence = sequence[:length].asnumpy().tolist()
         attention_matrix = np.stack(attention_lists.asnumpy()[:length, :], axis=0)
         score = seq_score.asscalar()
+        beam_history = [beam_history] if beam_history is not None else []
         return Translation(sequence, attention_matrix, score, beam_history)
 
     def _print_beam(self,

--- a/sockeye/output_handler.py
+++ b/sockeye/output_handler.py
@@ -291,7 +291,7 @@ class BeamStoringHandler(OutputHandler):
         :param t_output: Translator output.
         :param t_walltime: Total wall-clock time for translation.
         """
-        assert len(t_output.beam_histories) >= 1, "Translator output should  contain beam histories."
+        assert len(t_output.beam_histories) >= 1, "Translator output should contain beam histories."
         # If the sentence was max_len split, we may have more than one history
         for h in t_output.beam_histories:
             # Add the number of steps in each beam


### PR DESCRIPTION
While looking into the following type inference error of the new mypy version (0.6.1)
```
sockeye/inference.py:1224: error: List item 0 has incompatible type "List[Optional[Dict[str, List[Any]]]]"; expected "Dict[str, List[Any]]"
```
I noticed that `_concat_translations` did not work correctly when beam_histories were present. The individual `Translation` objects did not contain lists of beam histories, but rather single objects, so that `translation.beam_history[0]` did not take the first and only element, but rather returned an empty list (as we use defaultdicts).

I fixed the issue and also the mypy type inference problems. This should fix CI. Additionally I fixed the mypy version in the requirements.dev.txt to manually update to new mypy versions in the future.

#### Pull Request Checklist ##
- [X] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [X] Unit tests pass (`pytest`)
- [X] Passed code style checking (`./style-check.sh`)
- [X] You have considered writing a test


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

