### PR TITLE
bugfix in source factor check (fixes #513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.50]
+### Fixed
+- Check for equivalency of training and validation source factors was incorrectly indented.
+
 ## [1.18.49]
 ### Changed
 - Removed dependence on the nvidia-smi tool. The number of GPUs is now determined programatically.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.49'
+__version__ = '1.18.50'

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -279,9 +279,9 @@ def create_data_iters_and_vocabs(args: argparse.Namespace,
             utils.check_condition(vocab.are_identical(target_vocab, model_target_vocab),
                                   "Prepared data and resumed model target vocabs do not match.")
 
-        check_condition(len(args.source_factors) == len(args.validation_source_factors),
-                        'Training and validation data must have the same number of factors: %d vs. %d.' % (
-                            len(args.source_factors), len(args.validation_source_factors)))
+        check_condition(data_config.num_source_factors == len(validation_sources),
+                        'Training and validation data must have the same number of factors, but found %d and %d.' % (
+                            data_config.num_source_factors, len(validation_sources)))
 
         return train_iter, validation_iter, data_config, source_vocabs, target_vocab
 
@@ -321,6 +321,10 @@ def create_data_iters_and_vocabs(args: argparse.Namespace,
 
         sources = [args.source] + args.source_factors
         sources = [str(os.path.abspath(source)) for source in sources]
+
+        check_condition(len(sources) == len(validation_sources),
+                        'Training and validation data must have the same number of factors, but found %d and %d.' % (
+                            len(source_vocabs), len(validation_sources)))
 
         train_iter, validation_iter, config_data, data_info = data_io.get_training_data_iters(
             sources=sources,

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -279,9 +279,9 @@ def create_data_iters_and_vocabs(args: argparse.Namespace,
             utils.check_condition(vocab.are_identical(target_vocab, model_target_vocab),
                                   "Prepared data and resumed model target vocabs do not match.")
 
-            check_condition(len(args.source_factors) == len(args.validation_source_factors),
-                            'Training and validation data must have the same number of factors: %d vs. %d.' % (
-                                len(args.source_factors), len(args.validation_source_factors)))
+        check_condition(len(args.source_factors) == len(args.validation_source_factors),
+                        'Training and validation data must have the same number of factors: %d vs. %d.' % (
+                            len(args.source_factors), len(args.validation_source_factors)))
 
         return train_iter, validation_iter, data_config, source_vocabs, target_vocab
 


### PR DESCRIPTION
The check for source factor equivalence between training and validation data was incorrectly indented.
