### PR TITLE
[WIP] Scoring

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -176,6 +176,13 @@ sockeye.rnn_attention module
     :members:
     :show-inheritance:
 
+sockeye.score module
+----------------------------
+
+.. automodule:: sockeye.score
+    :members:
+    :show-inheritance:
+
 sockeye.train module
 --------------------
 

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1092,6 +1092,17 @@ def add_score_cli_args(params):
     params.add_argument("--model", "-m", required=True,
                         help="Model directory containing trained model.")
 
+    params.add_argument('--length-penalty-alpha',
+                        default=1.0,
+                        type=float,
+                        help='Alpha factor for the length penalty used in beam search: '
+                        '(beta + len(Y))**alpha/(beta + 1)**alpha. A value of 0.0 will therefore turn off '
+                        'length normalization. Default: %(default)s')
+    params.add_argument('--length-penalty-beta',
+                        default=0.0,
+                        type=float,
+                        help='Beta factor for the length penalty used in beam search: '
+                        '(beta + len(Y))**alpha/(beta + 1)**alpha. Default: %(default)s')
 
 def add_max_output_cli_args(params):
     params.add_argument('--max-output-length',

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -782,7 +782,7 @@ def add_scoring_args(params):
 def add_training_args(params):
     train_params = params.add_argument_group("Training parameters")
 
-    add_batch_args(training_params)
+    add_batch_args(train_params)
 
     train_params.add_argument('--decoder-only',
                                action='store_true',

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -754,33 +754,43 @@ def add_model_parameters(params):
                                    "(and all convolutional weight matrices for CNN decoders). Default: %(default)s.")
 
 
+def add_batch_args(params):
+    params.add_argument('--batch-size', '-b',
+                        type=int_greater_or_equal(1),
+                        default=4096,
+                        help='Mini-batch size. Note that depending on the batch-type this either refers to '
+                             'words or sentences.'
+                             'Sentence: each batch contains X sentences, number of words varies. '
+                             'Word: each batch contains (approximately) X words, number of sentences varies. '
+                             'Default: %(default)s.')
+    params.add_argument("--batch-type",
+                        type=str,
+                        default=C.BATCH_TYPE_WORD,
+                        choices=[C.BATCH_TYPE_SENTENCE, C.BATCH_TYPE_WORD],
+                        help="Sentence: each batch contains X sentences, number of words varies."
+                             "Word: each batch contains (approximately) X target words, "
+                             "number of sentences varies. Default: %(default)s.")
+
+
+
+def add_scoring_args(params):
+    scoring_params = params.add_argument_group("Scoring parameters")
+
+    add_batch_args(scoring_params)
+
+
 def add_training_args(params):
     train_params = params.add_argument_group("Training parameters")
+
+    add_batch_args(training_params)
 
     train_params.add_argument('--decoder-only',
                                action='store_true',
                                help='Pre-train a decoder. This is currently for RNN decoders only. '
                                     'Default: %(default)s.')
-
-    train_params.add_argument('--batch-size', '-b',
-                              type=int_greater_or_equal(1),
-                              default=4096,
-                              help='Mini-batch size. Note that depending on the batch-type this either refers to '
-                                   'words or sentences.'
-                                   'Sentence: each batch contains X sentences, number of words varies. '
-                                   'Word: each batch contains (approximately) X words, number of sentences varies. '
-                                   'Default: %(default)s.')
-    train_params.add_argument("--batch-type",
-                              type=str,
-                              default=C.BATCH_TYPE_WORD,
-                              choices=[C.BATCH_TYPE_SENTENCE, C.BATCH_TYPE_WORD],
-                              help="Sentence: each batch contains X sentences, number of words varies."
-                                   "Word: each batch contains (approximately) X target words, "
-                                   "number of sentences varies. Default: %(default)s.")
-
     train_params.add_argument('--fill-up',
                               type=str,
-                              default='replicate',
+                              default=C.DEFAULT_FILL_UP_STRATEGY,
                               help=argparse.SUPPRESS)
 
     train_params.add_argument('--loss',
@@ -1067,6 +1077,20 @@ def add_translate_cli_args(params):
     add_inference_args(params)
     add_device_args(params)
     add_logging_args(params)
+
+
+def add_score_cli_args(params):
+    add_training_data_args(params, required=False)
+    add_prepared_data_args(params)
+    add_vocab_args(params)
+    add_bucketing_args(params)
+    add_scoring_args(params)
+    add_device_args(params)
+    add_logging_args(params)
+
+    params = params.add_argument_group("Scoring parameters")
+    params.add_argument("--model", "-m", required=True,
+                        help="Model directory containing trained model.")
 
 
 def add_max_output_cli_args(params):

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -393,6 +393,7 @@ DATA_INFO = "data.info"
 DATA_CONFIG = "data.config"
 PREPARED_DATA_VERSION_FILE = "data.version"
 PREPARED_DATA_VERSION = 2
+DEFAULT_FILL_UP_STRATEGY = 'replicate'
 
 # reranking
 RERANK_BLEU = "bleu"

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -751,8 +751,8 @@ def get_prepared_data_iters(prepared_data_dir: str,
 
 def get_training_data_iters(sources: List[str],
                             target: str,
-                            validation_sources: List[str],
-                            validation_target: str,
+                            validation_sources: Optional[List[str]],
+                            validation_target: Optional[str],
                             source_vocabs: List[vocab.Vocab],
                             target_vocab: vocab.Vocab,
                             source_vocab_paths: List[Optional[str]],
@@ -842,17 +842,19 @@ def get_training_data_iters(sources: List[str],
                                     bucket_batch_sizes=bucket_batch_sizes,
                                     num_factors=len(sources))
 
-    validation_iter = get_validation_data_iter(data_loader=data_loader,
-                                               validation_sources=validation_sources,
-                                               validation_target=validation_target,
-                                               buckets=buckets,
-                                               bucket_batch_sizes=bucket_batch_sizes,
-                                               source_vocabs=source_vocabs,
-                                               target_vocab=target_vocab,
-                                               max_seq_len_source=max_seq_len_source,
-                                               max_seq_len_target=max_seq_len_target,
-                                               batch_size=batch_size,
-                                               fill_up=fill_up)
+    validation_iter = None
+    if validation_sources is not None and validation_target is not None:
+        validation_iter = get_validation_data_iter(data_loader=data_loader,
+                                                   validation_sources=validation_sources,
+                                                   validation_target=validation_target,
+                                                   buckets=buckets,
+                                                   bucket_batch_sizes=bucket_batch_sizes,
+                                                   source_vocabs=source_vocabs,
+                                                   target_vocab=target_vocab,
+                                                   max_seq_len_source=max_seq_len_source,
+                                                   max_seq_len_target=max_seq_len_target,
+                                                   batch_size=batch_size,
+                                                   fill_up=fill_up)
 
     return train_iter, validation_iter, config_data, data_info
 

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -672,9 +672,10 @@ def get_prepared_data_iters(prepared_data_dir: str,
                             batch_size: int,
                             batch_by_words: bool,
                             batch_num_devices: int,
-                            fill_up: str) -> Tuple['BaseParallelSampleIter',
-                                                   'BaseParallelSampleIter',
-                                                   'DataConfig', List[vocab.Vocab], vocab.Vocab]:
+                            fill_up: str,
+                            no_permute: bool = False) -> Tuple['BaseParallelSampleIter',
+                                                               'BaseParallelSampleIter',
+                                                               'DataConfig', List[vocab.Vocab], vocab.Vocab]:
     logger.info("===============================")
     logger.info("Creating training data iterator")
     logger.info("===============================")

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -1024,6 +1024,22 @@ def ids2strids(ids: Iterable[int]) -> str:
     return " ".join(map(str, ids))
 
 
+def ids2tokens(token_ids: Iterable[int],
+               vocab_inv: vocab.Vocab,
+               exclude_list: List[int] = []) -> List[str]:
+    """
+    Transforms a list of token IDs into a list of words, exluding any IDs in `exclude_list`.
+
+    :param token_ids: The list of token IDs.
+    :param vocab_inv: The inverse vocabulary.
+    :param exclude_list: The list of token IDs to exclude.
+    :return: The list of words.
+"""
+
+    tokens = [vocab_inv[token] for token in token_ids]
+    return [tok for token_id, tok in zip(token_ids, tokens) if token_id not in exclude_list]
+
+
 class SequenceReader(Iterable):
     """
     Reads sequence samples from path and (optionally) creates integer id sequences.

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1274,6 +1274,7 @@ class Translator:
         attention_matrix = translation.attention_matrix
 
         target_tokens = [self.vocab_target_inv[target_id] for target_id in target_ids]
+        target_string = data_io.ids2tokens(target_ids, self.vocab_target_inv, self.strip_ids)
 
         target_string = C.TOKEN_SEPARATOR.join(
             tok for target_id, tok in zip(target_ids, target_tokens) if target_id not in self.strip_ids)

--- a/sockeye/score.py
+++ b/sockeye/score.py
@@ -120,7 +120,8 @@ def score(args: argparse.Namespace):
             max_seq_len_target=max_seq_len_target,
             shared_vocab=args.shared_vocab,
             resume_training=True,
-            output_folder=args.model)
+            output_folder=args.model,
+            fill_up='repeat_last')
 
         max_seq_len_source = config_data.max_seq_len_source
         max_seq_len_target = config_data.max_seq_len_target

--- a/sockeye/score.py
+++ b/sockeye/score.py
@@ -114,7 +114,7 @@ def score(args: argparse.Namespace):
                                                                  "size that is a multiple of %d." % len(context))
         logger.info("Scoring Device(s): %s", ", ".join(str(c) for c in context))
 
-        score_iter, _, config_data, source_vocabs, target_vocab = train.create_data_iters_and_vocabs(
+        score_iter, _, config_data, source_vocabs, target_vocab, data_info = train.create_data_iters_and_vocabs(
             args=args,
             max_seq_len_source=max_seq_len_source,
             max_seq_len_target=max_seq_len_target,

--- a/sockeye/score.py
+++ b/sockeye/score.py
@@ -121,7 +121,8 @@ def score(args: argparse.Namespace):
             shared_vocab=args.shared_vocab,
             resume_training=True,
             output_folder=args.model,
-            fill_up='repeat_last')
+            fill_up='zeros',
+            no_permute=True)
 
         max_seq_len_source = config_data.max_seq_len_source
         max_seq_len_target = config_data.max_seq_len_target

--- a/sockeye/score.py
+++ b/sockeye/score.py
@@ -1,0 +1,139 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""
+Simple Training CLI.
+"""
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+from contextlib import ExitStack
+from typing import Any, cast, Optional, Dict, List, Tuple
+
+import mxnet as mx
+
+from . import arguments
+from . import checkpoint_decoder
+from . import constants as C
+from . import convolution
+from . import coverage
+from . import data_io
+from . import decoder
+from . import encoder
+from . import initializer
+from . import loss
+from . import lr_scheduler
+from . import model
+from . import rnn
+from . import rnn_attention
+from . import scoring
+from . import train
+from . import training
+from . import transformer
+from . import utils
+from . import vocab
+from .config import Config
+from .log import setup_main_logger
+from .optimizers import OptimizerConfig
+from .utils import check_condition, log_basic_info
+
+# Temporary logger, the real one (logging to a file probably, will be created in the main function)
+logger = setup_main_logger(__name__, file_logging=False, console=True)
+
+
+def check_arg_compatibility(args: argparse.Namespace):
+    pass
+
+
+def create_scoring_model(config: model.ModelConfig,
+                         model_dir: str,
+                         context: List[mx.Context],
+                         score_iter: data_io.BaseParallelSampleIter) -> scoring.ScoringModel:
+    """
+    Create a scoring model and load the parameters from disk if needed.
+
+    :param config: The configuration for the model.
+    :param context: The context(s) to run on.
+    :param output_dir: Output folder.
+    :param train_iter: The training data iterator.
+    :param args: Arguments as returned by argparse.
+s    :return: The training model.
+    """
+    scoring_model = scoring.ScoringModel(config=config,
+                                         model_dir=model_dir,
+                                         context=context,
+                                         provide_data=score_iter.provide_data,
+                                         default_bucket_key=score_iter.default_bucket_key)
+
+    return scoring_model
+
+def main():
+    params = arguments.ConfigArgumentParser(description='Score data with an existing model.')
+    arguments.add_score_cli_args(params)
+    args = params.parse_args()
+    score(args)
+
+
+def score(args: argparse.Namespace):
+    check_arg_compatibility(args)
+
+    global logger
+    logger = setup_main_logger(__name__, file_logging=False)
+
+    utils.log_basic_info(args)
+
+    max_seq_len_source, max_seq_len_target = args.max_seq_len
+    # The maximum length is the length before we add the BOS/EOS symbols
+    max_seq_len_source = max_seq_len_source + C.SPACE_FOR_XOS
+    max_seq_len_target = max_seq_len_target + C.SPACE_FOR_XOS
+    logger.info("Adjusting maximum length to reserve space for a BOS/EOS marker. New maximum length: (%d, %d)",
+                max_seq_len_source, max_seq_len_target)
+
+    with ExitStack() as exit_stack:
+        context = utils.determine_context(device_ids=args.device_ids,
+                                          use_cpu=args.use_cpu,
+                                          disable_device_locking=args.disable_device_locking,
+                                          lock_dir=args.lock_dir,
+                                          exit_stack=exit_stack)
+        if args.batch_type == C.BATCH_TYPE_SENTENCE:
+            check_condition(args.batch_size % len(context) == 0, "When using multiple devices the batch size must be "
+                                                                 "divisible by the number of devices. Choose a batch "
+                                                                 "size that is a multiple of %d." % len(context))
+        logger.info("Scoring Device(s): %s", ", ".join(str(c) for c in context))
+
+        score_iter, _, config_data, source_vocabs, target_vocab = train.create_data_iters_and_vocabs(
+            args=args,
+            max_seq_len_source=max_seq_len_source,
+            max_seq_len_target=max_seq_len_target,
+            shared_vocab=args.shared_vocab,
+            resume_training=True,
+            output_folder=args.model)
+
+        max_seq_len_source = config_data.max_seq_len_source
+        max_seq_len_target = config_data.max_seq_len_target
+
+        model_config = model.SockeyeModel.load_config(os.path.join(args.model, C.CONFIG_NAME))
+
+        scoring_model = create_scoring_model(config=model_config,
+                                             model_dir=args.model,
+                                             context=context,
+                                             score_iter=score_iter)
+
+        scorer = scoring.Scorer(scoring_model, source_vocabs, target_vocab)
+
+        scorer.score(score_iter=score_iter)
+
+if __name__ == "__main__":
+    main()

--- a/sockeye/score.py
+++ b/sockeye/score.py
@@ -32,6 +32,7 @@ from . import coverage
 from . import data_io
 from . import decoder
 from . import encoder
+from . import inference
 from . import initializer
 from . import loss
 from . import lr_scheduler
@@ -131,7 +132,9 @@ def score(args: argparse.Namespace):
                                              context=context,
                                              score_iter=score_iter)
 
-        scorer = scoring.Scorer(scoring_model, source_vocabs, target_vocab)
+        scorer = scoring.Scorer(scoring_model, source_vocabs, target_vocab,
+                                length_penalty=inference.LengthPenalty(alpha=args.length_penalty_alpha,
+                                                                       beta=args.length_penalty_beta))
 
         scorer.score(score_iter=score_iter)
 

--- a/sockeye/scoring.py
+++ b/sockeye/scoring.py
@@ -217,6 +217,7 @@ class Scorer:
             batch_size, target_seq_len, _ = batch.provide_data[0][1]
             outputs = mx.nd.reshape(data=outputs[0], shape=(-4, batch_size, target_seq_len, -2))
 
+            # print('BATCH SOURCE', batch.data[0])
             probs = mx.nd.pick(outputs, labels)
             ones = mx.nd.ones_like(probs)
             lengths = mx.nd.sum(labels != 0, axis=1) - 1

--- a/sockeye/scoring.py
+++ b/sockeye/scoring.py
@@ -1,0 +1,214 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""
+Code for scoring.
+"""
+import logging
+import multiprocessing as mp
+import os
+import pickle
+import random
+import shutil
+import time
+from functools import reduce
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import mxnet as mx
+import numpy as np
+from math import sqrt
+
+from . import checkpoint_decoder
+from . import constants as C
+from . import data_io
+from . import loss
+from . import lr_scheduler
+from . import model
+from . import utils
+from . import vocab
+from .optimizers import BatchState, CheckpointState, SockeyeOptimizer, OptimizerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ScoringModel(model.SockeyeModel):
+    """
+    ScoringModel is a TrainingModel (which is in turn a SockeyeModel) that scores a pair of sentences.
+    That is, it full unrolls over source and target sequences, running the encoder and decoder, but stopping short of computing a loss and backpropagating.
+    It is analogous to TrainingModel, but more limited.
+
+    :param config: Configuration object holding details about the model.
+    :param context: The context(s) that MXNet will be run in (GPU(s)/CPU).
+    :param output_dir: Directory where this model is stored.
+    :param provide_data: List of input data descriptions.
+    :param provide_label: List of label descriptions.
+    :param default_bucket_key: Default bucket key.
+    :param bucketing: If True bucketing will be used, if False the computation graph will always be
+            unrolled to the full length.
+    """
+
+    def __init__(self,
+                 config: model.ModelConfig,
+                 model_dir: str,
+                 context: List[mx.context.Context],
+                 provide_data: List[mx.io.DataDesc],
+                 default_bucket_key: Tuple[int, int]) -> None:
+        super().__init__(config)
+        self.context = context
+        self._initialize(provide_data, default_bucket_key)
+
+        params_fname = os.path.join(model_dir, C.PARAMS_BEST_NAME)
+        self.load_params_from_file(params_fname)
+        self.module.set_params(arg_params=self.params,
+                               aux_params=self.aux_params,
+                               allow_missing=False)
+
+    def _initialize(self,
+                    provide_data: List[mx.io.DataDesc],
+                    default_bucket_key: Tuple[int, int]):
+        """
+        Initializes model components, creates training symbol and module, and binds it.
+        """
+        source = mx.sym.Variable(C.SOURCE_NAME)
+        source_words = source.split(num_outputs=self.config.config_embed_source.num_factors,
+                                    axis=2, squeeze_axis=True)[0]
+        source_length = utils.compute_lengths(source_words)
+        target = mx.sym.Variable(C.TARGET_NAME)
+        target_length = utils.compute_lengths(target)
+
+        data_names = [C.SOURCE_NAME, C.TARGET_NAME]
+
+        # check provide_{data,label} names
+        provide_data_names = [d[0] for d in provide_data]
+        utils.check_condition(provide_data_names == data_names,
+                              "incompatible provide_data: %s, names should be %s" % (provide_data_names, data_names))
+
+        def sym_gen(seq_lens):
+            """
+            Returns a (grouped) softmax symbol given source & target input lengths.
+            Also returns data and label names for the BucketingModule.
+            """
+            source_seq_len, target_seq_len = seq_lens
+
+            # source embedding
+            (source_embed,
+             source_embed_length,
+             source_embed_seq_len) = self.embedding_source.encode(source, source_length, source_seq_len)
+
+            # target embedding
+            (target_embed,
+             target_embed_length,
+             target_embed_seq_len) = self.embedding_target.encode(target, target_length, target_seq_len)
+
+            # encoder
+            # source_encoded: (batch_size, source_encoded_length, encoder_depth)
+            (source_encoded,
+             source_encoded_length,
+             source_encoded_seq_len) = self.encoder.encode(source_embed,
+                                                           source_embed_length,
+                                                           source_embed_seq_len)
+
+            # decoder
+            # target_decoded: (batch-size, target_len, decoder_depth)
+            target_decoded = self.decoder.decode_sequence(source_encoded, source_encoded_length, source_encoded_seq_len,
+                                                          target_embed, target_embed_length, target_embed_seq_len)
+
+            # target_decoded: (batch_size * target_seq_len, decoder_depth)
+            target_decoded = mx.sym.reshape(data=target_decoded, shape=(-3, 0))
+
+            # output layer
+            # logits: (batch_size * target_seq_len, target_vocab_size)
+            logits = self.output_layer(target_decoded)
+            outputs = mx.sym.softmax(data=logits, name=C.SOFTMAX_NAME)
+
+            # return the outputs and the data names (we don't need the labels)
+            return outputs, data_names, None
+
+        logger.info("Using bucketing. Default max_seq_len=%s", default_bucket_key)
+        self.module = mx.mod.BucketingModule(sym_gen=sym_gen,
+                                             logger=logger,
+                                             default_bucket_key=default_bucket_key,
+                                             context=self.context)
+
+        self.module.bind(data_shapes=provide_data,
+                         label_shapes=None,
+                         for_training=False,
+                         force_rebind=True,
+                         grad_req=None)
+
+
+    def prepare_batch(self, batch: mx.io.DataBatch):
+        """
+        Pre-fetches the next mini-batch.
+
+        :param batch: The mini-batch to prepare.
+        """
+        self.module.prepare(batch)
+
+    def run_forward(self, batch: mx.io.DataBatch):
+        """
+        Runs forward pass.
+        """
+        self.module.forward(batch, is_train=False)
+
+    def get_outputs(self):
+        return self.module.get_outputs()
+
+    def log_parameters(self):
+        """
+        Logs information about model parameters.
+        """
+        arg_params, aux_params = self.module.get_params()
+        total_parameters = 0
+        info = []  # type: List[str]
+        for name, array in sorted(arg_params.items()):
+            info.append("%s: %s" % (name, array.shape))
+            total_parameters += reduce(lambda x, y: x * y, array.shape)
+        logger.info("Model parameters: %s", ", ".join(info))
+        logger.info("Total # of parameters: %d", total_parameters)
+
+    def load_params_from_file(self, fname: str, allow_missing_params: bool = False):
+        """
+        Loads parameters from a file and sets the parameters of the underlying module and this model instance.
+
+        :param fname: File name to load parameters from.
+        :param allow_missing_params: If set, the given parameters are allowed to be a subset of the Module parameters.
+        """
+        super().load_params_from_file(fname)  # sets self.params & self.aux_params
+        self.module.set_params(arg_params=self.params,
+                               aux_params=self.aux_params,
+                               allow_missing=allow_missing_params)
+
+
+class Scorer:
+    def __init__(self,
+                 model: ScoringModel,
+                 source_vocabs: List[vocab.Vocab],
+                 target_vocab: vocab.Vocab):
+        self.model = model
+
+
+    def score(self,
+              score_iter):
+
+        for i, batch in enumerate(score_iter):
+            # data_io generates labels, too, which we don't need
+            label, batch.provide_label = batch.provide_label, None
+            self.model.prepare_batch(batch)
+            self.model.run_forward(batch)
+            outputs = self.model.get_outputs()
+
+            batch_size, target_seq_len, _ = batch.provide_data[0][1]
+            outputs = mx.nd.reshape(data=outputs[0], shape=(-4, batch_size, target_seq_len, -2))
+
+            print('OUTPUT', outputs.shape)

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -320,16 +320,8 @@ def create_data_iters_and_vocabs(args: argparse.Namespace,
                 word_min_count_target=word_min_count_target,
                 pad_to_multiple_of=args.pad_vocab_to_multiple_of)
 
-        check_condition(len(args.source_factors) == len(args.source_factors_num_embed),
-                        "Number of source factor data (%d) differs from provided source factor dimensions (%d)" % (
-                            len(args.source_factors), len(args.source_factors_num_embed)))
-
         sources = [args.source] + args.source_factors
         sources = [str(os.path.abspath(source)) for source in sources]
-
-        check_condition(len(sources) == len(validation_sources),
-                        'Training and validation data must have the same number of factors, but found %d and %d.' % (
-                            len(source_vocabs), len(validation_sources)))
 
         train_iter, validation_iter, config_data, data_info = data_io.get_training_data_iters(
             sources=sources,
@@ -349,10 +341,6 @@ def create_data_iters_and_vocabs(args: argparse.Namespace,
             max_seq_len_target=max_seq_len_target,
             bucketing=not args.no_bucketing,
             bucket_width=args.bucket_width)
-
-        data_info_fname = os.path.join(output_folder, C.DATA_INFO)
-        logger.info("Writing data config to '%s'", data_info_fname)
-        data_info.save(data_info_fname)
 
         return train_iter, validation_iter, config_data, source_vocabs, target_vocab
 
@@ -817,6 +805,18 @@ def train(args: argparse.Namespace):
             fill_up=args.fill_up)
         max_seq_len_source = config_data.max_seq_len_source
         max_seq_len_target = config_data.max_seq_len_target
+
+        data_info_fname = os.path.join(output_folder, C.DATA_INFO)
+        logger.info("Writing data config to '%s'", data_info_fname)
+        data_info.save(data_info_fname)
+
+        check_condition(len(args.source_factors) == len(args.source_factors_num_embed),
+                        "Number of source factor data (%d) differs from provided source factor dimensions (%d)" % (
+                            len(args.source_factors), len(args.source_factors_num_embed)))
+
+        check_condition(len(sources) == len(validation_sources),
+                        'Training and validation data must have the same number of factors, but found %d and %d.' % (
+                            len(source_vocabs), len(validation_sources)))
 
         # Dump the vocabularies if we're just starting up
         if not resume_training:

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -222,10 +222,11 @@ def create_data_iters_and_vocabs(args: argparse.Namespace,
                                  validation_sources: Optional[List[str]] = None,
                                  validation_target: Optional[str] = None,
                                  output_folder: Optional[str] = None,
-                                 fill_up: str = C.DEFAULT_FILL_UP_STRATEGY) -> Tuple['data_io.BaseParallelSampleIter',
-                                                                                     'data_io.BaseParallelSampleIter',
-                                                                                     'data_io.DataConfig',
-                                                                                     List[vocab.Vocab], vocab.Vocab]:
+                                 fill_up: str = C.DEFAULT_FILL_UP_STRATEGY,
+                                 no_permute: bool = False) -> Tuple['data_io.BaseParallelSampleIter',
+                                                                    'data_io.BaseParallelSampleIter',
+                                                                    'data_io.DataConfig',
+                                                                    List[vocab.Vocab], vocab.Vocab]:
     """
     Create the data iterators and the vocabularies.
 
@@ -337,6 +338,7 @@ def create_data_iters_and_vocabs(args: argparse.Namespace,
             batch_by_words=batch_by_words,
             batch_num_devices=batch_num_devices,
             fill_up=fill_up,
+            no_permute=no_permute,
             max_seq_len_source=max_seq_len_source,
             max_seq_len_target=max_seq_len_target,
             bucketing=not args.no_bucketing,

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -931,3 +931,18 @@ def split(data: mx.nd.NDArray,
     if num_outputs == 1:
         return [ndarray_or_list]
     return ndarray_or_list
+
+
+def inflect(noun: str,
+            count: int):
+    """
+    Minimal inflection module.
+
+    :param noun: The noun to inflect.
+    :param count: The count.
+    :return: The noun, perhaps inflected for number.
+    """
+    if noun in ['time']:
+        return noun if count == 1 else noun + 's'
+    else:
+        return noun + '(s)'


### PR DESCRIPTION
This implements scoring by fully reusing the training computation graph, per @bricksdont's original suggestion. It replaces PR #413.

It's nearly done, but I thought I'd submit it as WIP since it makes some changes required to generalize many of the procedures. These include:

- Making validation data optional when creating data iterators
- Adding a new data iterator `fill_up` policy that pads an uneven batch with zeros and does not randomly permute batches

#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
