### PR TITLE
Log __file__ of sockeye & mxnet version. Small cleanups

### DIFF
--- a/sockeye/image_captioning/train.py
+++ b/sockeye/image_captioning/train.py
@@ -274,7 +274,7 @@ def main():
     # TODO: make training compatible with full net
     args.image_preextracted_features = True  # override this for now
 
-    utils.seedRNGs(args.seed)
+    utils.seed_rngs(args.seed)
 
     check_arg_compatibility(args)
     output_folder = os.path.abspath(args.output)

--- a/sockeye/log.py
+++ b/sockeye/log.py
@@ -139,14 +139,14 @@ def setup_main_logger(name: str, file_logging=True, console=True, path: Optional
 
 
 def log_sockeye_version(logger):
-    from sockeye import __version__
+    from sockeye import __version__, __file__
     try:
         from sockeye.git_version import git_hash
     except ImportError:
         git_hash = "unknown"
-    logger.info("Sockeye version %s commit %s", __version__, git_hash)
+    logger.info("Sockeye version %s, commit %s, path %s", __version__, git_hash, __file__)
 
 
 def log_mxnet_version(logger):
-    from mxnet import __version__
-    logger.info("MXNet version %s", __version__)
+    from mxnet import __version__, __file__
+    logger.info("MXNet version %s, path %s", __version__, __file__)

--- a/sockeye/prepare_data.py
+++ b/sockeye/prepare_data.py
@@ -38,7 +38,7 @@ def prepare_data(args: argparse.Namespace):
     global logger
     logger = setup_main_logger(__name__, file_logging=True, path=os.path.join(output_folder, C.LOG_NAME))
 
-    utils.seedRNGs(args.seed)
+    utils.seed_rngs(args.seed)
 
     minimum_num_shards = args.min_num_shards
     samples_per_shard = args.num_samples_per_shard

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -775,7 +775,7 @@ def train(args: argparse.Namespace):
         args.output = temp_dir.name
         args.max_updates = 0
 
-    utils.seedRNGs(args.seed)
+    utils.seed_rngs(args.seed)
 
     check_arg_compatibility(args)
     output_folder = os.path.abspath(args.output)

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -15,6 +15,7 @@
 A set of utility methods.
 """
 import errno
+import fcntl
 import glob
 import gzip
 import itertools
@@ -28,7 +29,6 @@ import time
 from contextlib import contextmanager, ExitStack
 from typing import Mapping, Any, List, Iterator, Iterable, Set, Tuple, Dict, Optional, Union, IO, TypeVar, cast
 
-import fcntl
 import mxnet as mx
 import numpy as np
 
@@ -94,7 +94,7 @@ def log_basic_info(args) -> None:
     logger.info("Arguments: %s", args)
 
 
-def seedRNGs(seed: int) -> None:
+def seed_rngs(seed: int) -> None:
     """
     Seed the random number generators (Python, Numpy and MXNet)
 

--- a/test/unit/image_captioning/test_data_io.py
+++ b/test/unit/image_captioning/test_data_io.py
@@ -22,10 +22,10 @@ import sockeye.constants as C
 import sockeye.data_io
 import sockeye.image_captioning.data_io as data_io
 from sockeye import vocab
-from sockeye.utils import seedRNGs
+from sockeye.utils import seed_rngs
 from test.common_image_captioning import generate_img_or_feat, tmp_img_captioning_dataset, _FEATURE_SHAPE, _CNN_INPUT_IMAGE_SHAPE
 
-seedRNGs(12)
+seed_rngs(12)
 
 
 @pytest.mark.parametrize("source_list, target_sentences, num_samples_per_bucket, expected_source_0, expected_target_0, expected_label_0",

--- a/test/unit/test_data_io.py
+++ b/test/unit/test_data_io.py
@@ -23,10 +23,10 @@ import pytest
 from sockeye import constants as C
 from sockeye import data_io
 from sockeye import vocab
-from sockeye.utils import SockeyeError, get_tokens, seedRNGs
+from sockeye.utils import SockeyeError, get_tokens, seed_rngs
 from test.common import tmp_digits_dataset
 
-seedRNGs(12)
+seed_rngs(12)
 
 define_bucket_tests = [(50, 10, [10, 20, 30, 40, 50]),
                        (50, 20, [20, 40, 50]),


### PR DESCRIPTION
Sometimes its important to know what PYTHONPATH sockeye or mxnet are loaded from when running one of the CLIs. I added `__file__` info to the `log_*()` methods.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

