### PR TITLE
Skip softmax and topk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 
 ## [1.18.53]
 ### Added
-- Added options `--skip-softmax` and `--skip-topk` for greedy decoding at inference time.
+- Always skipping softmax for greedy decoding by default, only for single models.
+- Added option `--skip-topk` for greedy decoding.
 
 ## [1.18.52]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.53]
+### Added
+- Added options `--skip-softmax` and `--skip-topk` for greedy decoding at inference time.
+
 ## [1.18.52]
 ### Fixed
 - Fixed bug in constrained decoding to make sure best hypothesis satifies all constraints.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.52'
+__version__ = '1.18.53'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1148,6 +1148,16 @@ def add_inference_args(params):
                                     ' Default: %d without batching '
                                     'and %d * batch_size with batching.' % (C.CHUNK_SIZE_NO_BATCHING,
                                                                             C.CHUNK_SIZE_PER_BATCH_SEGMENT))
+    decode_params.add_argument('--skip-softmax',
+                               default=False,
+                               action='store_true',
+                               help='Do not compute softmax for greedy decoding (when --beam-size 1).'
+                                    'Default: %(default)s.')
+    decode_params.add_argument('--skip-topk',
+                               default=False,
+                               action='store_true',
+                               help='Use argmax instead of topk for greedy decoding (when --beam-size 1).'
+                                    'Default: %(default)s.')
     decode_params.add_argument('--ensemble-mode',
                                type=str,
                                default='linear',

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1148,11 +1148,6 @@ def add_inference_args(params):
                                     ' Default: %d without batching '
                                     'and %d * batch_size with batching.' % (C.CHUNK_SIZE_NO_BATCHING,
                                                                             C.CHUNK_SIZE_PER_BATCH_SEGMENT))
