### PR TITLE
Top-K lexicon update: defaults, files for running fast_align in contrib.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.24]
+### Added
+- Dockerfiles and convenience scripts for running `fast_align` to generate lexical tables.
+These tables can be used to create top-K lexicons for faster decoding via vocabulary selection ([documentation](https://github.com/awslabs/sockeye/tree/master/contrib/fast_align)).
+
+### Changed
+- Updated default top-K lexicon size from 20 to 200.
+
 ## [1.18.23]
 ### Fixed
 - Correctly create the convolutional embedding layers when the encoder is set to `transformer-with-conv-embed`. Previously

--- a/contrib/fast_align/Dockerfile
+++ b/contrib/fast_align/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+FROM amazonlinux:2017.09.0.20170930
+
+RUN yum install -y \
+    cmake \
+    git \
+    gcc \
+    gcc-c++ \
+    gperftools-devel \
+    && yum clean all
+
+ENV FAST_ALIGN_COMMIT 7c2bbca3d5d61ba4b0f634f098c4fcf63c1373e1
+RUN cd /opt \
+    && git clone https://github.com/clab/fast_align.git \
+    && cd fast_align \
+    && git reset --hard ${FAST_ALIGN_COMMIT} \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && make
+ENV PATH ${PATH}:/opt/fast_align/build

--- a/contrib/fast_align/README.md
+++ b/contrib/fast_align/README.md
@@ -1,0 +1,30 @@
+# fast_align
+
+[[Dyer et al., 2013](http://www.aclweb.org/anthology/N13-1073)] [[GitHub Page](https://github.com/clab/fast_align)]
+
+`fast_align` is a fast and reliable word aligner that can be used to generate probabilistic lexicons.
+These lexicons can then be used with Sockeye to speed up decoding by limiting each step's output layer to the most likely word-level translations of the source.
+
+This directory contains a Dockerfile and convenience script for generating `fast_align` lexical tables from the data used to train Sockeye models.
+
+## Running
+
+Install [Docker](https://www.docker.com/) and run the following script to build the `fast_align` image:
+
+```bash
+./build.sh
+```
+
+Given parallel training data for Sockeye (for instance, sentences.de and sentences.en), run the following script to generate a lexical table:
+
+```bash
+ ./lex_table.sh sentences.de sentences.en lex.out
+```
+
+This file can then be converted to Sockeye lexicon using:
+
+```bash
+python -m sockeye.lexicon create --input lex.out ...
+```
+
+This requires a trained Sockeye model and the resulting lexicon is specific to that model.

--- a/contrib/fast_align/build.sh
+++ b/contrib/fast_align/build.sh
@@ -1,4 +1,6 @@
-# Copyright 2017, 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#!/usr/bin/env bash
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -11,4 +13,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.24'
+# Make sure we are running from the fast_align directory
+cd $(dirname $0)
+
+docker build -t fast_align -f Dockerfile .

--- a/contrib/fast_align/lex_table.sh
+++ b/contrib/fast_align/lex_table.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+if [ $(docker images -q fast_align |wc -l) -lt 1 ]; then
+    echo "Please install Docker and run build.sh to create the fast_align image." >&2
+    exit 2
+fi
+
+if [ $# -lt 3 ]; then
+    echo "Create lex table with fast_align" >&2
+    echo "Usage: ${0} train.src train.trg lex.out" >&2
+    exit 2
+fi
+
+# Bitext format: source ||| target
+# Plus a few tricks for macOS compatibility
+TAB=$'\t'
+LEX_FILE=$(cd "$(dirname "$3")" && pwd -P)/$(basename "$3")
+paste <(zcat -f <"$1") <(zcat -f <"$2") |sed -e "s/${TAB}/ ||| /g" > "$LEX_FILE".tmp
+
+# Run fast_align with recommended settings, write lex table but not alignments
+touch "$LEX_FILE"
+docker run --rm -i -v "$LEX_FILE".tmp:/input -v "$LEX_FILE":/lexicon fast_align fast_align -i /input -v -d -o -p /lexicon -t -1000000 >/dev/null
+
+# Cleanup
+rm "$LEX_FILE".tmp

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -54,7 +54,7 @@ class ConfigArgumentParser(argparse.ArgumentParser):
         def _new_add_argument(this_self, *args, **kwargs):
             action = this_self.original_add_argument(*args, **kwargs)
             this_self.config_container._register_argument(action, *args, **kwargs)
-        
+
         original_object.original_add_argument = original_object.add_argument
         original_object.config_container = self
         original_object.add_argument = types.MethodType(_new_add_argument, original_object)
@@ -286,7 +286,7 @@ def add_lexicon_args(params):
     lexicon_params = params.add_argument_group("Model & Top-k")
     lexicon_params.add_argument("--model", "-m", required=True,
                                 help="Model directory containing source and target vocabularies.")
-    lexicon_params.add_argument("-k", type=int, default=20,
+    lexicon_params.add_argument("-k", type=int, default=200,
                                 help="Number of target translations to keep per source. Default: %(default)s.")
 
 

--- a/sockeye/lexicon.py
+++ b/sockeye/lexicon.py
@@ -319,7 +319,7 @@ def main():
     params = argparse.ArgumentParser(description="Create or inspect a top-k lexicon for use during decoding.")
     subparams = params.add_subparsers(title="Commands")
 
-    params_create = subparams.add_parser('create', description="Create top-k lexicon for use during decoding.")
+    params_create = subparams.add_parser('create', description="Create top-k lexicon for use during decoding. See contrib/fast_align/README.md for information on creating input lexical tables.")
     arguments.add_lexicon_args(params_create)
     arguments.add_lexicon_create_args(params_create)
     arguments.add_logging_args(params_create)


### PR DESCRIPTION
This expands our functionality for learning and using top-k lexicons to speed up CPU decoding.  The idea is that users should be able to take advantage of this functionality without manually installing and running software in addition to Sockeye.
- Add convenience files for running `fast_align` to contrib.  This is done via Docker as there are unfortunately no Python bindings for `fast_align`.  There is also a short convenience script for running `fast_align` to produce lex tables.
- Add reference to contrib/fast_align to the lexicon module help message.
- Update default size of top-k lexicon to 200 for better quality.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.