### PR TITLE
No longer relying on external translation id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.47]
+### Changed
+- translate CLI: no longer rely on external, user-given input id for sorting translations. Also allow string ids for sentences.
+
 ## [1.18.46]
 ### Fixed
 - Fixed issue with `--num-words 0:0` in image captioning and another issue related to loading all features to memory with variable length.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.46'
+__version__ = '1.18.47'

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1184,12 +1184,13 @@ class Translator:
         # Concatenate results
         results = []  # type: List[TranslatorOutput]
         chunks_by_input_idx = itertools.groupby(translated_chunks, key=lambda translation: translation.input_idx)
-        for trans_input, (input_idx, chunks) in zip(trans_inputs, chunks_by_input_idx):
-            chunks = list(chunks)  # type: ignore
-            if len(chunks) == 1:  # type: ignore
-                translation = chunks[0].translation  # type: ignore
+        for trans_input, (input_idx, translations_for_input_idx) in zip(trans_inputs, chunks_by_input_idx):
+            translations_for_input_idx = list(translations_for_input_idx)  # type: ignore
+            if len(translations_for_input_idx) == 1:  # type: ignore
+                translation = translations_for_input_idx[0].translation  # type: ignore
             else:
-                translations_to_concat = [translated_chunk.translation for translated_chunk in chunks]
+                translations_to_concat = [translated_chunk.translation
+                                          for translated_chunk in translations_for_input_idx]
                 translation = self._concat_translations(translations_to_concat)
 
             results.append(self._make_result(trans_input, translation))

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1110,11 +1110,11 @@ class Translator:
             # bad input
             if isinstance(trans_input, BadTranslatorInput):
                 translated_chunks.append(IndexedTranslation(input_idx=trans_input_idx, chunk_idx=0,
-                                                         translation=empty_translation()))
+                                                            translation=empty_translation()))
             # empty input
             elif len(trans_input.tokens) == 0:
                 translated_chunks.append(IndexedTranslation(input_idx=trans_input_idx, chunk_idx=0,
-                                                         translation=empty_translation()))
+                                                            translation=empty_translation()))
             else:
                 # TODO(tdomhan): Remove branch without EOS with next major version bump, as future models will always be trained with source side EOS symbols
                 if self.source_with_eos:
