### PR TITLE
avoid_list now supports <s> in negative constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.43]
+### Fixed
+- `<s>` now supported in negative constraints (as the start of a multi-token sequence)
+
 ## [1.18.42]
 ### Changed
 - Simplified gluon blocks for length calculation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
 ## [1.18.43]
-### Fixed
+### Added
 - `<s>` now supported as the first token in a multi-word negative constraint
   (e.g., '<s> I think' to prevent a sentence from starting with 'I think')
+### Fixed
 - Bugfix in resetting the state of a multiple-word negative constraint
 
 ## [1.18.42]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 
 ## [1.18.43]
 ### Fixed
-- `<s>` now supported in negative constraints (as the start of a multi-token sequence)
+- `<s>` now supported as the first token in a multi-word negative constraint
+  (e.g., '<s> I think' to prevent a sentence from starting with 'I think')
+- Bugfix in resetting the state of a multiple-word negative constraint
 
 ## [1.18.42]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ## [1.18.43]
 ### Added
 - `<s>` now supported as the first token in a multi-word negative constraint
-  (e.g., '<s> I think' to prevent a sentence from starting with 'I think')
+  (e.g., `<s> I think` to prevent a sentence from starting with `I think`)
 ### Fixed
 - Bugfix in resetting the state of a multiple-word negative constraint
 

--- a/contrib/sacrebleu/sacrebleu.py
+++ b/contrib/sacrebleu/sacrebleu.py
@@ -37,7 +37,7 @@ from typing import List, Iterable, Tuple
 import math
 import unicodedata
 
-VERSION = '1.3.0'
+VERSION = '1.2.10'
 
 try:
     # SIGPIPE is not available on Windows machines, throwing an exception.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.42'
+__version__ = '1.18.43'

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1461,6 +1461,7 @@ class Translator:
             avoid_states = constrained.AvoidBatch(self.batch_size, self.beam_size,
                                                   avoid_list=raw_avoid_list,
                                                   global_avoid_trie=self.global_avoid_trie)
+            avoid_states.consume(best_word_indices)
 
         # Records items in the beam that are inactive. At the beginning (t==1), there is only one valid or active
         # item on the beam for each sentence

--- a/sockeye/lexical_constraints.py
+++ b/sockeye/lexical_constraints.py
@@ -120,8 +120,8 @@ class AvoidState:
         (1) If the word is found in our set of outgoing child arcs, we take that transition.
         (2) If the word is not found, and we are not in the root state, we need to reset.
             This means we pretend we were in the root state, and see if we can take a step
-        (3) Otherwise, if we are not already the root state (i.e., we were partially through
-            the trie), we need to create a new object to track the state, in the root state
+        (3) Otherwise, if we are not already in the root state (i.e., we were partially through
+            the trie), we need to create a new object whose state is the root state
         (4) Finally, if we couldn't advance and were already in the root state, we can reuse
             this object.
 

--- a/sockeye/lexical_constraints.py
+++ b/sockeye/lexical_constraints.py
@@ -116,10 +116,21 @@ class AvoidState:
         """
         Consumes a word, and updates the state based on it. Returns new objects on a state change.
 
+        The next state for a word can be tricky. Here are the cases:
+        (1) If the word is found in our set of outgoing child arcs, we take that transition.
+        (2) If the word is not found, and we are not in the root state, we need to reset.
+            This means we pretend we were in the root state, and see if we can take a step
+        (3) Otherwise, if we are not already the root state (i.e., we were partially through
+            the trie), we need to create a new object to track the state, in the root state
+        (4) Finally, if we couldn't advance and were already in the root state, we can reuse
+            this object.
+
         :param word_id: The word that was just generated.
         """
         if word_id in self.state.children:
             return AvoidState(self.root, self.state.step(word_id))
+        elif word_id in self.root.children:
+            return AvoidState(self.root, self.root.step(word_id))
         elif self.state != self.root:
             return AvoidState(self.root, self.root)
         else:

