### PR TITLE
Fix for transformer-with-conv-embed encoder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.23]
+### Fixed
+- Correctly create the convolutional embedding layers when the encoder is set to `transformer-with-conv-embed`. Previously
+no convolutional layers were added so that a standard Transformer model was trained instead.
+
 ## [1.18.22]
 ### Fixed
 - Make sure the default bucket is large enough with word based batching when the source is longer than the target (Previously

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.22'
+_version__ = '1.18.23'

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-_version__ = '1.18.23'
+__version__ = '1.18.23'

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -606,6 +606,14 @@ def create_model_config(args: argparse.Namespace,
                                                            pool_stride=args.conv_embed_pool_stride,
                                                            num_highway_layers=args.conv_embed_num_highway_layers,
                                                            dropout=args.conv_embed_dropout)
+    if args.encoder == C.TRANSFORMER_WITH_CONV_EMBED_TYPE:
+        config_conv = encoder.ConvolutionalEmbeddingConfig(num_embed=num_embed_source,
+                                                           output_dim=num_embed_source,
+                                                           max_filter_width=args.conv_embed_max_filter_width,
+                                                           num_filters=args.conv_embed_num_filters,
+                                                           pool_stride=args.conv_embed_pool_stride,
+                                                           num_highway_layers=args.conv_embed_num_highway_layers,
+                                                           dropout=args.conv_embed_dropout)
 
     config_encoder, encoder_num_hidden = create_encoder_config(args, max_seq_len_source, max_seq_len_target,
                                                                config_conv)


### PR DESCRIPTION
When the encoder model was `TRANSFORMER_WITH_CONV_EMBED_TYPE ` we didn't actually create the convolutional embedding config.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