@@ -1152,7 +1152,7 @@ class Translator:
                         # regular input
                         input_chunks.append(IndexedTranslatorInput(trans_input_idx,
                                                                    chunk_idx=0,
-                                                                   translator_input=trans_input.with_eos()))
+                                                                   translator_input=trans_input))
 
             if trans_input.constraints is not None:
                 logger.info("Input %d has %d %s: %s", trans_input.sentence_id,

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -571,7 +571,7 @@ class TranslatorInput:
     """
     Object required by Translator.translate().
 
-    :param sentence_id: SentenceId.
+    :param sentence_id: Sentence id.
     :param tokens: List of input tokens.
     :param factors: Optional list of additional factor sequences.
     :param constraints: Optional list of target-side constraints.
@@ -645,7 +645,7 @@ class TranslatorInput:
 
 class BadTranslatorInput(TranslatorInput):
 
-    def __init__(self, sentence_id: SentenceId, tokens: Tokens):
+    def __init__(self, sentence_id: SentenceId, tokens: Tokens) -> None:
         super().__init__(sentence_id=sentence_id, tokens=tokens, factors=None)
 
 
@@ -658,7 +658,7 @@ def make_input_from_plain_string(sentence_id: SentenceId, string: str) -> Transl
     """
     Returns a TranslatorInput object from a plain string.
 
-    :param sentence_id: SentenceId.
+    :param sentence_id: Sentence id.
     :param string: An input string.
     :return: A TranslatorInput.
     """
@@ -669,7 +669,7 @@ def make_input_from_json_string(sentence_id: SentenceId, json_string: str) -> Tr
     """
     Returns a TranslatorInput object from a JSON object, serialized as a string.
 
-    :param sentence_id: SentenceId.
+    :param sentence_id: Sentence id.
     :param json_string: A JSON object serialized as a string that must contain a key "text", mapping to the input text,
            and optionally a key "factors" that maps to a list of strings, each of which representing a factor sequence
            for the input text.
@@ -722,7 +722,7 @@ def make_input_from_factored_string(sentence_id: SentenceId,
     Returns a TranslatorInput object from a string with factor annotations on a token level, separated by delimiter.
     If translator does not require any source factors, the string is parsed as a plain token string.
 
-    :param sentence_id: SentenceId.
+    :param sentence_id: Sentence id.
     :param factored_string: An input string with additional factors per token, separated by delimiter.
     :param translator: A translator object.
     :param delimiter: A factor delimiter. Default: '|'.
@@ -759,7 +759,7 @@ def make_input_from_multiple_strings(sentence_id: SentenceId, strings: List[str]
     Returns a TranslatorInput object from multiple strings, where the first element corresponds to the surface tokens
     and the remaining elements to additional factors. All strings must parse into token sequences of the same length.
 
-    :param sentence_id: SentenceId.
+    :param sentence_id: Sentence id.
     :param strings: A list of strings representing a factored input sequence.
     :return: A TranslatorInput.
     """
@@ -778,7 +778,7 @@ class TranslatorOutput:
     """
     Output structure from Translator.
 
-    :param sentence_id: SentenceId.
+    :param sentence_id: Sentence id.
     :param translation: Translation string without sentence boundary tokens.
     :param tokens: List of translated tokens.
     :param attention_matrix: Attention matrix. Shape: (target_length, source_length).

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -574,7 +574,6 @@ class TranslatorInput:
     :param tokens: List of input tokens.
     :param factors: Optional list of additional factor sequences.
     :param constraints: Optional list of target-side constraints.
-    :param chunk_id: Chunk id. Defaults to -1.
     """
 
     __slots__ = ('sentence_id', 'tokens', 'factors', 'constraints', 'avoid_list')

--- a/sockeye/output_handler.py
+++ b/sockeye/output_handler.py
@@ -182,7 +182,7 @@ class StringWithAlignmentMatrixOutputHandler(StringOutputHandler):
         :param t_output: Translator output.
         :param t_walltime: Total wall-clock time for translation.
         """
-        line = "{sent_id:d} ||| {target} ||| {score:f} ||| {source} ||| {source_len:d} ||| {target_len:d}\n"
+        line = "{sent_id} ||| {target} ||| {score:f} ||| {source} ||| {source_len:d} ||| {target_len:d}\n"
         self.stream.write(line.format(sent_id=t_input.sentence_id,
                                       target=" ".join(t_output.tokens),
                                       score=t_output.score,
@@ -244,7 +244,7 @@ class AlignPlotHandler(OutputHandler):
         plot_attention(t_output.attention_matrix,
                        t_input.tokens,
                        t_output.tokens,
-                       "%s_%d.png" % (self.plot_prefix, t_input.sentence_id))
+                       "%s_%s.png" % (self.plot_prefix, t_input.sentence_id))
 
 
 class AlignTextHandler(OutputHandler):
@@ -297,6 +297,6 @@ class BeamStoringHandler(OutputHandler):
             # Add the number of steps in each beam
             h["number_steps"] = len(h["predicted_tokens"])  # type: ignore
             # Some outputs can have more than one beam, add the id for bookkeeping
-            h["id"] = t_output.id  # type: ignore
+            h["id"] = t_output.sentence_id  # type: ignore
             self.stream.write("%s\n" % json.dumps(h, sort_keys=True))
         self.stream.flush()

--- a/test/unit/test_inference.py
+++ b/test/unit/test_inference.py
@@ -143,13 +143,11 @@ def test_translator_input(sentence_id, sentence, factors, chunk_size):
     if factors is not None:
         for factor in trans_input.factors:
             assert len(factor) == len(tokens)
-    assert trans_input.chunk_id == -1
 
     chunked_inputs = list(trans_input.chunks(chunk_size))
     assert len(chunked_inputs) == ceil(len(tokens) / chunk_size)
     for chunk_id, chunk_input in enumerate(chunked_inputs):
         assert chunk_input.sentence_id == sentence_id
-        assert chunk_input.chunk_id == chunk_id
         assert chunk_input.tokens == trans_input.tokens[chunk_id * chunk_size: (chunk_id + 1) * chunk_size]
         if factors:
             assert len(chunk_input.factors) == len(factors)
@@ -228,7 +226,6 @@ def test_make_input_from_factored_string(sentence, num_expected_factors, delimit
                                                             translator=translator, delimiter=delimiter)
     assert isinstance(inp, sockeye.inference.TranslatorInput)
     assert inp.sentence_id == sentence_id
-    assert inp.chunk_id == -1
     assert inp.tokens == expected_tokens
     assert inp.factors == expected_factors
     if num_expected_factors > 1:

--- a/test/unit/test_output_handler.py
+++ b/test/unit/test_output_handler.py
@@ -12,28 +12,30 @@
 # permissions and limitations under the License.
 
 import io
-import pytest
+
 import numpy as np
-from sockeye.inference import TranslatorInput, TranslatorOutput
+import pytest
+
 import sockeye.output_handler
+from sockeye.inference import TranslatorInput, TranslatorOutput
 
 stream_handler_tests = [(sockeye.output_handler.StringOutputHandler(io.StringIO()),
                          TranslatorInput(sentence_id=0, tokens=[], factors=[], constraints=[]),
-                         TranslatorOutput(id=0, translation="ein Test", tokens=None,
+                         TranslatorOutput(sentence_id=0, translation="ein Test", tokens=None,
                                           attention_matrix=None,
                                           score=0.),
                          0.,
                          "ein Test\n"),
                         (sockeye.output_handler.StringOutputHandler(io.StringIO()),
                          TranslatorInput(sentence_id=0, tokens=[], factors=[]),
-                         TranslatorOutput(id=0, translation="", tokens=None,
+                         TranslatorOutput(sentence_id=0, translation="", tokens=None,
                                           attention_matrix=None,
                                           score=0.),
                          0.,
                          "\n"),
                         (sockeye.output_handler.StringWithAlignmentsOutputHandler(io.StringIO(), threshold=0.5),
                          TranslatorInput(sentence_id=0, tokens="a test".split(), factors=[]),
-                         TranslatorOutput(id=0, translation="ein Test", tokens=None,
+                         TranslatorOutput(sentence_id=0, translation="ein Test", tokens=None,
                                           attention_matrix=np.asarray([[1, 0],
                                                                        [0, 1]]),
                                           score=0.),
@@ -41,7 +43,7 @@ stream_handler_tests = [(sockeye.output_handler.StringOutputHandler(io.StringIO(
                          "ein Test\t0-0 1-1\n"),
                         (sockeye.output_handler.StringWithAlignmentsOutputHandler(io.StringIO(), threshold=0.5),
                          TranslatorInput(sentence_id=0, tokens="a test".split(), factors=[]),
-                         TranslatorOutput(id=0, translation="ein Test !", tokens=None,
+                         TranslatorOutput(sentence_id=0, translation="ein Test !", tokens=None,
                                           attention_matrix=np.asarray([[0.4, 0.6],
                                                                        [0.8, 0.2],
                                                                        [0.5, 0.5]]),
@@ -50,14 +52,14 @@ stream_handler_tests = [(sockeye.output_handler.StringOutputHandler(io.StringIO(
                          "ein Test !\t0-1 1-0\n"),
                         (sockeye.output_handler.BenchmarkOutputHandler(io.StringIO()),
                          TranslatorInput(sentence_id=0, tokens=["a", "test"], factors=[]),
-                         TranslatorOutput(id=0, translation="ein Test", tokens=["ein", "Test"],
+                         TranslatorOutput(sentence_id=0, translation="ein Test", tokens=["ein", "Test"],
                                           attention_matrix=None,
                                           score=0.),
                          0.5,
                          "input=a test\toutput=ein Test\tinput_tokens=2\toutput_tokens=2\ttranslation_time=0.5000\n"),
                         (sockeye.output_handler.BeamStoringHandler(io.StringIO()),
                          TranslatorInput(sentence_id=0, tokens=["What"]),
-                         TranslatorOutput(id=0, translation="Was", tokens=["Was"],
+                         TranslatorOutput(sentence_id=0, translation="Was", tokens=["Was"],
                                           attention_matrix=None, score=0.,
                                           beam_histories=[
                                               {"predicted_ids": [[258, 137, 31],


### PR DESCRIPTION
We used to rely on the external id for sorting the translations correctly, which is not necessary and can cause some issues. With this change we still carry through the externally provided id to the user, but no longer rely on it internally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