--- a/test/common.py
+++ b/test/common.py
@@ -387,19 +387,19 @@ def run_train_translate(train_params: str,
                 with patch.object(sys, "argv", params.split()):
                     sockeye.translate.main()
 
-                print('JSON_INPUT', open(new_test_source_path).readlines(),
-                      'CONSTRAINED', open(out_path_constrained).readlines(),
-                      'UNCONSTRAINED', open(out_path).readlines(), sep='\n')
-                for json_input, constrained_out, unconstrained_out in zip(open(new_test_source_path), open(out_path_constrained), open(out_path)):
+                for json_input, constrained_out, unconstrained_out in zip(open(new_test_source_path),
+                                                                          open(out_path_constrained),
+                                                                          open(out_path)):
                     jobj = json.loads(json_input)
-                    print('JSON_INPUT', json_input, 'CONSTRAINED', constrained_out, 'UNCONSTRAINED', unconstrained_out, sep='\n')
                     if jobj.get(constraint_type, None) == None:
                         assert constrained_out == unconstrained_out
                     else:
                         restriction = jobj[constraint_type][0]
                         if constraint_type == 'constraints':
+                            # for positive constraints, ensure the constraint is in the constrained output
                             assert restriction in constrained_out
                         else:
+                            # for negative constraints, ensure the constraints is *not* in the constrained output
                             assert restriction not in constrained_out
 
         # Translate corpus with the 2nd params

--- a/test/common.py
+++ b/test/common.py
@@ -153,8 +153,7 @@ def tmp_digits_dataset(prefix: str,
                        test_line_count: int, test_line_count_empty: int, test_max_length: int,
                        sort_target: bool = False,
                        seed_train: int = 13, seed_dev: int = 13,
-                       with_source_factors: bool = False,
-                       with_target_constraints: bool = False):
+                       with_source_factors: bool = False):
     with TemporaryDirectory(prefix=prefix) as work_dir:
         # Simple digits files for train/dev data
         train_source_path = os.path.join(work_dir, "train.src")
