### PR TITLE
Added option to pad vocabulary to a multiple of x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.32]
+### Added
+- Added option to pad vocabulary to a multiple of x: e.g. `--pad-vocab-to-multiple-of 16`.
+
 ## [1.18.31]
 ### Added
 - Pre-training the RNN decoder. Usage:

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.31'
+__version__ = '1.18.32'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -483,6 +483,10 @@ def add_vocab_args(params):
                         type=multiple_values(num_values=2, greater_or_equal=1),
                         default=(1, 1),
                         help='Minimum frequency of words to be included in vocabularies. Default: %(default)s.')
+    params.add_argument('--pad-vocab-to-multiple-of',
+                        type=int,
+                        default=None,
+                        help='Pad vocabulary to a multiple of this integer. Default: %(default)s.')
 
 
 def add_model_parameters(params):

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -22,6 +22,7 @@ EOS_SYMBOL = "</s>"
 UNK_SYMBOL = "<unk>"
 PAD_SYMBOL = "<pad>"
 PAD_ID = 0
+PAD_FORMAT = "<pad%d>"
 TOKEN_SEPARATOR = " "
 VOCAB_SYMBOLS = [PAD_SYMBOL, UNK_SYMBOL, BOS_SYMBOL, EOS_SYMBOL]
 # reserve extra space for the EOS or BOS symbol that is added to both source and target

--- a/sockeye/prepare_data.py
+++ b/sockeye/prepare_data.py
@@ -71,7 +71,8 @@ def prepare_data(args: argparse.Namespace):
         num_words_source=num_words_source,
         word_min_count_source=word_min_count_source,
         num_words_target=num_words_target,
