### PR TITLE
Ensure recent numpy version to avoid MKL conflicts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,14 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
-## [1.18.42]
+## [1.18.41]
 ### Changed
 - Require numpy 1.14 or later to avoid MKL conflicts between numpy as mxnet-mkl.
 
-## [1.18.41]
+## [1.18.40]
 ### Fixed
 - Fixed bad check for existence of negative constraints.
 - Resolved conflict for phrases that are both positive and negative constraints.
-
-## [1.18.40]
-### Fixed
 - Fixed softmax temperature at inference time.
 
 ## [1.18.39]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ### Changed
 - Require numpy 1.14 or later to avoid MKL conflicts between numpy as mxnet-mkl.
 
-## [1.18.40]
+## [1.18.41]
 ### Fixed
 - Fixed bad check for existence of negative constraints.
 - Resolved conflict for phrases that are both positive and negative constraints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.37]
+### Changed
+- Require numpy 1.14 or later to avoid MKL conflicts between numpy as mxnet-mkl.
+
 ## [1.18.36]
 ### Changed
 - Updated to [MXNet 1.2.1](https://github.com/apache/incubator-mxnet/tree/1.2.1)

--- a/requirements/requirements.gpu-cu75.txt
+++ b/requirements/requirements.gpu-cu75.txt
@@ -1,4 +1,4 @@
 pyyaml==3.12
 mxnet-cu75mkl==1.2.1
-numpy>=1.12
+numpy>=1.14
 typing

--- a/requirements/requirements.gpu-cu80.txt
+++ b/requirements/requirements.gpu-cu80.txt
@@ -1,4 +1,4 @@
 pyyaml==3.12
 mxnet-cu80mkl==1.2.1
-numpy>=1.12
+numpy>=1.14
 typing

--- a/requirements/requirements.gpu-cu90.txt
+++ b/requirements/requirements.gpu-cu90.txt
@@ -1,4 +1,4 @@
 pyyaml==3.12
 mxnet-cu90mkl==1.2.1
-numpy>=1.12
+numpy>=1.14
 typing

--- a/requirements/requirements.gpu-cu91.txt
+++ b/requirements/requirements.gpu-cu91.txt
@@ -1,4 +1,4 @@
 pyyaml==3.12
 mxnet-cu91mkl==1.2.1
-numpy>=1.12
+numpy>=1.14
 typing

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 pyyaml==3.12
 mxnet-mkl==1.2.1
-numpy>=1.12
+numpy>=1.14
 typing

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.41'
+__version__ = '1.18.42'

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.42'
+__version__ = '1.18.41'

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.36'
+__version__ = '1.18.37'


### PR DESCRIPTION
Making numpy 1.14 a requirement as suggested by @pengzhao-intel in https://github.com/awslabs/sockeye/pull/480.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

