### PR TITLE
Added new docs yml file to Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,6 +19,7 @@ recursive-include docs *.bat
 recursive-include docs *.md
 recursive-include docs *.py
 recursive-include docs *.rst
+recursive-include docs *.yml
 recursive-include docs Makefile
 recursive-include tutorials *.md
 recursive-include tutorials *.png


### PR DESCRIPTION
fixes the failing travis builds.
```
$ check-manifest --ignore sockeye/git_version.py
lists of files in version control and sdist do not match!
missing from sdist:
  docs/_config.yml
suggested MANIFEST.in rules:
  recursive-include docs *.yml
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

