### PR TITLE
Add reranking CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.51]
+### Added
+- Added a CLI for reranking of an nbest list of translations.
+
 ## [1.18.50]
 ### Fixed
 - Check for equivalency of training and validation source factors was incorrectly indented.

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ entry_points={
         'sockeye-prepare-data = sockeye.prepare_data:main',
         'sockeye-train = sockeye.train:main',
         'sockeye-translate = sockeye.translate:main',
-        'sockeye-vocab = sockeye.vocab:main'
+        'sockeye-vocab = sockeye.vocab:main',
+        'sockeye-rerank = sockeye.rerank:main',
     ],
 }
 

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.50'
+__version__ = '1.18.51'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -282,6 +282,28 @@ def add_extract_args(params):
                                 help="File to write extracted parameters to (in .npz format).")
 
 
+def add_rerank_args(params):
+    rerank_params = params.add_argument_group("Reranking")
+    rerank_params.add_argument("--reference", "-r",
+                               type=str,
+                               required=True,
+                               help="File where target reference translations are stored.")
+    rerank_params.add_argument("--hypotheses", "-hy",
+                               type=str,
+                               required=True,
+                               help="File with nbest translations, one nbest list per line, in JSON format.")
+    rerank_params.add_argument("--metric", "-m",
+                               type=str,
+                               required=False,
+                               default=C.RERANK_BLEU,
+                               choices=C.RERANK_METRICS,
+                               help="Sentence-level metric used to compare each nbest translation to the reference."
+                                    "Default: %(default)s.")
+    rerank_params.add_argument("--output-best",
+                               action="store_true",
+                               help="Output only the best hypothesis from each nbest list.")
+
+
 def add_lexicon_args(params):
     lexicon_params = params.add_argument_group("Model & Top-k")
     lexicon_params.add_argument("--model", "-m", required=True,

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -393,3 +393,8 @@ DATA_INFO = "data.info"
 DATA_CONFIG = "data.config"
 PREPARED_DATA_VERSION_FILE = "data.version"
 PREPARED_DATA_VERSION = 2
+
+# reranking
+RERANK_BLEU = "bleu"
+RERANK_CHRF = "chrf"
+RERANK_METRICS = [RERANK_BLEU, RERANK_CHRF]

--- a/sockeye/rerank.py
+++ b/sockeye/rerank.py
@@ -1,0 +1,141 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""
+CLI to rerank an nbest list of translations.
+"""
+
+import json
+import sys
+import argparse
+import numpy as np
+from typing import List, Tuple
+from collections import namedtuple
+
+from . import log
+from . import utils
+from . import arguments
+from . import constants as C
+from contrib import sacrebleu
+
+logger = log.setup_main_logger(__name__, console=True, file_logging=False)
+
+RerankOutput = namedtuple('RerankOutput', ['hypotheses', 'scores'])
+
+
+class Reranker:
+    """
+    Reranks a list of hypotheses according to a sentence-level metric.
+
+    :param metric: Sentence-level metric such as smoothed BLEU.
+    :param return_score: If True, also return the sentence-level score.
+    """
+
+    def __init__(self, metric: str,
+                 return_score: bool = False, ):
+        if metric == 'bleu':
+            self.scoring_function = sacrebleu.sentence_bleu
+        elif metric == 'chrf':
+            self.scoring_function = sacrebleu.sentence_chrf
+        else:
+            raise utils.SockeyeError("Scoring metric '%s' unknown. Choices are: %s" % (metric, C.RERANK_METRICS))
+
+        self.return_score = return_score
+
+    def rerank_hypotheses(self, hypotheses: List[str],
+                          reference: str) -> RerankOutput:
+        """
+        Reranks a set of hypotheses that belong to one single reference
+        translation.
+
+        :param hypotheses: List of nbest translations.
+        :param reference: A single string with the actual reference translation.
+        :return: A sorted list of hypotheses, possibly with scores.
+        """
+        scores = [self.scoring_function(hypothesis, reference) for hypothesis in hypotheses]
+
+        sorted_indexes = np.argsort(scores)[::-1]  # descending
+        sorted_hypotheses = [hypotheses[i] for i in sorted_indexes]
+
+        if self.return_score:
+            sorted_scores = [scores[i] for i in sorted_indexes]
+            return RerankOutput(hypotheses=sorted_hypotheses,
+                                scores=sorted_scores)
+        else:
+            return RerankOutput(hypotheses=sorted_hypotheses,
+                                scores=[])
+
+    def rerank_top1(self, hypotheses: List[str],
+                    reference: str) -> RerankOutput:
+        """
+        Reranks a set of hypotheses that belong to one single reference
+        translation and outputs the best hypothesis.
+
+        :param hypotheses: List of nbest translations.
+        :param reference: A single string with the actual reference translation.
+        :return: The single best hypothesis, possibly with its score.
+        """
+        scores = [self.scoring_function(hypothesis, reference) for hypothesis in hypotheses]
+        best_index = np.argmax(scores)
+
+        if self.return_score:
+            return RerankOutput(hypotheses=[hypotheses[best_index]],
+                                scores=[scores[best_index]])
+        else:
+            return RerankOutput(hypotheses=[hypotheses[best_index]],
+                                scores=[])
+
+
+def rerank(args: argparse.Namespace):
+    """
+    Reranks a list of hypotheses acoording to a sentence-level metric.
+    Writes all output to STDOUT.
+
+    :param args: Namespace object holding CLI arguments.
+    """
+    reranker = Reranker(args.metric)
+
+    with utils.smart_open(args.reference) as reference, utils.smart_open(args.hypotheses) as hypotheses:
+        for reference_line, hypothesis_line in zip(reference, hypotheses):
+            reference_line = reference_line.strip()
+            hypotheses = json.loads(hypothesis_line)
+
+            utils.check_condition(len(hypotheses) > 1, "Reranking strictly needs more than 1 hypothesis.")
+
+            if args.output_best:
+                rank_output = reranker.rerank_top1(hypotheses, reference_line)
+                sys.stdout.write(rank_output.hypotheses[0] + "\n")
+            else:
+                rank_output = reranker.rerank_hypotheses(hypotheses, reference_line)
+                sys.stdout.write(json.dumps(rank_output.hypotheses) + "\n")
+
+
+def main():
+    """
+    Commandline interface to rerank nbest lists.
+    """
+    log.log_sockeye_version(logger)
+
+    params = argparse.ArgumentParser(description="Rerank nbest lists of translations."
+                                                 " Reranking sorts a list of hypotheses according"
+                                                 " to their score compared to a common reference.")
+    arguments.add_rerank_args(params)
+    args = params.parse_args()
+
+    logger.info(args)
+
+    rerank(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/sockeye/rerank.py
+++ b/sockeye/rerank.py
@@ -42,10 +42,10 @@ class Reranker:
     """
 
     def __init__(self, metric: str,
-                 return_score: bool = False, ):
-        if metric == 'bleu':
+                 return_score: bool = False) -> None:
+        if metric == C.RERANK_BLEU:
             self.scoring_function = sacrebleu.sentence_bleu
