### PR TITLE
Add sentence-level BLEU function to sacrebleu

### DIFF
--- a/contrib/sacrebleu/CHANGELOG.md
+++ b/contrib/sacrebleu/CHANGELOG.md
@@ -1,5 +1,8 @@
 # VERSION HISTORY
 
+- 1.2.11 (29 August 2018)
+   - Added a function for sentence-level, smoothed BLEU
+
 - 1.2.10 (23 May 2018)
    - Added wmt18 test set (with references)
 

--- a/contrib/sacrebleu/__init__.py
+++ b/contrib/sacrebleu/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from contrib.sacrebleu.sacrebleu import raw_corpus_bleu, compute_bleu, corpus_chrf, CHRF_ORDER, CHRF_BETA
+from contrib.sacrebleu.sacrebleu import raw_corpus_bleu, compute_bleu, corpus_chrf, CHRF_ORDER, CHRF_BETA, sentence_bleu, sentence_chrf

--- a/contrib/sacrebleu/sacrebleu.py
+++ b/contrib/sacrebleu/sacrebleu.py
@@ -37,7 +37,7 @@ from typing import List, Iterable, Tuple
 import math
 import unicodedata
 
-VERSION = '1.2.10'
+VERSION = '1.2.11'
 
 try:
     # SIGPIPE is not available on Windows machines, throwing an exception.
@@ -994,6 +994,29 @@ def compute_bleu(correct: List[int], total: List[int], sys_len: int, ref_len: in
     bleu = brevity_penalty * math.exp(sum(map(my_log, precisions[:effective_order])) / effective_order)
 
     return BLEU._make([bleu, correct, total, precisions, brevity_penalty, sys_len, ref_len])
+
+
+def sentence_bleu(hypothesis: str,
+                  reference: str,
+                  smooth_floor: float = 0.01,
+                  use_effective_order: bool = True):
+    """
+    Computes BLEU on a single sentence pair.
+
+    Disclaimer: computing BLEU on the sentence level is not its intended use,
+    BLEU is a corpus-level metric.
+
+    :param hypothesis: Hypothesis string.
+    :param reference: Reference string.
+    :param smooth_floor: For 'floor' smoothing, the floor value to use.
+    :param use_effective_order: Account for references that are shorter than the largest n-gram.
+    :return: Returns a single BLEU score as a float.
+    """
+    bleu = corpus_bleu(hypothesis, reference,
+                       smooth='floor',
+                       smooth_floor=smooth_floor,
+                       use_effective_order=use_effective_order)
+    return bleu.score
 
 
 def corpus_bleu(sys_stream, ref_streams, smooth='exp', smooth_floor=0.0, force=False, lowercase=False,


### PR DESCRIPTION
Adding a function for sentence-level, smoothed BLEU to sacreBLEU. It is currently not used anywhere in the master branch.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

