### PR TITLE
Allow warmup rates < 10.

### DIFF
--- a/sockeye/lr_scheduler.py
+++ b/sockeye/lr_scheduler.py
@@ -26,7 +26,7 @@ class LearningRateScheduler:
         self.base_lr = None  # Note: will be overwritten by MXNet optimizer
         check_condition(warmup >= 0, "warmup needs to be >= 0.")
         self.warmup = warmup
-        self.log_warmup_every_t = self.warmup // 10
+        self.log_warmup_every_t = max(self.warmup // 10, 1)
         self.last_warmup_log = -1
 
     def __call__(self, num_updates):


### PR DESCRIPTION
Before `log_warmup_every_t` would be set to `0`, which would lead to a 
```
ZeroDivisionError: integer division or modulo by zero
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

