### PR TITLE
Transformer Attention Probabilities

### DIFF
--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -343,7 +343,7 @@ class TransformerDecoder(Decoder):
         # average over layer probabilities
         attention_probs = mx.sym.mean(attention_probs, axis=0, keepdims=False)
         # average over heads
-        attention_probs = mx.sym.mean(attention_probs, axis=(1, 2), keepdims=False)
+        attention_probs = mx.sym.mean(attention_probs, axis=1, keepdims=False)
         return target, attention_probs, new_states
 
     def _get_cache_per_layer(self, cache: List[mx.sym.Symbol]) -> List[Dict[str, Optional[mx.sym.Symbol]]]:

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -330,6 +330,7 @@ class TransformerDecoder(Decoder):
             # store updated keys and values in states list.
             # (layer.__call__() has the side-effect of updating contents of layer_cache)
             new_states += [layer_cache['k'], layer_cache['v']]
+
             attention_probs.append(probs)
 
         # (batch_size, 1, model_size)
@@ -338,10 +339,15 @@ class TransformerDecoder(Decoder):
         target = mx.sym.reshape(target, shape=(-3, -1))
 
 
-        attention_probs = mx.sym.stack(*attention_probs, axis=0)
-        attention_probs = mx.sym.mean(attention_probs, axis=0, keepdims=False)
-        attention_probs = mx.sym.mean(attention_probs, axis=0, keepdims=False)
-        #attention_probs = mx.sym.mean(probs, axis=0, keepdims=False)
+        #attention_probs = mx.sym.stack(*attention_probs, axis=0)
+        #attention_probs = mx.sym.mean(attention_probs, axis=0, keepdims=False)
+        # (batch, heads, length, depth_per_head)
+        #attention_probs = mx.sym.reshape(data=attention_probs, shape=(-4, -1, self.config.attention_heads, 0, int(512/self.config.attention_heads)))
+        # biku nesmuki - 512 vaieta jabut attention dim
+
+        attention_probs = mx.sym.mean(probs, axis=(1,2), keepdims=False)
+        #attention_probs = mx.sym.mean(attention_probs, axis=, keepdims=False)
+        #attention_probs = mx.sym.mean(probs, axis=-1, keepdims=False)
         return target, attention_probs, new_states
 
     def _get_cache_per_layer(self, cache: List[mx.sym.Symbol]) -> List[Dict[str, Optional[mx.sym.Symbol]]]:

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -340,7 +340,9 @@ class TransformerDecoder(Decoder):
         target = mx.sym.reshape(target, shape=(-3, -1))
 
         attention_probs = mx.sym.stack(*attention_probs, axis=0)
+        # average over layer probabilities
         attention_probs = mx.sym.mean(attention_probs, axis=0, keepdims=False)
+        # average over heads
         attention_probs = mx.sym.mean(attention_probs, axis=(1, 2), keepdims=False)
         return target, attention_probs, new_states
 

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -269,7 +269,7 @@ class TransformerDecoder(Decoder):
             target = mx.sym.Dropout(data=target, p=self.config.dropout_prepost)
 
         for layer in self.layers:
