### PR TITLE
Fix constrained decoding: First hypothesis must satisfy constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.52]
+### Fixed
+- Fixed bug in constrained decoding to make sure best hypothesis satifies all constraints.
+
 ## [1.18.51]
 ### Added
 - Added a CLI for reranking of an nbest list of translations.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.51'
+__version__ = '1.18.52'

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1669,15 +1669,15 @@ class Translator:
         # Initialize the best_ids to the first item in each batch
         best_ids = np.arange(0, self.batch_size * self.beam_size, self.beam_size, dtype='int32')
 
-        # Obtain sequences for all best hypotheses in the batch
-        indices = self._get_best_word_indeces_for_kth_hypotheses(best_ids, best_hyp_indices)
-
         if any(constraints):
             # For constrained decoding, select from items that have met all constraints (might not be finished)
             unmet = np.array([c.num_needed() if c is not None else 0 for c in constraints])
             filtered = np.where(unmet == 0, seq_scores.flatten(), np.inf)
             filtered = filtered.reshape((self.batch_size, self.beam_size))
             best_ids += np.argmin(filtered, axis=1).astype('int32')
+
+        # Obtain sequences for all best hypotheses in the batch
+        indices = self._get_best_word_indeces_for_kth_hypotheses(best_ids, best_hyp_indices)
 
         histories = beam_histories if beam_histories is not None else [None] * self.batch_size  # type: List
         return [self._assemble_translation(*x) for x in zip(best_word_indices[indices, np.arange(indices.shape[1])],


### PR DESCRIPTION
The current inference code does not enforce that the best beam hypothesis satisfies all constraints.

The problem is just ordering: constraints have to be checked before retrieving indexes into the beam.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