-        word_min_count_target=word_min_count_target)
+        word_min_count_target=word_min_count_target,
+        pad_to_multiple_of=args.pad_vocab_to_multiple_of)
 
     data_io.prepare_data(source_fnames=source_paths,
                          target_fname=args.target,

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -354,7 +354,8 @@ def create_data_iters_and_vocabs(args: argparse.Namespace,
                 num_words_source=num_words_source,
                 num_words_target=num_words_target,
                 word_min_count_source=word_min_count_source,
-                word_min_count_target=word_min_count_target)
+                word_min_count_target=word_min_count_target,
+                pad_to_multiple_of=args.pad_vocab_to_multiple_of)
 
         check_condition(len(args.source_factors) == len(args.source_factors_num_embed),
                         "Number of source factor data (%d) differs from provided source factor dimensions (%d)" % (

--- a/sockeye/vocab.py
+++ b/sockeye/vocab.py
@@ -20,9 +20,9 @@ from contextlib import ExitStack
 from itertools import chain, islice
 from typing import Dict, Iterable, List, Optional, Tuple
 
-from . import utils
 from . import constants as C
 from . import log
+from . import utils
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,8 @@ Vocab = Dict[str, int]
 InverseVocab = Dict[int, str]
 
 
-def build_from_paths(paths: List[str], num_words: Optional[int] = None, min_count: int = 1) -> Vocab:
+def build_from_paths(paths: List[str], num_words: Optional[int] = None, min_count: int = 1,
+                     pad_to_multiple_of: Optional[int] = None) -> Vocab:
     """
     Creates vocabulary from paths to a file in sentence-per-line format. A sentence is just a whitespace delimited
     list of tokens. Note that special symbols like the beginning of sentence (BOS) symbol will be added to the
@@ -40,15 +41,17 @@ def build_from_paths(paths: List[str], num_words: Optional[int] = None, min_coun
     :param paths: List of paths to files with one sentence per line.
     :param num_words: Optional maximum number of words in the vocabulary.
     :param min_count: Minimum occurrences of words to be included in the vocabulary.
+    :param pad_to_multiple_of: If not None, pads the vocabulary to a size that is the next multiple of this int.
     :return: Word-to-id mapping.
     """
     with ExitStack() as stack:
         logger.info("Building vocabulary from dataset(s): %s", paths)
         files = (stack.enter_context(utils.smart_open(path)) for path in paths)
-        return build_vocab(chain(*files), num_words, min_count)
+        return build_vocab(chain(*files), num_words, min_count, pad_to_multiple_of)
 
 
-def build_vocab(data: Iterable[str], num_words: Optional[int] = None, min_count: int = 1) -> Vocab:
+def build_vocab(data: Iterable[str], num_words: Optional[int] = None, min_count: int = 1,
+                pad_to_multiple_of: Optional[int] = None) -> Vocab:
     """
     Creates a vocabulary mapping from words to ids. Increasing integer ids are assigned by word frequency,
     using lexical sorting as a tie breaker. The only exception to this are special symbols such as the padding symbol
@@ -57,6 +60,7 @@ def build_vocab(data: Iterable[str], num_words: Optional[int] = None, min_count:
     :param data: Sequence of sentences containing whitespace delimited tokens.
     :param num_words: Optional maximum number of words in the vocabulary.
     :param min_count: Minimum occurrences of words to be included in the vocabulary.
+    :param pad_to_multiple_of: If not None, pads the vocabulary to a size that is the next multiple of this int.
     :return: Word-to-id mapping.
     """
     vocab_symbols_set = set(C.VOCAB_SYMBOLS)
@@ -73,11 +77,23 @@ def build_vocab(data: Iterable[str], num_words: Optional[int] = None, min_count:
         vocab = pruned_vocab
         num_words_log = "None"
 
-    word_to_id = {word: idx for idx, word in enumerate(chain(C.VOCAB_SYMBOLS, vocab))}
+    if pad_to_multiple_of is not None:
+        current_vocab_size = len(vocab) + len(C.VOCAB_SYMBOLS)
+        rest = current_vocab_size % pad_to_multiple_of
+        padded_vocab_size = current_vocab_size if rest == 0 else current_vocab_size + pad_to_multiple_of - rest
+        logger.info("Padding vocabulary to a multiple of %d: %d -> %d",
+                    pad_to_multiple_of, current_vocab_size, padded_vocab_size)
+        pad_entries = [C.PAD_FORMAT % idx for idx in range(current_vocab_size, padded_vocab_size)]
+        pad_to_multiple_log = str(pad_to_multiple_of)
+    else:
+        pad_entries = []
+        pad_to_multiple_log = "None"
+
+    word_to_id = {word: idx for idx, word in enumerate(chain(C.VOCAB_SYMBOLS, vocab, pad_entries))}
     logger.info("Vocabulary: types: %d/%d/%d/%d (initial/min_pruned/max_pruned/+special) " +
-                "[min_frequency=%d, max_num_types=%s]",
-                len(raw_vocab), len(pruned_vocab), len(word_to_id) - len(C.VOCAB_SYMBOLS),
-                len(word_to_id), min_count, num_words_log)
+                "[min_frequency=%d, max_num_types=%s, pad_to_multiple_of=%s]",
+                len(raw_vocab), len(pruned_vocab), len(vocab),
+                len(word_to_id), min_count, num_words_log, pad_to_multiple_log)
 
     # Important: pad symbol becomes index 0
     assert word_to_id[C.PAD_SYMBOL] == C.PAD_ID
@@ -153,13 +169,15 @@ def load_target_vocab(folder: str) -> Vocab:
     return vocab_from_json(os.path.join(folder, C.VOCAB_TRG_NAME % 0))
 
 
-def load_or_create_vocab(data: str, vocab_path: Optional[str], num_words: int, word_min_count: int) -> Vocab:
+def load_or_create_vocab(data: str, vocab_path: Optional[str], num_words: int, word_min_count: int,
+                         pad_to_multiple_of: Optional[int] = None) -> Vocab:
     """
     If the vocabulary path is defined, the vocabulary is loaded from the path.
     Otherwise, it is built from the data file. No writing to disk occurs.
     """
     if vocab_path is None:
-        return build_from_paths(paths=[data], num_words=num_words, min_count=word_min_count)
+        return build_from_paths(paths=[data], num_words=num_words, min_count=word_min_count,
+                                pad_to_multiple_of=pad_to_multiple_of)
     else:
         return vocab_from_json(vocab_path)
 
@@ -170,7 +188,8 @@ def load_or_create_vocabs(source_paths: List[str],
                           target_vocab_path: Optional[str],
                           shared_vocab: bool,
                           num_words_source: Optional[int], word_min_count_source: int,
-                          num_words_target: Optional[int], word_min_count_target: int) -> Tuple[List[Vocab], Vocab]:
+                          num_words_target: Optional[int], word_min_count_target: int,
+                          pad_to_multiple_of: Optional[int] = None) -> Tuple[List[Vocab], Vocab]:
     """
     Returns vocabularies for source files (including factors) and target.
     If the respective vocabulary paths are not None, the vocabulary is read from the path and returned.
@@ -185,6 +204,7 @@ def load_or_create_vocabs(source_paths: List[str],
     :param word_min_count_source: Minimum frequency of words in the source vocabulary.
     :param num_words_target: Number of words in the target vocabulary.
     :param word_min_count_target: Minimum frequency of words in the target vocabulary.
+    :param pad_to_multiple_of: If not None, pads the vocabularies to a size that is the next multiple of this int.
     :return: List of source vocabularies (for source and factors), and target vocabulary.
     """
     source_path, *source_factor_paths = source_paths
@@ -212,7 +232,8 @@ def load_or_create_vocabs(source_paths: List[str],
                                   "to be the same.")
             vocab_source = vocab_target = build_from_paths(paths=[source_path, target_path],
                                                            num_words=num_words_source,
-                                                           min_count=word_min_count_source)
+                                                           min_count=word_min_count_source,
+                                                           pad_to_multiple_of=pad_to_multiple_of)
 
         else:
             vocab_path = source_vocab_path if source_vocab_path is not None else target_vocab_path
