### PR TITLE
Fixing the pyyaml version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.28]
+### Changed
+- Temporarily fixing the pyyaml version to 3.12 as version 4.1 introduced some backwards incompatible changes.
 
 ## [1.18.27]
 ### Fixed

--- a/requirements/requirements.docs.txt
+++ b/requirements/requirements.docs.txt
@@ -2,4 +2,4 @@ sphinx>=1.7.4
 sphinx_rtd_theme
 sphinx-autodoc-typehints>=1.3.0
 recommonmark
-pyyaml
+pyyaml==3.12

--- a/requirements/requirements.gpu-cu75.txt
+++ b/requirements/requirements.gpu-cu75.txt
@@ -1,4 +1,4 @@
-pyyaml
+pyyaml==3.12
 mxnet-cu75mkl==1.2.0
 numpy>=1.12
 typing

--- a/requirements/requirements.gpu-cu80.txt
+++ b/requirements/requirements.gpu-cu80.txt
@@ -1,4 +1,4 @@
-pyyaml
+pyyaml==3.12
 mxnet-cu80mkl==1.2.0
 numpy>=1.12
 typing

--- a/requirements/requirements.gpu-cu90.txt
+++ b/requirements/requirements.gpu-cu90.txt
@@ -1,4 +1,4 @@
-pyyaml
+pyyaml==3.12
 mxnet-cu90mkl==1.2.0
 numpy>=1.12
 typing

--- a/requirements/requirements.gpu-cu91.txt
+++ b/requirements/requirements.gpu-cu91.txt
@@ -1,4 +1,4 @@
-pyyaml
+pyyaml==3.12
 mxnet-cu91mkl==1.2.0
 numpy>=1.12
 typing

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-pyyaml
+pyyaml==3.12
 mxnet-mkl==1.2.0
 numpy>=1.12
 typing

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.27'
+__version__ = '1.18.28'


### PR DESCRIPTION
The new pyyaml version is introducing some issues, which we should fix. For now let's depend on the old version to unblock Travis.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

