### PR TITLE
bugfix: check for symlink existence before creating

### DIFF
--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -927,8 +927,10 @@ class EarlyStoppingTrainer:
 
         # (1) Parameters: link current file
         params_base_fname = C.PARAMS_NAME % self.state.checkpoint
-        os.symlink(os.path.join("..", params_base_fname),
-                   os.path.join(training_state_dirname, C.TRAINING_STATE_PARAMS_NAME))
+        params_file = os.path.join(training_state_dirname, C.TRAINING_STATE_PARAMS_NAME)
+        if os.path.exists(params_file):
+            os.unlink(params_file)
+        os.symlink(os.path.join("..", params_base_fname), params_file)
 
         # (2) Optimizer states
         opt_state_fname = os.path.join(training_state_dirname, C.OPT_STATES_LAST)


### PR DESCRIPTION
Occasionally this symlink exists and then the whole training procedures dies. My guess is that stray NFS files prevent the deletion of the temporary directory from the previous round. The other files are safely overwritten because they use direct writes instead of a symlink. This should solve that problem.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