@@ -220,8 +241,10 @@ def load_or_create_vocabs(source_paths: List[str],
             vocab_source = vocab_target = vocab_from_json(vocab_path)
 
     else:
-        vocab_source = load_or_create_vocab(source_path, source_vocab_path, num_words_source, word_min_count_source)
-        vocab_target = load_or_create_vocab(target_path, target_vocab_path, num_words_target, word_min_count_target)
+        vocab_source = load_or_create_vocab(source_path, source_vocab_path, num_words_source, word_min_count_source,
+                                            pad_to_multiple_of=pad_to_multiple_of)
+        vocab_target = load_or_create_vocab(target_path, target_vocab_path, num_words_target, word_min_count_target,
+                                            pad_to_multiple_of=pad_to_multiple_of)
 
     vocab_source_factors = []  # type: List[Vocab]
     if source_factor_paths:
@@ -266,6 +289,8 @@ def main():
     args = params.parse_args()
 
     num_words, num_words_other = args.num_words
+    num_words = num_words if num_words > 0 else None
+    num_words_other = num_words_other if num_words_other > 0 else None
     utils.check_condition(num_words == num_words_other,
                           "Vocabulary CLI only allows a common value for --num-words")
     word_min_count, word_min_count_other = args.word_min_count
@@ -276,7 +301,10 @@ def main():
     logger = log.setup_main_logger("build_vocab", file_logging=True, console=True,
                                    path="%s.%s" % (args.output, C.LOG_NAME))
 
-    vocab = build_from_paths(args.inputs, num_words=num_words, min_count=word_min_count)
+    vocab = build_from_paths(args.inputs,
+                             num_words=num_words,
+                             min_count=word_min_count,
+                             pad_to_multiple_of=args.pad_vocab_to_multiple_of)
     logger.info("Vocabulary size: %d ", len(vocab))
     vocab_to_json(vocab, args.output)
 

--- a/test/common.py
+++ b/test/common.py
@@ -218,7 +218,7 @@ _TRAIN_PARAMS_COMMON = "--use-cpu --max-seq-len {max_len} --source {train_source
                        " --seed {seed}"
 
 _PREPARE_DATA_COMMON = " --max-seq-len {max_len} --source {train_source} --target {train_target}" \
-                       " --output {output} {quiet}"
+                       " --output {output} {quiet} --pad-vocab-to-multiple-of 16"
 
 _TRAIN_WITH_FACTORS_COMMON = " --source-factors {source_factors}"
 _DEV_WITH_FACTORS_COMMON = " --validation-source-factors {dev_source_factors}"

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -36,6 +36,7 @@ from itertools import zip_longest
           validation_source_factors=[],
           output='test_output', overwrite_output=False,
           source_vocab=None, target_vocab=None, shared_vocab=False, num_words=(0, 0), word_min_count=(1, 1),
+          pad_vocab_to_multiple_of=None,
           no_bucketing=False, bucket_width=10, max_seq_len=(99, 99),
           monitor_pattern=None, monitor_stat_func='mx_default')),
 
