### PR TITLE
Add GNMT Config to Autopilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.45]
+### Added
+- Added an 8 layer LSTM model similar (but not exactly identical) to the 'GNMT' architecture to autopilot.
+
 ## [1.18.44]
 ### Fixed
 - Fixed an issue with `--max-num-epochs` causing training to stop before the update/batch that actually completes the epoch was made.

--- a/contrib/autopilot/autopilot.py
+++ b/contrib/autopilot/autopilot.py
@@ -43,7 +43,7 @@ from contrib.autopilot.tasks import TEXT_UTF8_RAW_BITEXT_REVERSE, TEXT_REQUIRES_
 from contrib.autopilot.tasks import TEXT_UTF8_TOKENIZED
 from contrib.autopilot.tasks import RAW_FILES
 from contrib.autopilot.tasks import Task, TASKS
-from contrib.autopilot.models import MODELS, MODEL_NONE, MODEL_TEST_ARGS
+from contrib.autopilot.models import MODELS, MODEL_NONE, MODEL_GNMT, MODEL_TEST_ARGS
 from contrib.autopilot.models import DECODE_ARGS, DECODE_STANDARD, DECODE_GNMT
 from contrib.autopilot import third_party
 
@@ -721,8 +721,8 @@ def run_steps(args: argparse.Namespace):
 
     logging.info("=== Train translation model ===")
     logging.info("Model: %s", args.model)
-    if args.model == "gnmt_like":
-        logging.info("WARNING: This is an 8 layer LSTMs model which can resembles the 'GNMT' architecture.")
+    if args.model == MODEL_GNMT:
+        logging.info("NOTE: This is an 8 layer LSTM model similar (but not exactly identical) to the 'GNMT' architecture.")
     step_dir_model = os.path.join(dir_task, DIR_PREFIX_MODEL + args.model)
     complete_fname = os.path.join(step_dir_model, FILE_COMPLETE)
     if os.path.exists(complete_fname):

--- a/contrib/autopilot/autopilot.py
+++ b/contrib/autopilot/autopilot.py
@@ -721,6 +721,8 @@ def run_steps(args: argparse.Namespace):
 
     logging.info("=== Train translation model ===")
     logging.info("Model: %s", args.model)
+    if args.model == "gnmt_like":
+        logging.info("WARNING: This is an 8 layer LSTMs model which can resembles the 'GNMT' architecture.")
     step_dir_model = os.path.join(dir_task, DIR_PREFIX_MODEL + args.model)
     complete_fname = os.path.join(step_dir_model, FILE_COMPLETE)
     if os.path.exists(complete_fname):

--- a/contrib/autopilot/autopilot.py
+++ b/contrib/autopilot/autopilot.py
@@ -43,8 +43,9 @@ from contrib.autopilot.tasks import TEXT_UTF8_RAW_BITEXT_REVERSE, TEXT_REQUIRES_
 from contrib.autopilot.tasks import TEXT_UTF8_TOKENIZED
 from contrib.autopilot.tasks import RAW_FILES
 from contrib.autopilot.tasks import Task, TASKS
-from contrib.autopilot.models import MODELS, MODEL_NONE, MODEL_TEST_ARGS
-from contrib.autopilot.models import DECODE_ARGS, DECODE_STANDARD
+from contrib.autopilot.models import MODELS, MODEL_NONE
+from contrib.autopilot.models import MODEL_TEST_ARGS, MODEL_TEST_ARGS_TRANSFORMER, MODEL_TEST_ARGS_GNMT
+from contrib.autopilot.models import DECODE_ARGS, DECODE_STANDARD, DECODE_GNMT
 from contrib.autopilot import third_party
 
 
@@ -863,6 +864,8 @@ def main():
                             help="Pre-defined data set for model training.")
     arg_parser.add_argument("--model", type=str, choices=sorted(MODELS.keys()),
                             help="Type of translation model to train.")