-    decode_params.add_argument('--skip-softmax',
-                               default=False,
-                               action='store_true',
-                               help='Do not compute softmax for greedy decoding (when --beam-size 1).'
-                                    'Default: %(default)s.')
     decode_params.add_argument('--skip-topk',
                                default=False,
                                action='store_true',

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1030,6 +1030,9 @@ class Translator:
         self.batch_size = self.models[0].batch_size
         # skip softmax for a single model, but not for an ensemble
         self.skip_softmax = self.models[0].skip_softmax
+        if self.skip_softmax:
+            utils.check_condition(len(self.models) == 1 and self.beam_size == 1, "Skipping softmax cannot be enabled for several models, or a beam size > 1.")
+
         self.skip_topk = skip_topk
         # after models are loaded we ensured that they agree on max_input_length, max_output_length and batch size
         self._max_input_length = self.models[0].max_input_length
@@ -1412,7 +1415,7 @@ class Translator:
 
         # combine model predictions and convert to neg log probs
         if len(self.models) == 1:
-            if self.beam_size == 1 and self.skip_softmax:
+            if self.skip_softmax:
                 neg_probs = -probs[0]
             else:
                 neg_probs = -mx.nd.log(probs[0])  # pylint: disable=invalid-unary-operand-type

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -373,7 +373,6 @@ def load_models(context: mx.context.Context,
                 cache_output_layer_w_b: bool = False,
                 forced_max_output_len: Optional[int] = None,
                 override_dtype: Optional[str] = None,
-                skip_softmax: bool = False,
                 skip_topk: bool = False) -> Tuple[List[InferenceModel],
                                                   List[vocab.Vocab],
                                                   vocab.Vocab]:
@@ -395,7 +394,6 @@ def load_models(context: mx.context.Context,
                                    restrict lexicon).
     :param forced_max_output_len: An optional overwrite of the maximum output length.
     :param override_dtype: Overrides dtype of encoder and decoder defined at training time to a different one.
-    :param skip_softmax: If True, does not compute softmax for greedy decoding.
     :param skip_topk: If True, uses argmax instead of topk for greedy decoding.
     :return: List of models, source vocabulary, target vocabulary, source factor vocabularies.
     """
@@ -407,6 +405,13 @@ def load_models(context: mx.context.Context,
 
     if checkpoints is None:
         checkpoints = [None] * len(model_folders)
+
+    # skip softmax for a single model,
+    if len(model_folders) == 1:
+        skip_softmax = True
+    else:
+        # but not for an ensemble
+        skip_softmax = False
 
     for model_folder, checkpoint in zip(model_folders, checkpoints):
         model_source_vocabs = vocab.load_source_vocabs(model_folder)
@@ -442,6 +447,8 @@ def load_models(context: mx.context.Context,
                               "number of source factors for model '%s' (%d)" % (len(model_source_vocabs), model_folder,
                                                                                 inference_model.num_source_factors))
         models.append(inference_model)
+
+
 
     utils.check_condition(vocab.are_identical(*target_vocabs), "Target vocabulary ids do not match")
     first_model_vocabs = source_vocabs[0]
@@ -1021,7 +1028,8 @@ class Translator:
         self.interpolation_func = self._get_interpolation_func(ensemble_mode)
         self.beam_size = self.models[0].beam_size
         self.batch_size = self.models[0].batch_size
-        self.skip_softmax = self.models[0].skip_softmax
+        # skip softmax for a single model, but not for an ensemble
+        self.skip_softmax = True if len(models) == 1 else False
         self.skip_topk = self.models[0].skip_topk
         # after models are loaded we ensured that they agree on max_input_length, max_output_length and batch size
         self._max_input_length = self.models[0].max_input_length

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -410,7 +410,6 @@ def load_models(context: mx.context.Context,
     else:
         # but not for an ensemble or beam search
         skip_softmax = False
-        logger.info("Disabled skipping softmax for several models or beam size larger than 1.")
 
     for model_folder, checkpoint in zip(model_folders, checkpoints):
         model_source_vocabs = vocab.load_source_vocabs(model_folder)

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -52,6 +52,10 @@ def run_translate(args: argparse.Namespace):
     if args.checkpoints is not None:
         check_condition(len(args.checkpoints) == len(args.models), "must provide checkpoints for each model")
 
+    if args.skip_softmax:
+        check_condition(len(args.models) == 1,
+                        "For an ensemble of models, softmax cannot be skipped. Do not use --skip-softmax.")
+
     log_basic_info(args)
 
     output_handler = get_output_handler(args.output_type,
@@ -83,7 +87,9 @@ def run_translate(args: argparse.Namespace):
             max_output_length_num_stds=args.max_output_length_num_stds,
             decoder_return_logit_inputs=args.restrict_lexicon is not None,
             cache_output_layer_w_b=args.restrict_lexicon is not None,
-            override_dtype=args.override_dtype)
+            override_dtype=args.override_dtype,
+            skip_softmax=args.skip_softmax,
+            skip_topk=args.skip_topk)
         restrict_lexicon = None  # type: Optional[TopKLexicon]
         if args.restrict_lexicon:
             restrict_lexicon = TopKLexicon(source_vocabs[0], target_vocab)

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -52,10 +52,6 @@ def run_translate(args: argparse.Namespace):
     if args.checkpoints is not None:
         check_condition(len(args.checkpoints) == len(args.models), "must provide checkpoints for each model")
 
-    if args.skip_softmax:
-        check_condition(len(args.models) == 1,
-                        "For an ensemble of models, softmax cannot be skipped. Do not use --skip-softmax.")
-
     log_basic_info(args)
 
     output_handler = get_output_handler(args.output_type,
@@ -88,7 +84,6 @@ def run_translate(args: argparse.Namespace):
             decoder_return_logit_inputs=args.restrict_lexicon is not None,
             cache_output_layer_w_b=args.restrict_lexicon is not None,
             override_dtype=args.override_dtype,
-            skip_softmax=args.skip_softmax,
             skip_topk=args.skip_topk)
         restrict_lexicon = None  # type: Optional[TopKLexicon]
         if args.restrict_lexicon:

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -52,6 +52,10 @@ def run_translate(args: argparse.Namespace):
     if args.checkpoints is not None:
         check_condition(len(args.checkpoints) == len(args.models), "must provide checkpoints for each model")
 
+    if args.skip_topk:
+        check_condition(args.beam_size == 1, "--skip-topk has no effect if beam size is larger than 1")
+        check_condition(len(args.models) == 1, "--skip-topk has no effect for decoding with more than 1 model")
+
     log_basic_info(args)
 
     output_handler = get_output_handler(args.output_type,

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -87,8 +87,7 @@ def run_translate(args: argparse.Namespace):
             max_output_length_num_stds=args.max_output_length_num_stds,
             decoder_return_logit_inputs=args.restrict_lexicon is not None,
             cache_output_layer_w_b=args.restrict_lexicon is not None,
-            override_dtype=args.override_dtype,
-            skip_topk=args.skip_topk)
+            override_dtype=args.override_dtype)
         restrict_lexicon = None  # type: Optional[TopKLexicon]
         if args.restrict_lexicon:
             restrict_lexicon = TopKLexicon(source_vocabs[0], target_vocab)
@@ -107,7 +106,8 @@ def run_translate(args: argparse.Namespace):
                                           restrict_lexicon=restrict_lexicon,
                                           avoid_list=args.avoid_list,
                                           store_beam=store_beam,
-                                          strip_unknown_words=args.strip_unknown_words)
+                                          strip_unknown_words=args.strip_unknown_words,
+                                          skip_topk=args.skip_topk)
         read_and_translate(translator=translator,
                            output_handler=output_handler,
                            chunk_size=args.chunk_size,

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -252,6 +252,28 @@ class OnlineMeanAndVariance:
             return self._M2 / self._count
 
 
+def top1(scores: mx.nd.NDArray,
+         offset: mx.nd.NDArray) -> Tuple[mx.nd.NDArray, mx.nd.NDArray, mx.nd.NDArray]:
+    """
+    Get the single lowest element per sentence from a `scores` matrix. Expects that
+    beam size is 1, for greedy decoding.
+
+    NOTE(mathmu): The current implementation of argmin in MXNet much slower than topk with k=1.
+
+    :param scores: Vocabulary scores for the next beam step. (batch_size * beam_size, target_vocabulary_size)
+    :param offset: Array to add to the hypothesis indices for offsetting in batch decoding.
+    :return: The row indices, column indices and values of the smallest items in matrix.
+    """
+    best_word_indices = mx.nd.cast(mx.nd.argmin(scores, axis=1), dtype='int32')
+    values = scores[mx.nd.arange(scores.shape[0], dtype='int32', ctx=scores.context), best_word_indices]
+
+    values = values.reshape((-1, 1))
+
+    # for top1, the best hyp indices are equal to the plain offset
+
+    return offset, best_word_indices, values
+
+
 def topk(scores: mx.nd.NDArray,
          k: int,
          batch_size: int,

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -33,6 +33,22 @@ ENCODER_DECODER_SETTINGS = [
      " --decode-and-evaluate 0",
      "--beam-size 2 --softmax-temperature 0.01",
      True, False, False),
+    # "Vanilla" LSTM encoder-decoder with attention, greedy and skip softmax
+    ("--encoder rnn --decoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 8 --num-embed 4 "
+     " --rnn-attention-type mlp"
+     " --rnn-attention-num-hidden 8 --batch-size 2 --loss cross-entropy --optimized-metric perplexity --max-updates 2"
+     " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01 --batch-type sentence "
+     " --decode-and-evaluate 0",
+     "--beam-size 2 --softmax-temperature 0.01 --skip-softmax",
+     True, False, False),
+    # "Vanilla" LSTM encoder-decoder with attention, greedy and skip topk
+    ("--encoder rnn --decoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 8 --num-embed 4 "
+     " --rnn-attention-type mlp"
+     " --rnn-attention-num-hidden 8 --batch-size 2 --loss cross-entropy --optimized-metric perplexity --max-updates 2"
+     " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01 --batch-type sentence "
+     " --decode-and-evaluate 0",
+     "--beam-size 2 --softmax-temperature 0.01 --skip-topk",
+     True, False, False),
     # "Kitchen sink" LSTM encoder-decoder with attention
     ("--encoder rnn --decoder rnn --num-layers 3:2 --rnn-cell-type lstm --rnn-num-hidden 8"
      " --rnn-residual-connections"

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -33,21 +33,13 @@ ENCODER_DECODER_SETTINGS = [
      " --decode-and-evaluate 0",
      "--beam-size 2 --softmax-temperature 0.01",
      True, False, False),
-    # "Vanilla" LSTM encoder-decoder with attention, greedy and skip softmax
-    ("--encoder rnn --decoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 8 --num-embed 4 "
-     " --rnn-attention-type mlp"
-     " --rnn-attention-num-hidden 8 --batch-size 2 --loss cross-entropy --optimized-metric perplexity --max-updates 2"
-     " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01 --batch-type sentence "
-     " --decode-and-evaluate 0",
-     "--beam-size 2 --softmax-temperature 0.01",
-     True, False, False),
     # "Vanilla" LSTM encoder-decoder with attention, greedy and skip topk
     ("--encoder rnn --decoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 8 --num-embed 4 "
      " --rnn-attention-type mlp"
      " --rnn-attention-num-hidden 8 --batch-size 2 --loss cross-entropy --optimized-metric perplexity --max-updates 2"
      " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01 --batch-type sentence "
      " --decode-and-evaluate 0",
-     "--beam-size 2 --softmax-temperature 0.01 --skip-topk",
+     "--beam-size 1 --softmax-temperature 0.01 --skip-topk",
      True, False, False),
     # "Kitchen sink" LSTM encoder-decoder with attention
     ("--encoder rnn --decoder rnn --num-layers 3:2 --rnn-cell-type lstm --rnn-num-hidden 8"

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -39,7 +39,7 @@ ENCODER_DECODER_SETTINGS = [
      " --rnn-attention-num-hidden 8 --batch-size 2 --loss cross-entropy --optimized-metric perplexity --max-updates 2"
      " --checkpoint-frequency 2 --optimizer adam --initial-learning-rate 0.01 --batch-type sentence "
      " --decode-and-evaluate 0",
-     "--beam-size 2 --softmax-temperature 0.01 --skip-softmax",
+     "--beam-size 2 --softmax-temperature 0.01",
      True, False, False),
     # "Vanilla" LSTM encoder-decoder with attention, greedy and skip topk
     ("--encoder rnn --decoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 8 --num-embed 4 "

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -217,7 +217,9 @@ def test_training_arg(test_params, expected_params):
                       length_penalty_alpha=1.0,
                       length_penalty_beta=0.0,
                       strip_unknown_words=False,
-                      override_dtype=None)),
+                      override_dtype=None,
+                      skip_softmax=False,
+                      skip_topk=False)),
 ])
 def test_inference_args(test_params, expected_params):
     _test_args(test_params, expected_params, arguments.add_inference_args)

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -218,7 +218,6 @@ def test_training_arg(test_params, expected_params):
                       length_penalty_beta=0.0,
                       strip_unknown_words=False,
                       override_dtype=None,
-                      skip_softmax=False,
                       skip_topk=False)),
 ])
 def test_inference_args(test_params, expected_params):


### PR DESCRIPTION
Skip softmax by default for greedy decoding, and adding option to skip topk:
- this change only affects inference
- only affects greedy decoding

Skipping softmax is significantly faster, skipping topk is significantly slower, but it could be faster if the MXnet implementation of argmin changes.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