-        elif metric == 'chrf':
+        elif metric == C.RERANK_CHRF:
             self.scoring_function = sacrebleu.sentence_chrf
         else:
             raise utils.SockeyeError("Scoring metric '%s' unknown. Choices are: %s" % (metric, C.RERANK_METRICS))

--- a/test/unit/test_reranking.py
+++ b/test/unit/test_reranking.py
@@ -1,0 +1,98 @@
+# Copyright 2017, 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import numpy as np
+import pytest
+
+import sockeye.rerank as rerank
+
+
+@pytest.mark.parametrize("hypotheses, reference, expected_output, metric", [
+    (["No Liber@@ ation for Ty@@ mo@@ sh@@ en@@ ko by Parliament",
+      "No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament"],
+     "Parliament Does Not Support Amendment Fre@@ eing Ty@@ mo@@ sh@@ en@@ ko",
+     ['No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament',
+      'No Liber@@ ation for Ty@@ mo@@ sh@@ en@@ ko by Parliament'], "bleu"),
+    # test chrf as metric
+    (["No Liber@@ ation for Ty@@ mo@@ sh@@ en@@ ko by Parliament",
+      "No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament"],
+     "Parliament Does Not Support Amendment Fre@@ eing Ty@@ mo@@ sh@@ en@@ ko",
+     ['No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament',
+      'No Liber@@ ation for Ty@@ mo@@ sh@@ en@@ ko by Parliament'], "chrf"),
+    # test empty hypothesis
+    (["",
+      "No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament"],
+     "Parliament Does Not Support Amendment Fre@@ eing Ty@@ mo@@ sh@@ en@@ ko",
+     ['No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament',
+      ''], "bleu")
+])
+def test_rerank_hypotheses(hypotheses, reference, expected_output, metric):
+    reranker = rerank.Reranker(metric=metric, return_score=False)
+
+    reranked = reranker.rerank_hypotheses(hypotheses, reference)
+    actual_list = reranked.hypotheses
+
+    assert actual_list == expected_output
+
+
+@pytest.mark.parametrize("hypotheses, reference, expected_scores", [
+    (["Completely different",
+      "No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament"],
+     "Parliament Does Not Support Amendment Fre@@ eing Ty@@ mo@@ sh@@ en@@ ko",
+     [60.26404810093175, 3.2102598200446005e-05, ])
+])
+def test_rerank_return_score(hypotheses, reference, expected_scores):
+    reranker = rerank.Reranker(metric="bleu", return_score=True)
+
+    reranked_with_scores = reranker.rerank_hypotheses(hypotheses, reference)
+
+    actual_scores = reranked_with_scores.scores
+
+    assert np.allclose(actual_scores, expected_scores)
+
+
+@pytest.mark.parametrize("hypotheses, reference, expected_best", [
+    (["Completely different",
+      "No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament"],
+     "Parliament Does Not Support Amendment Fre@@ eing Ty@@ mo@@ sh@@ en@@ ko",
+     "No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament")
+])
+def test_rerank_top1(hypotheses, reference, expected_best):
+    reranker = rerank.Reranker(metric="bleu", return_score=False)
+
+    reranked = reranker.rerank_top1(hypotheses, reference)
+
+    assert len(reranked.hypotheses) == 1, "Rerank top1 should not return more than 1 hypothesis."
+    actual_hypothesis = reranked.hypotheses[0]
+
+    assert actual_hypothesis == expected_best
+
+
+@pytest.mark.parametrize("hypotheses, reference, expected_best, expected_score", [
+    (["Completely different",
+      "No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament"],
+     "Parliament Does Not Support Amendment Fre@@ eing Ty@@ mo@@ sh@@ en@@ ko",
+     "No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament",
+     60.26404810093175)
+])
+def test_rerank_top1_score(hypotheses, reference, expected_best, expected_score):
+    reranker = rerank.Reranker(metric="bleu", return_score=True)
+
+    reranked_with_scores = reranker.rerank_top1(hypotheses, reference)
+
+    assert len(reranked_with_scores.hypotheses) == 1, "Rerank top1 should not return more than 1 hypothesis."
+    actual_hypothesis = reranked_with_scores.hypotheses[0]
+    actual_score = reranked_with_scores.scores[0]
+
+    assert actual_hypothesis == expected_best
+    assert np.isclose(actual_score, expected_score)


### PR DESCRIPTION
Add a reranking CLI. Takes a JSON list of hypotheses and reranks them by
- comparing to a common reference
- scoring with a sentence-level metric

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