@@ -187,34 +186,6 @@ def tmp_digits_dataset(prefix: str,
             data['train_source_factors'] = [train_factor_path]
             data['dev_source_factors'] = [dev_factor_path]
             data['test_source_factors'] = [test_factor_path]
-
-        if with_target_constraints:
-            # When using constrained decoding, rewrite the source file to contain target
-            # constraints.  Generating a mixture of sentences with and without constraints here is
-            # critical, since this can happen in production and also introduces sometimes some
-            # unanticipated interactions.
-            new_sources = []
-            with open(data['test_source']) as source_inp, open(data['test_target']) as target_inp:
-                for sentno, (source, target) in enumerate(zip(source_inp, target_inp)):
-                    target_words = target.rstrip().split()
-                    target_len = len(target_words)
-                    new_source = {'text': source.rstrip()}
-                    # From the odd-numbered sentences that are not too long, create constraints. We do
-                    # only odds to ensure we get batches with mixed constraints / lack of constraints.
-                    if target_len > 0 and sentno % 2 == 0:
-                        start_pos = 0
-                        end_pos = min(target_len, 3)
-                        constraint = ' '.join(target_words[start_pos:end_pos])
-                        # Alternate between positive and negative constraints
-                        if sentno % 4 == 0:
-                            new_source['constraints'] = [constraint]
-                        else:
-                            new_source['avoid'] = [constraint]
-                    new_sources.append(json.dumps(new_source))
-
-            with open(data['test_source'], 'w') as out:
-                for json_line in new_sources:
-                    print(json_line, file=out)
 
         yield data
 
@@ -257,6 +228,7 @@ def run_train_translate(train_params: str,
                         dev_source_factor_paths: Optional[List[str]] = None,
                         test_source_factor_paths: Optional[List[str]] = None,
                         use_prepared_data: bool = False,
+                        use_target_constraints: bool = False,
                         max_seq_len: int = 10,
                         restrict_lexicon: bool = False,
                         work_dir: Optional[str] = None,
@@ -374,6 +346,61 @@ def run_train_translate(train_params: str,
 
         with patch.object(sys, "argv", params.split()):
             sockeye.translate.main()
+
+        # Test target constraints
+        if use_target_constraints:
+            """
+            Read in the unconstrained system output from the first pass and use it to generate positive
+            and negative constraints. It is important to generate a mix of positive, negative, and no
+            constraints per batch, to test these production-realistic interactions as well.
+            """
+            # 'constraint' = positive constraints (must appear), 'avoid' = negative constraints (must not appear)
+            for constraint_type in ["constraints", "avoid"]:
+                constrained_sources = []
+                with open(test_source_path) as source_inp, open(out_path) as system_out:
+                    for sentno, (source, target) in enumerate(zip(source_inp, system_out)):
+                        target_words = target.rstrip().split()
+                        target_len = len(target_words)
+                        new_source = {'text': source.rstrip()}
+                        # From the odd-numbered sentences that are not too long, create constraints. We do
+                        # only odds to ensure we get batches with mixed constraints / lack of constraints.
+                        if target_len > 0 and sentno % 2 == 0:
+                            start_pos = 0
+                            end_pos = min(target_len, 3)
+                            constraint = ' '.join(target_words[start_pos:end_pos])
+                            new_source[constraint_type] = [constraint]
+                        constrained_sources.append(json.dumps(new_source))
+
+                new_test_source_path = os.path.join(work_dir, "test_constrained.txt")
+                with open(new_test_source_path, 'w') as out:
+                    for json_line in constrained_sources:
+                        print(json_line, file=out)
+
+                out_path_constrained = os.path.join(work_dir, "out_constrained.txt")
+                params = "{} {} {} --json-input".format(sockeye.translate.__file__,
+                                                        _TRANSLATE_PARAMS_COMMON.format(model=model_path,
+                                                                                        input=new_test_source_path,
+                                                                                        output=out_path_constrained,
+                                                                                        quiet=quiet_arg),
+                                                        translate_params)
+
+                with patch.object(sys, "argv", params.split()):
+                    sockeye.translate.main()
+
+                print('JSON_INPUT', open(new_test_source_path).readlines(),
+                      'CONSTRAINED', open(out_path_constrained).readlines(),
+                      'UNCONSTRAINED', open(out_path).readlines(), sep='\n')
+                for json_input, constrained_out, unconstrained_out in zip(open(new_test_source_path), open(out_path_constrained), open(out_path)):
+                    jobj = json.loads(json_input)
+                    print('JSON_INPUT', json_input, 'CONSTRAINED', constrained_out, 'UNCONSTRAINED', unconstrained_out, sep='\n')
+                    if jobj.get(constraint_type, None) == None:
+                        assert constrained_out == unconstrained_out
+                    else:
+                        restriction = jobj[constraint_type][0]
+                        if constraint_type == 'constraints':
+                            assert restriction in constrained_out
+                        else:
+                            assert restriction not in constrained_out
 
         # Translate corpus with the 2nd params
         if translate_params_equiv is not None:

--- a/test/common.py
+++ b/test/common.py
@@ -392,6 +392,7 @@ def run_train_translate(train_params: str,
                                                                           open(out_path)):
                     jobj = json.loads(json_input)
                     if jobj.get(constraint_type, None) == None:
+                        # if there were no constraints, make sure the output is the same as the unconstrained output
                         assert constrained_out == unconstrained_out
                     else:
                         restriction = jobj[constraint_type][0]

--- a/test/integration/test_constraints_int.py
+++ b/test/integration/test_constraints_int.py
@@ -1,0 +1,85 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""
+Tests constraints in many forms.
+"""
+
+import pytest
+import random
+
+import sockeye.constants as C
+from test.common import run_train_translate, tmp_digits_dataset
+
+_TRAIN_LINE_COUNT = 20
+_DEV_LINE_COUNT = 5
+_TEST_LINE_COUNT = 5
+_TEST_LINE_COUNT_EMPTY = 2
+_LINE_MAX_LENGTH = 9
+_TEST_MAX_LENGTH = 20
+
+ENCODER_DECODER_SETTINGS = [
+    # "Vanilla" LSTM encoder-decoder with attention
+    ("--encoder rnn --decoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 8 --num-embed 4 "
+     " --rnn-attention-type mlp"
+     " --rnn-attention-num-hidden 8 --loss cross-entropy --optimized-metric perplexity --max-updates 2"
+     " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01 --batch-type sentence "
+     " --decode-and-evaluate 0",
+     2, 10),
+    # Full transformer
+    ("--encoder transformer --decoder transformer"
+     " --num-layers 2 --transformer-attention-heads 2 --transformer-model-size 8 --num-embed 8"
+     " --transformer-feed-forward-num-hidden 16"
+     " --transformer-dropout-prepost 0.1 --transformer-preprocess n --transformer-postprocess dr"
+     " --weight-tying --weight-tying-type src_trg_softmax"
+     " --weight-init-scale=3.0 --weight-init-xavier-factor-type=avg --embed-weight-init=normal"
+     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
+     " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01",
+     1, 10)]
+
+
+@pytest.mark.parametrize(
+    "train_params, batch_size, beam_size",
+    ENCODER_DECODER_SETTINGS)
+def test_constraints(train_params: str,
+                     beam_size: int,
+                     batch_size: int):
+    """Task: copy short sequences of digits"""
+
+    with tmp_digits_dataset(prefix="test_constraints",
+                            train_line_count=_TRAIN_LINE_COUNT,
+                            train_max_length=_LINE_MAX_LENGTH,
+                            dev_line_count=_DEV_LINE_COUNT,
+                            dev_max_length=_LINE_MAX_LENGTH,
+                            test_line_count=_TEST_LINE_COUNT,
+                            test_line_count_empty=_TEST_LINE_COUNT_EMPTY,
+                            test_max_length=_TEST_MAX_LENGTH,
+                            sort_target=False) as data:
+
+        translate_params = " --batch-size {} --beam-size {}".format(batch_size, beam_size)
+
+        # Ignore return values (perplexity and BLEU) for integration test
+        run_train_translate(train_params=train_params,
+                            translate_params=translate_params,
+                            translate_params_equiv=None,
+                            train_source_path=data['source'],
+                            train_target_path=data['target'],
+                            dev_source_path=data['validation_source'],
+                            dev_target_path=data['validation_target'],
+                            test_source_path=data['test_source'],
+                            test_target_path=data['test_target'],
+                            max_seq_len=_LINE_MAX_LENGTH + C.SPACE_FOR_XOS,
+                            work_dir=data['work_dir'],
+                            use_prepared_data=False,
+                            restrict_lexicon=False,
+                            use_target_constraints=True)

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -144,18 +144,12 @@ def test_seq_copy(train_params: str,
                             sort_target=False,
                             with_source_factors=use_source_factors) as data:
 
-        # Only one of these is supported at a time in the tests
-        assert not (use_source_factors and use_constrained_decoding)
-
         # When using source factors
         train_source_factor_paths, dev_source_factor_paths, test_source_factor_paths = None, None, None
         if use_source_factors:
             train_source_factor_paths = [data['source']]
             dev_source_factor_paths = [data['validation_source']]
             test_source_factor_paths = [data['test_source']]
-
-        if use_constrained_decoding:
-            translate_params += " --json-input"
 
         # Test model configuration, including the output equivalence of batch and no-batch decoding
         translate_params_batch = translate_params + " --batch-size 2"
@@ -177,4 +171,4 @@ def test_seq_copy(train_params: str,
                             restrict_lexicon=restrict_lexicon,
                             work_dir=data['work_dir'],
                             use_prepared_data=use_prepared_data,
-                            use_target_constraints=use_target_constraints)
+                            use_target_constraints=False)

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -32,7 +32,7 @@ ENCODER_DECODER_SETTINGS = [
      " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01 --batch-type sentence "
      " --decode-and-evaluate 0",
      "--beam-size 2 --softmax-temperature 0.01",
-     True, False, False, True),
+     True, False, False),
     # "Kitchen sink" LSTM encoder-decoder with attention
     ("--encoder rnn --decoder rnn --num-layers 3:2 --rnn-cell-type lstm --rnn-num-hidden 8"
      " --rnn-residual-connections"
@@ -45,7 +45,7 @@ ENCODER_DECODER_SETTINGS = [
      " --rnn-h2h-init orthogonal_stacked --batch-type sentence --decode-and-evaluate 0"
      " --learning-rate-decay-param-reset --weight-normalization --source-factors-num-embed 5",
      "--beam-size 2 --beam-search-stop first",
-     False, True, True, False),
+     False, True, True),
     # Convolutional embedding encoder + LSTM encoder-decoder with attention
     ("--encoder rnn-with-conv-embed --decoder rnn --conv-embed-max-filter-width 3 --conv-embed-num-filters 4:4:8"
      " --conv-embed-pool-stride 2 --conv-embed-num-highway-layers 1 --num-layers 1 --rnn-cell-type lstm"
@@ -53,7 +53,7 @@ ENCODER_DECODER_SETTINGS = [
      " --optimized-metric perplexity --max-updates 2 --checkpoint-frequency 2 --optimizer adam --batch-type sentence"
      " --initial-learning-rate 0.01 --decode-and-evaluate 0",
      "--beam-size 2",
-     False, False, False, False),
+     False, False, False),
     # Transformer encoder, GRU decoder, mhdot attention
     ("--encoder transformer --decoder rnn --num-layers 2:1 --rnn-cell-type gru --rnn-num-hidden 8 --num-embed 4:8"
      " --transformer-attention-heads 2 --transformer-model-size 4"
@@ -63,7 +63,7 @@ ENCODER_DECODER_SETTINGS = [
      " --weight-init-xavier-factor-type avg --weight-init-scale 3.0 --embed-weight-init normal --batch-type sentence"
      " --decode-and-evaluate 0",
      "--beam-size 2",
-     False, True, False, False),
+     False, True, False),
     # LSTM encoder, Transformer decoder
     ("--encoder rnn --decoder transformer --num-layers 2:2 --rnn-cell-type lstm --rnn-num-hidden 8 --num-embed 8"
      " --transformer-attention-heads 2 --transformer-model-size 8"
@@ -71,7 +71,7 @@ ENCODER_DECODER_SETTINGS = [
      " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
      " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01",
      "--beam-size 3",
-     False, True, False, False),
+     False, True, False),
     # Full transformer
     ("--encoder transformer --decoder transformer"
      " --num-layers 2 --transformer-attention-heads 2 --transformer-model-size 8 --num-embed 8"
@@ -82,7 +82,7 @@ ENCODER_DECODER_SETTINGS = [
      " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
      " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01",
      "--beam-size 2",
-     True, False, False, False),
+     True, False, False),
     # Full transformer with source factor
     ("--encoder transformer --decoder transformer"
      " --num-layers 2 --transformer-attention-heads 2 --transformer-model-size 8 --num-embed 8"
@@ -92,14 +92,14 @@ ENCODER_DECODER_SETTINGS = [
      " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
      " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01 --source-factors-num-embed 4",
      "--beam-size 2",
-     True, False, True, False),
+     True, False, True),
     # 2-layer cnn
     ("--encoder cnn --decoder cnn "
      " --batch-size 2 --num-layers 2 --max-updates 2 --checkpoint-frequency 2"
      " --cnn-num-hidden 32 --cnn-positional-embedding-type fixed"
      " --optimizer adam --initial-learning-rate 0.001 --batch-type sentence --decode-and-evaluate 0",
      "--beam-size 2",
-     True, False, False, False),
+     True, False, False),
     # Vanilla LSTM like above but activating LHUC. In the normal case you would
     # start with a trained system instead of a random initialized one like here.
     (
@@ -109,7 +109,7 @@ ENCODER_DECODER_SETTINGS = [
      " --loss cross-entropy --optimized-metric perplexity --max-updates 2"
      " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01 --lhuc all",
      "--beam-size 2",
-    True, False, False, False),
+    True, False, False),
     # Full transformer with LHUC
     ("--encoder transformer --decoder transformer"
      " --num-layers 2 --transformer-attention-heads 2 --transformer-model-size 8 --num-embed 8"
@@ -120,18 +120,17 @@ ENCODER_DECODER_SETTINGS = [
      " --batch-size 2 --max-updates 2 --batch-type sentence  --decode-and-evaluate 0"
      " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01 --lhuc all",
      "--beam-size 2 --beam-prune 1",
-     True, False, False, False)]
+     True, False, False)]
 
 
 @pytest.mark.parametrize(
-    "train_params, translate_params, restrict_lexicon, use_prepared_data, use_source_factors, use_constrained_decoding",
+    "train_params, translate_params, restrict_lexicon, use_prepared_data, use_source_factors",
     ENCODER_DECODER_SETTINGS)
 def test_seq_copy(train_params: str,
                   translate_params: str,
                   restrict_lexicon: bool,
                   use_prepared_data: bool,
-                  use_source_factors: bool,
-                  use_constrained_decoding: bool):
+                  use_source_factors: bool):
     """Task: copy short sequences of digits"""
 
     with tmp_digits_dataset(prefix="test_seq_copy",
@@ -143,8 +142,7 @@ def test_seq_copy(train_params: str,
                             test_line_count_empty=_TEST_LINE_COUNT_EMPTY,
                             test_max_length=_TEST_MAX_LENGTH,
                             sort_target=False,
-                            with_source_factors=use_source_factors,
-                            with_target_constraints=use_constrained_decoding) as data:
+                            with_source_factors=use_source_factors) as data:
 
         # Only one of these is supported at a time in the tests
         assert not (use_source_factors and use_constrained_decoding)
@@ -178,4 +176,5 @@ def test_seq_copy(train_params: str,
                             max_seq_len=_LINE_MAX_LENGTH + C.SPACE_FOR_XOS,
                             restrict_lexicon=restrict_lexicon,
                             work_dir=data['work_dir'],
-                            use_prepared_data=use_prepared_data)
+                            use_prepared_data=use_prepared_data,
+                            use_target_constraints=use_target_constraints)

--- a/tutorials/constraints/README.md
+++ b/tutorials/constraints/README.md
@@ -32,7 +32,7 @@ This JSON object can be produced with the provided script:
 
 The script creates a Python object with the constraints encoded as follows:
 
-    { 'text': 'This is a test .', 'constraints': ['constr@@ aint', 'multi@@ word constr@@ aint'] }
+    { 'text': 'This is a test .', 'constraints': ['constr@@ aint', 'multi@@ word constr@@ aint'] }]
 
 You can pass the output of this to Sockeye.
 Make sure that you (a) the JSON object is on a *single line* and (b) you pass `--json-input` to Sockeye, so that it knows to parse the input (without that flag, it will treat the JSON input as a regular sentence).
@@ -43,3 +43,26 @@ We also recommend that you increase the beam a little bit and enable beam prunin
       | python3 -m sockeye.translate -m /path/to/model --json-input --beam-size 20 --beam-prune 20 [other args]
 
 You will get a translation with the required constraints as part of the output.
+
+## Scoring
+
+Lexical constraints can also be used as a rudimentary scoring mechanism, by providing the entire reference (with `<s>` and `</s>` tokens) as a constraint.
+For example:
+
+    echo '{ "text": "This is a test", "constraints": ["<s> Dies ist ein Test </s>"] }' \
+      python3 -m sockeye.translate -m /path/to/model --json-input --beam-size 1 --output-type translation_with_score
+
+This will output tab-delimited pairs of (score, translation).
+As always, don't forget to apply source- and target-side preprocessing to your input and your constraint.
+
+## Negative constraints
+
+Negative constraints---phrases that must *not* appear in the output---are also supported.
+To use them, use the "avoid" key in the JSON object instead of "constraints".
+An example JSON object:
+
+    { 'text': 'This is a test .', 'avoid': ['Test'] }
+
+Multiple negative constraints and multi-word negative constraints are supported, just like for positive constraints.
+You can also add `<s>` and `</s>` to constraints, to specify that phrases that must not start or end a sentence.
+Don't forget to apply your preprocessing!


### PR DESCRIPTION
Simple fix that lets you add `<s>` as the beginning of a sequence to avoid.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

