### PR TITLE
Properly sorting empty sentences to keep the source and translations aligned

### DIFF
--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1103,14 +1103,14 @@ class Translator:
 
         # split into chunks
         input_chunks = []  # type: List[TranslatorInput]
-        for input_idx, trans_input in enumerate(trans_inputs, 1):
+        for trans_input in trans_inputs:
             # bad input
             if isinstance(trans_input, BadTranslatorInput):
-                translated_chunks.append(TranslatedChunk(id=input_idx, chunk_id=0, translation=empty_translation()))
+                translated_chunks.append(TranslatedChunk(id=trans_input.sentence_id, chunk_id=0, translation=empty_translation()))
 
             # empty input
             elif len(trans_input.tokens) == 0:
-                translated_chunks.append(TranslatedChunk(id=input_idx, chunk_id=0, translation=empty_translation()))
+                translated_chunks.append(TranslatedChunk(id=trans_input.sentence_id, chunk_id=0, translation=empty_translation()))
             else:
                 # TODO(tdomhan): Remove branch without EOS with next major version bump, as future models will always be trained with source side EOS symbols
                 if self.source_with_eos:


### PR DESCRIPTION
Hi,
  I came across a bug when translating empty sentences.  If you translate empty source sentences, your first chunk will stay aligned but the subsequent chunks will *all* get there translations moved to the end of that chunks.  In other words, chunk block number >1 will have `#empty_source` empty lines followed by `chunk_size - #empty_source` translations.  Note that this is for a chunk where the empty sentence are not necessarily at the begin of that chunk.  To illustrate, suppose you want to translate the following 20 source sentences.

SOURCE:
```
> 
> Home
> 
> 
> 
> 
> 
> 
> 
> 
> Contact the Pro@@ shop for golf en@@ qui@@ ries , tee times , group book@@ ings or other questions regarding golf play
> Inside a world where everyone is conscious of what they put onto the bodies as much as what they cover their own health with , fashion is a requirement cheap mon@@ c@@ ler mens jacket for many .
> 
> 
> 
> T@@ 5@@ 60 14 T@@ 6@@ 60 28 T@@ 6@@ 70 24
> 
> Agenda Mor@@ ges and region
> Restaurants - access to people with reduced mobility
> Number of places : 40 , in dor@@ mit@@ ories ( 25 in winter ) and 5 rooms with 2 beds .
```

BAD RESULT
```
> 
> Home C@@ ateg@@ ories
> 
> 
> 
> 
> 
> 
> 
> 
> 
> 
> 
> 
> Contact the Pro@@ shop for golf en@@ qui@@ ries , tee times , group book@@ ings or other questions regarding golf play
> Inside a world where everyone is conscious of what they put onto the bodies as much as what they cover their own health with , fashion is a requirement cheap mon@@ c@@ ler
> T@@ 5@@ 60 14 T@@ 6@@ 60 28 T@@ 6@@ 70 24
> Agenda Mor@@ ges and region
> Restaurants - access to people with reduced mobility
> Number of places : 40 , in dor@@ mit@@ ories ( 25 in winter ) and 5 rooms with 2 beds .
```

EXPECTED TRANSLATIONS
```
>
> Home C@@ ateg@@ ories
> 
> 
> 
> 
> 
> 
> 
> 
> Contact the Pro@@ shop for golf en@@ qui@@ ries , tee times , group book@@ ings or other questions regarding golf play
> Inside a world where everyone is conscious of what they put onto the bodies as much as what they cover their own health with , fashion is a requirement cheap mon@@ c@@ ler
> 
> 
> 
> T@@ 5@@ 60 14 T@@ 6@@ 60 28 T@@ 6@@ 70 24
> 
> Agenda Mor@@ ges and region
> Restaurants - access to people with reduced mobility
> Number of places : 40 , in dor@@ mit@@ ories ( 25 in winter ) and 5 rooms with 2 beds .
```

The problem is that empty sentences in a chunk is numbered sequentially from 1 regardless of the chunk but the non-empty sentences are number we their sentence_id with respect to the whole document to translate.  Then, when sorting the the translations, the empty sentences, which always have a lower index number in chunks > 1, end up been at the beginning of the sorted translation_chunks.


#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