-            target = layer(target=target,
+            target, probs = layer(target=target,
                            target_bias=target_bias,
                            source=source_encoded,
                            source_bias=source_bias)

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -339,15 +339,11 @@ class TransformerDecoder(Decoder):
         target = mx.sym.reshape(target, shape=(-3, -1))
 
 
-        #attention_probs = mx.sym.stack(*attention_probs, axis=0)
-        #attention_probs = mx.sym.mean(attention_probs, axis=0, keepdims=False)
-        # (batch, heads, length, depth_per_head)
-        #attention_probs = mx.sym.reshape(data=attention_probs, shape=(-4, -1, self.config.attention_heads, 0, int(512/self.config.attention_heads)))
-        # biku nesmuki - 512 vaieta jabut attention dim
+        attention_probs = mx.sym.stack(*attention_probs, axis=0)
 
-        attention_probs = mx.sym.mean(probs, axis=(1,2), keepdims=False)
-        #attention_probs = mx.sym.mean(attention_probs, axis=, keepdims=False)
-        #attention_probs = mx.sym.mean(probs, axis=-1, keepdims=False)
+        attention_probs = mx.sym.mean(attention_probs, axis=0, keepdims=False)
+
+        attention_probs = mx.sym.mean(attention_probs, axis=(1,2), keepdims=False)
         return target, attention_probs, new_states
 
     def _get_cache_per_layer(self, cache: List[mx.sym.Symbol]) -> List[Dict[str, Optional[mx.sym.Symbol]]]:

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -631,8 +631,8 @@ class MultiHeadAttentionWithProbs(MultiHeadAttention):
 
         # (batch, query_max_length, depth)
         contexts = combine_heads(contexts, self.depth_per_head, self.heads)
-        # (batch, length, heads, depth_per_head)
-        attention_probs = mx.sym.reshape(data=probs, shape=(-4, -1, self.heads, 0, query_max_length))
+        # (batch, length, heads, query_max_length)
+        attention_probs = mx.sym.reshape(data=probs, shape=(-4, -1, self.heads, 0, query_max_length)) # <- where/how to get query_max_length
 
         # contexts: (batch, query_max_length, output_depth)
         contexts = mx.sym.FullyConnected(data=contexts,

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -615,7 +615,7 @@ class MultiHeadAttentionWithProbs(MultiHeadAttention):
         :param lengths: Optional lengths of keys. Shape: (batch_size,).
         :param bias: Optional 3d bias.
         :return: Context vectors: Shape: (batch_size, query_max_length, output_depth).
-        :return: Attention probabilities: Shape: (batch_size, 1, heads, source_length).
+        :return: Attention probabilities: Shape: (batch_size, length, heads, source_length).
         """
         # scale by sqrt(depth_per_head)
         queries = queries * (self.depth_per_head ** -0.5)
@@ -634,7 +634,9 @@ class MultiHeadAttentionWithProbs(MultiHeadAttention):
         contexts = combine_heads(contexts, self.depth_per_head, self.heads)
         # (batch, length, heads, source_length)
         attention_probs = mx.sym.reshape(data=attention_probs, shape=(-4, -1, self.heads, 0, 0))
-
+        # MultiHeadAttentionWithProbs is only used in Encoder therefore length=1 so we can drop it
+        # (batch, heads, source_length)
+        attention_probs = mx.sym.reshape(data=attention_probs, shape=(0, -3, 0))
         # contexts: (batch, query_max_length, output_depth)
         contexts = mx.sym.FullyConnected(data=contexts,
                                          weight=self.w_h2o,

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -632,7 +632,7 @@ class MultiHeadAttentionWithProbs(MultiHeadAttention):
         # (batch, query_max_length, depth)
         contexts = combine_heads(contexts, self.depth_per_head, self.heads)
         # (batch, length, heads, query_max_length)
-        attention_probs = mx.sym.reshape(data=probs, shape=(-4, -1, self.heads, 0, 0)) # <- where/how to get query_max_length
+        attention_probs = mx.sym.reshape(data=probs, shape=(-4, -1, self.heads, 0, 0))
 
         # contexts: (batch, query_max_length, output_depth)
         contexts = mx.sym.FullyConnected(data=contexts,

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -44,7 +44,7 @@ def activation(data: mx.sym.Symbol, act_type: str) -> mx.sym.Symbol:
         return data * mx.sym.Activation(data, act_type="sigmoid")
     elif act_type == C.GELU:
         # Approximation of x * gaussian_cdf(x) used by Hendrycks and Gimpel
-        return 0.5 * data * (1 + mx.sym.Activation((math.sqrt(2 / math.pi) * (data + (0.044715 * (data**3)))),
+        return 0.5 * data * (1 + mx.sym.Activation((math.sqrt(2 / math.pi) * (data + (0.044715 * (data ** 3)))),
                                                    act_type="tanh"))
     else:
         return mx.sym.Activation(data, act_type=act_type)
@@ -60,6 +60,7 @@ class LayerNormalization:
     :param scale_init: Initial value of scale variable if scale is None. Default 1.0.
     :param shift_init: Initial value of shift variable if shift is None. Default 0.0.
     """
+
     def __init__(self,
                  prefix: str = 'layernorm',
                  scale: Optional[mx.sym.Symbol] = None,
@@ -99,6 +100,7 @@ class LHUC:
     :param weight: Optional parameter vector.
     :param prefix: Optional prefix for created parameters (if not given as weight).
     """
+
     def __init__(self,
                  num_hidden: int,
                  weight: Optional[mx.sym.Symbol] = None,
@@ -376,7 +378,6 @@ def dot_attention_with_probs(queries: mx.sym.Symbol,
     return mx.sym.batch_dot(lhs=probs_with_dropout, rhs=values, name='%scontexts' % prefix), probs
 
 
-
 class MultiHeadAttentionBase:
     """
     Base class for Multi-head attention.
@@ -387,6 +388,7 @@ class MultiHeadAttentionBase:
     :param depth_out: Output depth / number of output units.
     :param dropout: Dropout probability on attention scores
     """
+
     def __init__(self,
                  prefix: str,
                  depth_att: int = 512,
@@ -457,6 +459,7 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
     :param depth_out: Output depth / number of output units.
     :param dropout: Dropout probability on attention scores
     """
+
     def __init__(self,
                  prefix: str,
                  depth_att: int = 512,
@@ -615,7 +618,7 @@ class MultiHeadAttentionWithProbs(MultiHeadAttention):
         :param lengths: Optional lengths of keys. Shape: (batch_size,).
         :param bias: Optional 3d bias.
         :return: Context vectors: Shape: (batch_size, query_max_length, output_depth).
-        :return: Attention probabilities: Shape: (batch_size, length, heads, source_length).
+        :return: Attention probabilities: Shape: (batch_size, heads, source_length).
         """
         # scale by sqrt(depth_per_head)
         queries = queries * (self.depth_per_head ** -0.5)
@@ -628,7 +631,8 @@ class MultiHeadAttentionWithProbs(MultiHeadAttention):
 
         # (batch*heads, query_max_length, depth_per_head), (batch*heads, query_max_length, source_length)
         contexts, attention_probs = dot_attention_with_probs(queries, keys, values,
-                                                   lengths=lengths, dropout=self.dropout, bias=bias, prefix=self.prefix)
+                                                             lengths=lengths, dropout=self.dropout, bias=bias,
+                                                             prefix=self.prefix)
 
         # (batch, query_max_length, depth)
         contexts = combine_heads(contexts, self.depth_per_head, self.heads)
@@ -637,6 +641,7 @@ class MultiHeadAttentionWithProbs(MultiHeadAttention):
         # MultiHeadAttentionWithProbs is only used in Encoder therefore length=1 so we can drop it
         # (batch, heads, source_length)
         attention_probs = mx.sym.reshape(data=attention_probs, shape=(0, -3, 0))
+
         # contexts: (batch, query_max_length, output_depth)
         contexts = mx.sym.FullyConnected(data=contexts,
                                          weight=self.w_h2o,

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -632,7 +632,7 @@ class MultiHeadAttentionWithProbs(MultiHeadAttention):
         # (batch, query_max_length, depth)
         contexts = combine_heads(contexts, self.depth_per_head, self.heads)
         # (batch, length, heads, query_max_length)
-        attention_probs = mx.sym.reshape(data=probs, shape=(-4, -1, self.heads, 0, query_max_length)) # <- where/how to get query_max_length
+        attention_probs = mx.sym.reshape(data=probs, shape=(-4, -1, self.heads, 0, 0)) # <- where/how to get query_max_length
 
         # contexts: (batch, query_max_length, output_depth)
         contexts = mx.sym.FullyConnected(data=contexts,

--- a/sockeye/output_handler.py
+++ b/sockeye/output_handler.py
@@ -189,7 +189,7 @@ class StringWithAlignmentMatrixOutputHandler(StringOutputHandler):
                                       source=" ".join(t_input.tokens),
                                       source_len=len(t_input.tokens),
                                       target_len=len(t_output.tokens)))
-        attention_matrix = t_output.attention_matrix.T
+        attention_matrix = t_output.attention_matrix
         for i in range(0, attention_matrix.shape[0]):
             attention_vector = attention_matrix[i]
             self.stream.write(" ".join(["%f" % value for value in attention_vector]))

--- a/sockeye/output_handler.py
+++ b/sockeye/output_handler.py
@@ -189,7 +189,7 @@ class StringWithAlignmentMatrixOutputHandler(StringOutputHandler):
                                       source=" ".join(t_input.tokens),
                                       source_len=len(t_input.tokens),
                                       target_len=len(t_output.tokens)))
-        attention_matrix = t_output.attention_matrix
+        attention_matrix = t_output.attention_matrix.T
         for i in range(0, attention_matrix.shape[0]):
             attention_vector = attention_matrix[i]
             self.stream.write(" ".join(["%f" % value for value in attention_vector]))

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -95,8 +95,9 @@ class TransformerEncoderBlock:
                                                dropout=config.dropout_prepost,
                                                prefix="%sff_post_" % prefix)
         self.lhuc = None
-        if config.use_lhuc:
-            self.lhuc = layers.LHUC(config.model_size, prefix=prefix)
+        if hasattr(config, 'use_lhuc'):
+            if config.use_lhuc:
+                self.lhuc = layers.LHUC(config.model_size, prefix=prefix)
 
     def __call__(self, data: mx.sym.Symbol, bias: mx.sym.Symbol) -> mx.sym.Symbol:
         # self-attention
@@ -162,8 +163,9 @@ class TransformerDecoderBlock:
                                                prefix="%sff_post_" % prefix)
 
         self.lhuc = None
-        if config.use_lhuc:
-            self.lhuc = layers.LHUC(config.model_size, prefix=prefix)
+        if hasattr(config, 'use_lhuc'):
+            if config.use_lhuc:
+                self.lhuc = layers.LHUC(config.model_size, prefix=prefix)
 
     def __call__(self,
                  target: mx.sym.Symbol,

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -179,8 +179,8 @@ class TransformerDecoderBlock:
 
         # encoder attention
         target_enc_att, attention_probs = self.enc_attention(queries=self.pre_enc_attention(target, None),
-                                            memory=source,
-                                            bias=source_bias)
+                                                             memory=source,
+                                                             bias=source_bias)
         target = self.post_enc_attention(target_enc_att, target)
 
         # feed-forward
@@ -382,7 +382,7 @@ class AutoRegressiveBias(mx.operator.CustomOp):
     0 0 0 0
     """
 
-    def __init__(self, length: int, dtype:str, ctx: mx.Context) -> None:
+    def __init__(self, length: int, dtype: str, ctx: mx.Context) -> None:
         super().__init__()
         self.bias = self.get_bias(length, dtype, ctx)
 

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -140,11 +140,11 @@ class TransformerDecoderBlock:
         self.pre_enc_attention = TransformerProcessBlock(sequence=config.preprocess_sequence,
                                                          dropout=config.dropout_prepost,
                                                          prefix="%satt_enc_pre_" % prefix)
-        self.enc_attention = layers.MultiHeadAttentionProbs(depth_att=config.model_size,
-                                                       heads=config.attention_heads,
-                                                       depth_out=config.model_size,
-                                                       dropout=config.dropout_attention,
-                                                       prefix="%satt_enc_" % prefix)
+        self.enc_attention = layers.MultiHeadAttentionWithProbs(depth_att=config.model_size,
+                                                                heads=config.attention_heads,
+                                                                depth_out=config.model_size,
+                                                                dropout=config.dropout_attention,
+                                                                prefix="%satt_enc_" % prefix)
         self.post_enc_attention = TransformerProcessBlock(sequence=config.postprocess_sequence,
                                                           dropout=config.dropout_prepost,
                                                           prefix="%satt_enc_post_" % prefix)

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -178,7 +178,7 @@ class TransformerDecoderBlock:
         target = self.post_self_attention(target_self_att, target)
 
         # encoder attention
-        target_enc_att, probs = self.enc_attention(queries=self.pre_enc_attention(target, None),
+        target_enc_att, attention_probs = self.enc_attention(queries=self.pre_enc_attention(target, None),
                                             memory=source,
                                             bias=source_bias)
         target = self.post_enc_attention(target_enc_att, target)
@@ -190,7 +190,7 @@ class TransformerDecoderBlock:
         if self.lhuc:
             target = self.lhuc(target)
 
-        return target, probs
+        return target, attention_probs
 
 
 class TransformerProcessBlock:

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -140,7 +140,7 @@ class TransformerDecoderBlock:
         self.pre_enc_attention = TransformerProcessBlock(sequence=config.preprocess_sequence,
                                                          dropout=config.dropout_prepost,
                                                          prefix="%satt_enc_pre_" % prefix)
-        self.enc_attention = layers.MultiHeadAttention(depth_att=config.model_size,
+        self.enc_attention = layers.MultiHeadAttentionProbs(depth_att=config.model_size,
                                                        heads=config.attention_heads,
                                                        depth_out=config.model_size,
                                                        dropout=config.dropout_attention,
@@ -178,7 +178,7 @@ class TransformerDecoderBlock:
         target = self.post_self_attention(target_self_att, target)
 
         # encoder attention
-        target_enc_att = self.enc_attention(queries=self.pre_enc_attention(target, None),
+        target_enc_att, probs = self.enc_attention(queries=self.pre_enc_attention(target, None),
                                             memory=source,
                                             bias=source_bias)
         target = self.post_enc_attention(target_enc_att, target)
@@ -190,7 +190,7 @@ class TransformerDecoderBlock:
         if self.lhuc:
             target = self.lhuc(target)
 
-        return target
+        return target, probs
 
 
 class TransformerProcessBlock:

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -629,7 +629,7 @@ def acquire_gpus(requested_device_ids: List[int], lock_dir: str = "/tmp",
             if master_lock is not None and not any_failed:
                 try:
                     yield acquired_gpus
-                except:
+                except:  # pylint: disable=try-except-raise
                     raise
                 return
 


### PR DESCRIPTION
This change adds attention probabilities for transformer decoder and completes  [TODO](https://github.com/awslabs/sockeye/blob/527de3805df79710bbb17227da1ed100080b5384/sockeye/decoder.py#L338) by @fhieber. 
Specifically, we compute transformer attention probabilities as the average attention probabilities over all attention heads in all layers. 
To do so, we create, `MultiHeadAttentionWithProbs`, a subclass of `MultiHeadAttention` which overrides `_attend` to return attention probabilities. 

To evaluate the resulting attention probability matrices we used them as a basis for discrete word alignments. The resulting alignments were then compared against:
-  alignments obtained from LSTM attention matrices,
-  alignments by _FastAlign_.

When conducting a human evaluation, we found that resulting word alignments are on average judged as acceptable as word alignments from LSTM attention matrices and strictly better than alignments by _FastAlign_. 

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

