### PR TITLE
[WIP] Dynamic batch_size during inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.51]
+### Changed
+- Batch size is now specified during inference runtime, rather than preallocated.
+### Added
+- Added option for --use-dynamic-batch-size, to allow Sockeye to support dynamic batch sizes during inference (on STDIN with json input only).
+
 ## [1.18.50]
 ### Fixed
 - Check for equivalency of training and validation source factors was incorrectly indented.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 pyyaml==3.12
-mxnet-mkl==1.2.1
+mxnet-mkl>=1.2.1
 numpy>=1.14
 typing

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.50'
+__version__ = '1.18.51'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1139,6 +1139,14 @@ def add_inference_args(params):
                                type=int,
                                default=None,
                                help='Maximum input sequence length. Default: value from model(s).')
+    decode_params.add_argument('--use-dynamic-batch-size',
+                               action='store_true',
+                               default=False,
+                               help='Turning on this option allows inference to be done with dynamic batch-sizes, up to the'
+                                    'specified value in the --batch-size argument.  NOTE: This option can only be used when'
+                                    'reading from STDIN for translation using the built-in interface - otherwise the option'
+                                    'will simply be disregarded. Default: False')
+
     decode_params.add_argument('--softmax-temperature',
                                type=float,
                                default=None,

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -206,6 +206,7 @@ def test_training_arg(test_params, expected_params):
                       ensemble_mode='linear',
                       bucket_width=10,
                       max_input_len=None,
+                      use_dynamic_batch_size=False,
                       restrict_lexicon=None,
                       restrict_lexicon_topk=None,
                       avoid_list=None,

--- a/test/unit/test_inference.py
+++ b/test/unit/test_inference.py
@@ -303,6 +303,34 @@ def test_failed_make_input_from_valid_json_string(text, text_key, factors, facto
     inp = sockeye.inference.make_input_from_json_string(sentence_id, json.dumps({text_key: text, factors_key: factors}))
     assert isinstance(inp, sockeye.inference.BadTranslatorInput)
 
+@pytest.mark.parametrize("inputs",
+                         [[{"text": "this is a test without factors", "factors": None},
+                           {"text": "", "factors": None},
+                           {"text": "test", "factors": ["X", "X"]},
+                           {"text": "a b c", "factors": ["x y z"]},
+                           {"text": "a", "factors": []}]])
+def test_make_inputs_from_valid_json_string_list(inputs):
+    sentence_id = 1
+    expected_tokens = [list(sockeye.data_io.get_tokens(json_obj["text"])) for json_obj in inputs]
+    expected_factors = [json_obj["factors"] for json_obj in inputs]
+    inp = sockeye.inference.make_inputs_from_json_string_list(sentence_id, json.dumps(inputs))
+    assert len(inp) == len(expected_tokens)
+    for parsed_json, expected_token_list, expected_factor_list in zip(inp, expected_tokens, expected_factors):
+        assert len(parsed_json.tokens) == len(expected_token_list)
+        assert parsed_json.tokens == expected_token_list
+        if expected_factor_list is not None:
+            assert len(parsed_json.factors) == len(expected_factor_list)
+        else:
+            assert parsed_json.factors is None
+
+
+@pytest.mark.parametrize("text, text_key, factors, factors_key", [("a", "blub", None, "")])
+def test_failed_make_inputs_from_valid_json_string_list(text, text_key, factors, factors_key):
+    sentence_id = 1
+    inp = sockeye.inference.make_inputs_from_json_string_list(sentence_id, json.dumps({text_key: text, factors_key: factors}))
+    for actual in inp:
+        assert isinstance(actual, sockeye.inference.BadTranslatorInput)
+
 
 @pytest.mark.parametrize("strings",
                          [


### PR DESCRIPTION
Added option for --use-dynamic-batch-size, to allow Sockeye to support dynamic batch sizes during inference (on STDIN with json input only).

### Notes
This change makes the the "batch_size" argument dynamic, such that a user could specify a different batch_size per invocation. The default behavior of the pipeline is unchanged if you do not specify this option, and I have verified below that this does not have an impact on latency. I have also verified that there is no diff in the translation results whatsoever in the standard use-case.

This of course, may not be the case if we are to batch sentences together. If needed, we can do more extensive testing on that.

### Testing
Added new unit test cases, and everything passes.

For the dataset below:
```
[samples  202] [mean 18.30 tok] [+/- 12.61 tok] [max 123.00] [min 5.00]
```

#### Before Change
```
[samples  202] [mean 88.446089 tok/s] [+/- 22.044562 tok/s] [max 164.731684] [min 25.449224]
```

#### After Change
```
[samples  202] [mean 88.533140 tok/s] [+/- 22.097902 tok/s] [max 167.662940] [min 25.452589]
```

Note that this confirms that there should be no impact to latency.

#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