+    arg_parser.add_argument("--model-test-settings", type=str, choices=sorted(MODEL_TEST_ARGS.keys()), default=MODEL_TEST_ARGS_TRANSFORMER,
+                            help="Model test settings. Default: %(default)s.")
     arg_parser.add_argument("--decode-settings", type=str, choices=sorted(DECODE_ARGS.keys()), default=DECODE_STANDARD,
                             help="Decoding settings. Default: %(default)s.")
     arg_parser.add_argument("--custom-task", type=str, metavar="NAME",

--- a/contrib/autopilot/models.py
+++ b/contrib/autopilot/models.py
@@ -14,11 +14,11 @@
 # Names model types
 MODEL_NONE = "none"
 MODEL_TRANSFORMER = "transformer"
-MODEL_GNMT = "gnmt"
+MODEL_GNMT = "gnmt_like"
 
 # Named decoding settings
 DECODE_STANDARD = "standard"
-DECODE_GNMT = "gnmt"
+DECODE_GNMT = "gnmt_like"
 
 # Model configurations (architecture, training recipe, etc.)
 MODELS = {

--- a/contrib/autopilot/models.py
+++ b/contrib/autopilot/models.py
@@ -16,13 +16,9 @@ MODEL_NONE = "none"
 MODEL_TRANSFORMER = "transformer"
 MODEL_GNMT = "gnmt"
 
-# Names model test settings
-MODEL_TEST_ARGS_TRANSFORMER = "ttransformer"
-MODEL_TEST_ARGS_GNMT = "tgnmt"
-
 # Named decoding settings
 DECODE_STANDARD = "standard"
-DECODE_GNMT = "dgnmt"
+DECODE_GNMT = "gnmt"
 
 # Model configurations (architecture, training recipe, etc.)
 MODELS = {
@@ -98,7 +94,7 @@ MODELS = {
 # version quickly for system tests.  When multiple versions of the same argument
 # exist, the last version to appear (this list) takes precedence.
 MODEL_TEST_ARGS = {
-    MODEL_TEST_ARGS_TRANSFORMER: [
+    MODEL_TRANSFORMER: [
         "--num-layers=1:1",
         "--transformer-model-size=16",
         "--transformer-feed-forward-num-hidden=16",
@@ -110,7 +106,7 @@ MODEL_TEST_ARGS = {
         "--checkpoint-frequency=2",
     ],
 
-    MODEL_TEST_ARGS_GNMT: [
+    MODEL_GNMT: [
         "--num-layers=1:1",
         "--rnn-num-hidden=16",
         "--num-embed=16:16",

--- a/contrib/autopilot/models.py
+++ b/contrib/autopilot/models.py
@@ -16,6 +16,10 @@ MODEL_NONE = "none"
 MODEL_TRANSFORMER = "transformer"
 MODEL_GNMT = "gnmt"
 
+# Names model test settings
+MODEL_TEST_ARGS_TRANSFORMER = "ttransformer"
+MODEL_TEST_ARGS_GNMT = "tgnmt"
+
 # Named decoding settings
 DECODE_STANDARD = "standard"
 DECODE_GNMT = "dgnmt"
@@ -65,7 +69,7 @@ MODELS = {
     MODEL_GNMT: [
         "--encoder=rnn",
         "--decoder=rnn",
-        "--rnn-num-hidden=512"，
+        "--rnn-num-hidden=512",
         "--rnn-attention-in-upper-layers",
         "--rnn-attention-type=dot",
         "--rnn-decoder-hidden-dropout=0.2",
@@ -75,7 +79,7 @@ MODELS = {
         "--weight-init-scale=3.0",
         "--weight-init-xavier-factor-type=avg",
         "--num-embed=256:256",
-        "--max-seq-len=100"
+        "--max-seq-len=100",
         "--optimizer=adam",
         "--optimized-metric=perplexity",
         "--initial-learning-rate=0.0001",

--- a/contrib/autopilot/models.py
+++ b/contrib/autopilot/models.py
@@ -14,9 +14,11 @@
 # Names model types
 MODEL_NONE = "none"
 MODEL_TRANSFORMER = "transformer"
+MODEL_GNMT = "gnmt"
 
 # Named decoding settings
 DECODE_STANDARD = "standard"
+DECODE_GNMT = "dgnmt"
 
 # Model configurations (architecture, training recipe, etc.)
 MODELS = {
@@ -59,22 +61,62 @@ MODELS = {
         "--decode-and-evaluate=500",
         "--keep-last-params=60",
     ],
+
+    MODEL_GNMT: [
+        "--encoder=rnn",
+        "--decoder=rnn",
+        "--rnn-num-hidden=512"，
+        "--rnn-attention-in-upper-layers",
+        "--rnn-attention-type=dot",
+        "--rnn-decoder-hidden-dropout=0.2",
+        "--embed-dropout=0.2",
+        "--num-layers=8:8",
+        "--weight-init=xavier",
+        "--weight-init-scale=3.0",
+        "--weight-init-xavier-factor-type=avg",
+        "--num-embed=256:256",
+        "--max-seq-len=100"
+        "--optimizer=adam",
+        "--optimized-metric=perplexity",
+        "--initial-learning-rate=0.0001",
+        "--learning-rate-reduce-num-not-improved=8",
+        "--learning-rate-reduce-factor=0.7",
+        "--max-num-checkpoint-not-improved=32",
+        "--batch-type=sentence",
+        "--batch-size=128",
+        "--checkpoint-frequency=2000",
+        "--decode-and-evaluate=500",
+        "--keep-last-params=60",
+    ],
 }  # type: Dict[str, List[str]]
 
 # Arguments added to the end of any model in test mode to train a smaller
 # version quickly for system tests.  When multiple versions of the same argument
 # exist, the last version to appear (this list) takes precedence.
-MODEL_TEST_ARGS = [
-    "--num-layers=1:1",
-    "--transformer-model-size=16",
-    "--transformer-feed-forward-num-hidden=16",
-    "--num-embed=16:16",
-    "--num-words=16:16",
-    "--batch-type=sentence",
-    "--batch-size=1",
-    "--max-updates=4",
-    "--checkpoint-frequency=2",
-]
+MODEL_TEST_ARGS = {
+    MODEL_TEST_ARGS_TRANSFORMER: [
+        "--num-layers=1:1",
+        "--transformer-model-size=16",
+        "--transformer-feed-forward-num-hidden=16",
+        "--num-embed=16:16",
+        "--num-words=16:16",
+        "--batch-type=sentence",
+        "--batch-size=1",
+        "--max-updates=4",
+        "--checkpoint-frequency=2",
+    ],
+
+    MODEL_TEST_ARGS_GNMT: [
+        "--num-layers=1:1",
+        "--rnn-num-hidden=16",
+        "--num-embed=16:16",
+        "--num-words=16:16",
+        "--batch-type=sentence",
+        "--batch-size=1",
+        "--max-updates=4",
+        "--checkpoint-frequency=2",
+    ],
+}
 
 # Decoding configurations
 DECODE_ARGS = {
@@ -86,5 +128,15 @@ DECODE_ARGS = {
         "--length-penalty-beta=0.0",
         "--max-output-length-num-stds=2",
         "--bucket-width=10",
-    ]
+    ],
+
+    DECODE_GNMT: [
+        "--beam-size=10",
+        "--batch-size=32",
+        "--chunk-size=1000",
+        "--length-penalty-alpha=0.1",
+        "--length-penalty-beta=0.0",
+        "--max-output-length-num-stds=2",
+        "--bucket-width=10",
+    ],
 }

--- a/contrib/autopilot/test.py
+++ b/contrib/autopilot/test.py
@@ -81,16 +81,6 @@ def main():
     with tempfile.TemporaryDirectory(prefix="sockeye.autopilot.") as tmp_dir:
         work_dir = os.path.join(tmp_dir, "workspace")
 
-        # WNMT task with pre-tokenized data
-        command = [sys.executable,
-                   "-m",
-                   "contrib.autopilot.autopilot",
-                   "--task={}".format(WNMT_TASK),
-                   "--model=transformer",
-                   "--gpus=0",
-                   "--test"]
-        run_test(command, workspace=work_dir)
-
         # WMT task, prepare data only
         command = [sys.executable,
                    "-m",
@@ -101,7 +91,17 @@ def main():
                    "--test"]
         run_test(command, workspace=work_dir)
 
-        # WMT task with raw data
+        # WNMT task with pre-tokenized data (Transformer)
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--task={}".format(WNMT_TASK),
+                   "--model=transformer",
+                   "--gpus=0",
+                   "--test"]
+        run_test(command, workspace=work_dir)
+
+        # WMT task with raw data (Transformer)
         command = [sys.executable,
                    "-m",
                    "contrib.autopilot.autopilot",
@@ -111,7 +111,29 @@ def main():
                    "--test"]
         run_test(command, workspace=work_dir)
 
-        # Custom task (raw data)
+        # WNMT task with pre-tokenized data (GNMT)
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--task={}".format(WNMT_TASK),
+                   "--model=gnmt",
+                   "--decode-settings=gnmt",
+                   "--gpus=0",
+                   "--test"]
+        run_test(command, workspace=work_dir)
+
+        # WMT task with raw data (GNMT)
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--task={}".format(WMT_TASK),
+                   "--model=gnmt",
+                   "--decode-settings=gnmt",
+                   "--gpus=0",
+                   "--test"]
+        run_test(command, workspace=work_dir)
+
+        # Custom task (raw data Transformer)
         command = [sys.executable,
                    "-m",
                    "contrib.autopilot.autopilot",
@@ -140,7 +162,7 @@ def main():
                    "--test"]
         run_test(command, workspace=work_dir)
 
-        # Custom task (tokenized data)
+        # Custom task (tokenized data Transformer)
         command = [sys.executable,
                    "-m",
                    "contrib.autopilot.autopilot",
@@ -167,7 +189,7 @@ def main():
                    "--test"]
         run_test(command, workspace=work_dir)
 
-        # Custom task (byte-pair encoded data)
+        # Custom task (byte-pair encoded data Transformer)
         command = [sys.executable,
                    "-m",
                    "contrib.autopilot.autopilot",
@@ -189,6 +211,91 @@ def main():
                                 autopilot.DIR_BPE, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
                    "--custom-text-type=bpe",
                    "--model=transformer",
+                   "--gpus=0",
+                   "--test"]
+        run_test(command, workspace=work_dir)
+
+        # Custom task (raw data GNMT)
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--custom-task=custom_raw",
+                   "--custom-train",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-dev",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_DEV + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_DEV + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-test",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_RAW, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-lang",
+                   WMT_SRC,
+                   WMT_TRG,
+                   "--custom-bpe-op={}".format(WMT_BPE),
+                   "--model=gnmt",
+                   "--decode-settings=gnmt",
+                   "--gpus=0",
+                   "--test"]
+        run_test(command, workspace=work_dir)
+
+        # Custom task (tokenized data GNMT)
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--custom-task=custom_tok",
+                   "--custom-train",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-dev",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_DEV + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_DEV + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-test",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_TOK, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-text-type=tok",
+                   "--custom-bpe-op={}".format(WMT_BPE),
+                   "--model=gnmt",
+                   "--decode-settings=gnmt",
+                   "--gpus=0",
+                   "--test"]
+        run_test(command, workspace=work_dir)
+
+        # Custom task (byte-pair encoded data GNMT)
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--custom-task=custom_bpe",
+                   "--custom-train",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-dev",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_DEV + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_DEV + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-test",
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_SRC_GZ),
+                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
+                                autopilot.DIR_BPE, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
+                   "--custom-text-type=bpe",
+                   "--model=gnmt",
+                   "--decode-settings=gnmt",
                    "--gpus=0",
                    "--test"]
         run_test(command, workspace=work_dir)

--- a/contrib/autopilot/test.py
+++ b/contrib/autopilot/test.py
@@ -116,8 +116,8 @@ def main():
                    "-m",
                    "contrib.autopilot.autopilot",
                    "--task={}".format(WNMT_TASK),
-                   "--model=gnmt",
-                   "--decode-settings=gnmt",
+                   "--model=gnmt_like",
+                   "--decode-settings=gnmt_like",
                    "--gpus=0",
                    "--test"]
         run_test(command, workspace=work_dir)
@@ -127,8 +127,8 @@ def main():
                    "-m",
                    "contrib.autopilot.autopilot",
                    "--task={}".format(WMT_TASK),
-                   "--model=gnmt",
-                   "--decode-settings=gnmt",
+                   "--model=gnmt_like",
+                   "--decode-settings=gnmt_like",
                    "--gpus=0",
                    "--test"]
         run_test(command, workspace=work_dir)
@@ -239,8 +239,8 @@ def main():
                    WMT_SRC,
                    WMT_TRG,
                    "--custom-bpe-op={}".format(WMT_BPE),
-                   "--model=gnmt",
-                   "--decode-settings=gnmt",
+                   "--model=gnmt_like",
+                   "--decode-settings=gnmt_like",
                    "--gpus=0",
                    "--test"]
         run_test(command, workspace=work_dir)
@@ -267,8 +267,8 @@ def main():
                                 autopilot.DIR_TOK, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
                    "--custom-text-type=tok",
                    "--custom-bpe-op={}".format(WMT_BPE),
-                   "--model=gnmt",
-                   "--decode-settings=gnmt",
+                   "--model=gnmt_like",
+                   "--decode-settings=gnmt_like",
                    "--gpus=0",
                    "--test"]
         run_test(command, workspace=work_dir)
@@ -294,8 +294,8 @@ def main():
                    os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
                                 autopilot.DIR_BPE, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
                    "--custom-text-type=bpe",
-                   "--model=gnmt",
-                   "--decode-settings=gnmt",
+                   "--model=gnmt_like",
+                   "--decode-settings=gnmt_like",
                    "--gpus=0",
                    "--test"]
         run_test(command, workspace=work_dir)

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.44'
+__version__ = '1.18.45'


### PR DESCRIPTION
Hi, we trained a de-en gnmt model with 8 layers LSTM encoder & decoder using sockeye. The validation bleu on `newstests2016.de` has reached up to 26.91 both on CPU and GPU. Also, the translate performance is very good on CPU (around 24 sentences/sec on Skylake 8180 one socket) after some optimizations. We are going to add the model config to autopilot to enable out-of-box GNMT task.
@pengzhao-intel @TaoLv
#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

