### PR TITLE
Autopilot: minimize tests and disable WNMT due to data outage.

### DIFF
--- a/contrib/autopilot/test.py
+++ b/contrib/autopilot/test.py
@@ -81,43 +81,12 @@ def main():
     with tempfile.TemporaryDirectory(prefix="sockeye.autopilot.") as tmp_dir:
         work_dir = os.path.join(tmp_dir, "workspace")
 
-        # WMT task, prepare data only
-        command = [sys.executable,
-                   "-m",
-                   "contrib.autopilot.autopilot",
-                   "--task={}".format(DATA_ONLY_TASK),
-                   "--model=none",
-                   "--gpus=0",
-                   "--test"]
-        run_test(command, workspace=work_dir)
-
-        # WNMT task with pre-tokenized data (Transformer)
-        command = [sys.executable,
-                   "-m",
-                   "contrib.autopilot.autopilot",
-                   "--task={}".format(WNMT_TASK),
-                   "--model=transformer",
-                   "--gpus=0",
-                   "--test"]
-        run_test(command, workspace=work_dir)
-
         # WMT task with raw data (Transformer)
         command = [sys.executable,
                    "-m",
                    "contrib.autopilot.autopilot",
                    "--task={}".format(WMT_TASK),
                    "--model=transformer",
-                   "--gpus=0",
-                   "--test"]
-        run_test(command, workspace=work_dir)
-
-        # WNMT task with pre-tokenized data (GNMT)
-        command = [sys.executable,
-                   "-m",
-                   "contrib.autopilot.autopilot",
-                   "--task={}".format(WNMT_TASK),
-                   "--model=gnmt_like",
-                   "--decode-settings=gnmt_like",
                    "--gpus=0",
                    "--test"]
         run_test(command, workspace=work_dir)
@@ -133,7 +102,29 @@ def main():
                    "--test"]
         run_test(command, workspace=work_dir)
 
-        # Custom task (raw data Transformer)
+        # TODO: Currently disabled due to periodic outages of nlp.stanford.edu
+        #       preventing downloading data.
+        # WNMT task with pre-tokenized data (Transformer)
+        # command = [sys.executable,
+        #            "-m",
+        #            "contrib.autopilot.autopilot",
+        #            "--task={}".format(WNMT_TASK),
+        #            "--model=transformer",
+        #            "--gpus=0",
+        #            "--test"]
+        # run_test(command, workspace=work_dir)
+
+        # WMT task, prepare data only
+        command = [sys.executable,
+                   "-m",
+                   "contrib.autopilot.autopilot",
+                   "--task={}".format(DATA_ONLY_TASK),
+                   "--model=none",
+                   "--gpus=0",
+                   "--test"]
+        run_test(command, workspace=work_dir)
+
+        # Custom task (raw data, Transformer)
         command = [sys.executable,
                    "-m",
                    "contrib.autopilot.autopilot",
@@ -162,7 +153,7 @@ def main():
                    "--test"]
         run_test(command, workspace=work_dir)
 
-        # Custom task (tokenized data Transformer)
+        # Custom task (tokenized data, Transformer)
         command = [sys.executable,
                    "-m",
                    "contrib.autopilot.autopilot",
@@ -189,7 +180,7 @@ def main():
                    "--test"]
         run_test(command, workspace=work_dir)
 
-        # Custom task (byte-pair encoded data Transformer)
+        # Custom task (byte-pair encoded data, Transformer)
         command = [sys.executable,
                    "-m",
                    "contrib.autopilot.autopilot",
@@ -215,90 +206,6 @@ def main():
                    "--test"]
         run_test(command, workspace=work_dir)
 
-        # Custom task (raw data GNMT)
-        command = [sys.executable,
-                   "-m",
-                   "contrib.autopilot.autopilot",
-                   "--custom-task=custom_raw",
-                   "--custom-train",
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_RAW, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_SRC_GZ),
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_RAW, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_TRG_GZ),
-                   "--custom-dev",
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_RAW, autopilot.PREFIX_DEV + autopilot.SUFFIX_SRC_GZ),
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_RAW, autopilot.PREFIX_DEV + autopilot.SUFFIX_TRG_GZ),
-                   "--custom-test",
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_RAW, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_SRC_GZ),
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_RAW, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
-                   "--custom-lang",
-                   WMT_SRC,
-                   WMT_TRG,
-                   "--custom-bpe-op={}".format(WMT_BPE),
-                   "--model=gnmt_like",
-                   "--decode-settings=gnmt_like",
-                   "--gpus=0",
-                   "--test"]
-        run_test(command, workspace=work_dir)
-
-        # Custom task (tokenized data GNMT)
-        command = [sys.executable,
-                   "-m",
-                   "contrib.autopilot.autopilot",
-                   "--custom-task=custom_tok",
-                   "--custom-train",
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_TOK, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_SRC_GZ),
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_TOK, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_TRG_GZ),
-                   "--custom-dev",
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_TOK, autopilot.PREFIX_DEV + autopilot.SUFFIX_SRC_GZ),
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_TOK, autopilot.PREFIX_DEV + autopilot.SUFFIX_TRG_GZ),
-                   "--custom-test",
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_TOK, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_SRC_GZ),
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_TOK, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
-                   "--custom-text-type=tok",
-                   "--custom-bpe-op={}".format(WMT_BPE),
-                   "--model=gnmt_like",
-                   "--decode-settings=gnmt_like",
-                   "--gpus=0",
-                   "--test"]
-        run_test(command, workspace=work_dir)
-
-        # Custom task (byte-pair encoded data GNMT)
-        command = [sys.executable,
-                   "-m",
-                   "contrib.autopilot.autopilot",
-                   "--custom-task=custom_bpe",
-                   "--custom-train",
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_BPE, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_SRC_GZ),
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_BPE, autopilot.PREFIX_TRAIN + autopilot.SUFFIX_TRG_GZ),
-                   "--custom-dev",
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_BPE, autopilot.PREFIX_DEV + autopilot.SUFFIX_SRC_GZ),
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_BPE, autopilot.PREFIX_DEV + autopilot.SUFFIX_TRG_GZ),
-                   "--custom-test",
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_BPE, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_SRC_GZ),
-                   os.path.join(work_dir, autopilot.DIR_SYSTEMS, WMT_TASK + autopilot.SUFFIX_TEST, autopilot.DIR_DATA,
-                                autopilot.DIR_BPE, autopilot.PREFIX_TEST + PREFIX_ZERO + autopilot.SUFFIX_TRG_GZ),
-                   "--custom-text-type=bpe",
-                   "--model=gnmt_like",
-                   "--decode-settings=gnmt_like",
-                   "--gpus=0",
-                   "--test"]
-        run_test(command, workspace=work_dir)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This commit disables the WNMT test and removes other redundant tests.  It appears that https://nlp.stanford.edu is currently down, causing any task using the WNMT data to fail.  The remaining tests still cover our two main models (Transformer and GNMT) and all levels of input data pre-processing.  With these changes, the Autopilot tests are back to passing.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] tests pass (`python contrib/autopilot/test.py`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