@@ -50,6 +51,7 @@ from itertools import zip_longest
           validation_source_factors=[],
           output='test_output', overwrite_output=False,
           source_vocab=None, target_vocab=None, shared_vocab=False, num_words=(0, 0), word_min_count=(1, 1),
+          pad_vocab_to_multiple_of=None,
           no_bucketing=False, bucket_width=10, max_seq_len=(99, 99),
           monitor_pattern=None, monitor_stat_func='mx_default'))
 ])
@@ -336,6 +338,7 @@ def test_tutorial_averaging_args(test_params, expected_params, expected_params_p
           shared_vocab=False,
           num_words=(0, 0),
           word_min_count=(1, 1),
+          pad_vocab_to_multiple_of=None,
           no_bucketing=False,
           bucket_width=10,
           max_seq_len=(99, 99),
@@ -358,6 +361,7 @@ def test_tutorial_prepare_data_cli_args(test_params, expected_params):
           shared_vocab=False,
           num_words=(0, 0),
           word_min_count=(1, 1),
+          pad_vocab_to_multiple_of=None,
           no_bucketing=False,
           bucket_width=10,
           max_seq_len=(99, 99),

--- a/test/unit/test_vocab.py
+++ b/test/unit/test_vocab.py
@@ -18,6 +18,8 @@ from sockeye.vocab import build_vocab, get_ordered_tokens_from_vocab
 
 test_vocab = [
         # Example 1
+        (["one two three", "one two three"], None, 1,
+         {"<pad>": 0, "<unk>": 1, "<s>": 2, "</s>": 3, "two": 4, "three": 5, "one": 6}),
         (["one two three", "one two three"], 3, 1,
          {"<pad>": 0, "<unk>": 1, "<s>": 2, "</s>": 3, "two": 4, "three": 5, "one": 6}),
         (["one two three", "one two three"], 3, 2,
@@ -38,8 +40,18 @@ test_vocab = [
 
 @pytest.mark.parametrize("data,size,min_count,expected", test_vocab)
 def test_build_vocab(data, size, min_count, expected):
-    vocab = build_vocab(data, size, min_count)
+    vocab = build_vocab(data=data, num_words=size, min_count=min_count)
     assert vocab == expected
+
+
+@pytest.mark.parametrize("num_types,pad_to_multiple_of,expected_vocab_size",
+                         [(4, None, 8), (2, 8, 8), (4, 8, 8), (8, 8, 16), (10, 16, 16), (13, 16, 32)])
+def test_padded_build_vocab(num_types, pad_to_multiple_of, expected_vocab_size):
+    data = [" ".join('word%d' % i for i in range(num_types))]
+    size = None
+    min_count = 1
+    vocab = build_vocab(data, size, min_count, pad_to_multiple_of=pad_to_multiple_of)
+    assert len(vocab) == expected_vocab_size
 
 
 test_constants = [


### PR DESCRIPTION
As discussed in #348 we wanted to have the ability to pad the vocabulary to a multiple of 16. This PR adds this functionality as an option (`--pad-vocab-to-multiple-of`). By default this is None.
I added such padding (to a multiple of 16) to the system/integration tests that use prepared data.

I have not done any benchmarks whether this already speeds up anything in training on P3s or similar.

Main question for reviewers: are you fine with the naming of the new flag?

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

