### PR TITLE
Change to use MXNet's topk for CPUs in inference

### DIFF
--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1021,7 +1021,7 @@ class Translator:
                              k=self.beam_size,
                              batch_size=self.batch_size,
                              offset=self.offset,
-                             use_mxnet_topk=self.context != mx.cpu())  # MXNet implementation is faster on GPUs
+                             use_mxnet_topk=True)
 
         self._sort_by_index = SortByIndex()
         self._sort_by_index.initialize(ctx=self.context)


### PR DESCRIPTION
Since MXNet's topk has better performance than numpy version with
PR https://github.com/apache/incubator-mxnet/pull/12085, in order
to leverage such performance boost, change to use MXNet's topk for
CPU device when doing inference.

(description of the change)

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

