### PR TITLE
[tiny] Entry-point fix after the contrib/ rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.57]
+### Fixed
+- Entry-point clean-up after the contrib/ rename
+
 ## [1.18.56]
 ### Changed
 - Update to MXNet 1.3.0.post0

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ else:
 
 entry_points={
     'console_scripts': [
-        'sockeye-autopilot = contrib.autopilot.autopilot:main',
+        'sockeye-autopilot = sockeye_contrib.autopilot.autopilot:main',
         'sockeye-average = sockeye.average:main',
         'sockeye-embeddings = sockeye.embeddings:main',
         'sockeye-evaluate = sockeye.evaluate:main',

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.56'
+__version__ = '1.18.57'


### PR DESCRIPTION
One entry point was left out after renaming contrib/ to sockeye_contrib/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

