### PR TITLE
Unrestricted vocabulary by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.29]
+- No longer restrict the vocabulary to 50,000 words by default, but rather create the vocabulary from all words which occur at least `--word-min-count` times. Specifying `--num-words` explicitly will still lead to a restricted
+  vocabulary.
+
 ## [1.18.28]
 ### Changed
 - Temporarily fixing the pyyaml version to 3.12 as version 4.1 introduced some backwards incompatible changes.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.28'
+__version__ = '1.18.29'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -474,8 +474,10 @@ def add_vocab_args(params):
                              'Will be automatically turned on when using weight tying. Default: %(default)s.')
     params.add_argument('--num-words',
                         type=multiple_values(num_values=2, greater_or_equal=0),
-                        default=(50000, 50000),
+                        default=(0, 0),
                         help='Maximum vocabulary size. Use "x:x" to specify separate values for src&tgt. '
+                             'A value of 0 indicates that the vocabulary unrestricted and determined from the data by '
+                             'creating an entry for all words that occur at least --word-min-count times.'
                              'Default: %(default)s.')
     params.add_argument('--word-min-count',
                         type=multiple_values(num_values=2, greater_or_equal=1),

--- a/sockeye/prepare_data.py
+++ b/sockeye/prepare_data.py
@@ -51,6 +51,9 @@ def prepare_data(args: argparse.Namespace):
     source_vocab_paths = [args.source_vocab] + source_factor_vocab_paths
 
     num_words_source, num_words_target = args.num_words
+    num_words_source = num_words_source if num_words_source > 0 else None
+    num_words_target = num_words_target if num_words_target > 0 else None
+
     word_min_count_source, word_min_count_target = args.word_min_count
     max_seq_len_source, max_seq_len_target = args.max_seq_len
     # The maximum length is the length before we add the BOS/EOS symbols

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -268,6 +268,9 @@ def create_data_iters_and_vocabs(args: argparse.Namespace,
     :return: The data iterators (train, validation, config_data) as well as the source and target vocabularies.
     """
     num_words_source, num_words_target = args.num_words
+    num_words_source = num_words_source if num_words_source > 0 else None
+    num_words_target = num_words_target if num_words_target > 0 else None
+
     word_min_count_source, word_min_count_target = args.word_min_count
     batch_num_devices = 1 if args.use_cpu else sum(-di if di < 0 else 1 for di in args.device_ids)
     batch_by_words = args.batch_type == C.BATCH_TYPE_WORD

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -35,7 +35,7 @@ from itertools import zip_longest
           validation_source='test_validation_src', validation_target='test_validation_tgt',
           validation_source_factors=[],
           output='test_output', overwrite_output=False,
-          source_vocab=None, target_vocab=None, shared_vocab=False, num_words=(50000, 50000), word_min_count=(1, 1),
+          source_vocab=None, target_vocab=None, shared_vocab=False, num_words=(0, 0), word_min_count=(1, 1),
           no_bucketing=False, bucket_width=10, max_seq_len=(99, 99),
           monitor_pattern=None, monitor_stat_func='mx_default')),
 
@@ -49,7 +49,7 @@ from itertools import zip_longest
           validation_source='test_validation_src', validation_target='test_validation_tgt',
           validation_source_factors=[],
           output='test_output', overwrite_output=False,
-          source_vocab=None, target_vocab=None, shared_vocab=False, num_words=(50000, 50000), word_min_count=(1, 1),
+          source_vocab=None, target_vocab=None, shared_vocab=False, num_words=(0, 0), word_min_count=(1, 1),
           no_bucketing=False, bucket_width=10, max_seq_len=(99, 99),
           monitor_pattern=None, monitor_stat_func='mx_default'))
 ])
@@ -333,7 +333,7 @@ def test_tutorial_averaging_args(test_params, expected_params, expected_params_p
           target_vocab=None,
           source_factors=[],
           shared_vocab=False,
-          num_words=(50000, 50000),
+          num_words=(0, 0),
           word_min_count=(1, 1),
           no_bucketing=False,
           bucket_width=10,
@@ -355,7 +355,7 @@ def test_tutorial_prepare_data_cli_args(test_params, expected_params):
           target_vocab=None,
           source_factors=[],
           shared_vocab=False,
-          num_words=(50000, 50000),
+          num_words=(0, 0),
           word_min_count=(1, 1),
           no_bucketing=False,
           bucket_width=10,


### PR DESCRIPTION
It was not obvious to users that Sockeye had this default restriction to 50,000 words so that it potentially silently restricted the vocabulary without the user being aware. We still have the option to explicitly restrict the vocabulary, but now by default it is built based on all observed words. This especially makes sense if one uses character based or sub-word unit based models, which at least in MT is the default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

