### PR TITLE
Don't do state cleanup if training not converged and return trainer's state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
 ## [1.18.59]
+### Added
 - A flag is returned alongside the best metric indicating if training converged.
 ### Changed
 - Training state cleanup will not be performed for training runs that did not converge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 
 ## [1.18.59]
 ### Added
-- A flag is returned alongside the best metric indicating if training converged.
+- Full training state is now returned from EarlyStoppingTrainer's fit().
 ### Changed
 - Training state cleanup will not be performed for training runs that did not converge.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ### Added
 - Full training state is now returned from EarlyStoppingTrainer's fit().
 ### Changed
-- Training state cleanup will not be performed for training runs that did not converge.
+- Training state cleanup will not be performed for training runs that did not converge yet.
 
 ## [1.18.58]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.59]
+- A flag is returned alongside the best metric indicating if training converged.
+### Changed
+- Training state cleanup will not be performed for training runs that did not converge.
+
 ## [1.18.58]
 ### Added
 - Added nbest translation, exposed as `--nbest-size`. Nbest translation means to not only output the most probable translation according to a model, but the top n most probable hypotheses. If `--nbest-size > 1` and the option `--output-type` is not explicitly specified, the output type will be changed to one JSON list of nbest translations per line. `--nbest-size` can never be larger than `--beam-size`.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.58'
+__version__ = '1.18.59'

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -238,8 +238,10 @@ ARGS_STATE_NAME = "args.yaml"
 # Arguments that may differ and still resume training
 ARGS_MAY_DIFFER = ["overwrite_output", "use-tensorboard", "quiet",
                    "align_plot_prefix", "sure_align_threshold",
-                   "keep_last_params", "seed", "max-updates",
-                   "max-num-epochs", "max-samples"]
+                   "keep_last_params", "seed",
+                   "max-updates", "min-updates",
+                   "max-num-epochs", "min-num-epochs",
+                   "max-samples", "min-samples"]
 
 # Other argument constants
 TRAINING_ARG_SOURCE = "--source"

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -238,7 +238,8 @@ ARGS_STATE_NAME = "args.yaml"
 # Arguments that may differ and still resume training
 ARGS_MAY_DIFFER = ["overwrite_output", "use-tensorboard", "quiet",
                    "align_plot_prefix", "sure_align_threshold",
-                   "keep_last_params"]
+                   "keep_last_params", "seed", "max-updates",
+                   "max-num-epochs", "max-samples"]
 
 # Other argument constants
 TRAINING_ARG_SOURCE = "--source"

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -763,7 +763,7 @@ def main():
     train(args)
 
 
-def train(args: argparse.Namespace) -> Tuple[float, bool]:
+def train(args: argparse.Namespace) -> training.TrainState:
     if args.dry_run:
         # Modify arguments so that we write to a temporary directory and
         # perform 0 training iterations
@@ -863,26 +863,26 @@ def train(args: argparse.Namespace) -> Tuple[float, bool]:
                                                 source_vocabs=source_vocabs,
                                                 target_vocab=target_vocab)
 
-        return trainer.fit(train_iter=train_iter,
-                           validation_iter=eval_iter,
-                           early_stopping_metric=args.optimized_metric,
-                           metrics=args.metrics,
-                           checkpoint_frequency=args.checkpoint_frequency,
-                           max_num_not_improved=max_num_checkpoint_not_improved,
-                           min_samples=min_samples,
-                           max_samples=max_samples,
-                           min_updates=min_updates,
-                           max_updates=max_updates,
-                           min_epochs=min_epochs,
-                           max_epochs=max_epochs,
-                           lr_decay_param_reset=args.learning_rate_decay_param_reset,
-                           lr_decay_opt_states_reset=args.learning_rate_decay_optimizer_states_reset,
-                           decoder=create_checkpoint_decoder(args, exit_stack, context),
-                                                 mxmonitor_pattern=args.monitor_pattern,
-                                                 mxmonitor_stat_func=args.monitor_stat_func,
-                                                 allow_missing_parameters=args.allow_missing_params or model_config.lhuc,
-                           existing_parameters=args.params)
-
+        training_state = trainer.fit(train_iter=train_iter,
+                                     validation_iter=eval_iter,
+                                     early_stopping_metric=args.optimized_metric,
+                                     metrics=args.metrics,
+                                     checkpoint_frequency=args.checkpoint_frequency,
+                                     max_num_not_improved=max_num_checkpoint_not_improved,
+                                     min_samples=min_samples,
+                                     max_samples=max_samples,
+                                     min_updates=min_updates,
+                                     max_updates=max_updates,
+                                     min_epochs=min_epochs,
+                                     max_epochs=max_epochs,
+                                     lr_decay_param_reset=args.learning_rate_decay_param_reset,
+                                     lr_decay_opt_states_reset=args.learning_rate_decay_optimizer_states_reset,
+                                     decoder=create_checkpoint_decoder(args, exit_stack, context),
+                                     mxmonitor_pattern=args.monitor_pattern,
+                                     mxmonitor_stat_func=args.monitor_stat_func,
+                                     allow_missing_parameters=args.allow_missing_params or model_config.lhuc,
+                                     existing_parameters=args.params)
+        return training_state
 
 if __name__ == "__main__":
     main()

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -763,7 +763,7 @@ def main():
     train(args)
 
 
-def train(args: argparse.Namespace):
+def train(args: argparse.Namespace) -> Tuple[float, bool]:
     if args.dry_run:
         # Modify arguments so that we write to a temporary directory and
         # perform 0 training iterations
@@ -863,25 +863,25 @@ def train(args: argparse.Namespace):
                                                 source_vocabs=source_vocabs,
                                                 target_vocab=target_vocab)
 
-        trainer.fit(train_iter=train_iter,
-                    validation_iter=eval_iter,
-                    early_stopping_metric=args.optimized_metric,
-                    metrics=args.metrics,
-                    checkpoint_frequency=args.checkpoint_frequency,
-                    max_num_not_improved=max_num_checkpoint_not_improved,
-                    min_samples=min_samples,
-                    max_samples=max_samples,
-                    min_updates=min_updates,
-                    max_updates=max_updates,
-                    min_epochs=min_epochs,
-                    max_epochs=max_epochs,
-                    lr_decay_param_reset=args.learning_rate_decay_param_reset,
-                    lr_decay_opt_states_reset=args.learning_rate_decay_optimizer_states_reset,
-                    decoder=create_checkpoint_decoder(args, exit_stack, context),
-                    mxmonitor_pattern=args.monitor_pattern,
-                    mxmonitor_stat_func=args.monitor_stat_func,
-                    allow_missing_parameters=args.allow_missing_params or model_config.lhuc,
-                    existing_parameters=args.params)
+        return trainer.fit(train_iter=train_iter,
+                           validation_iter=eval_iter,
+                           early_stopping_metric=args.optimized_metric,
+                           metrics=args.metrics,
+                           checkpoint_frequency=args.checkpoint_frequency,
+                           max_num_not_improved=max_num_checkpoint_not_improved,
+                           min_samples=min_samples,
+                           max_samples=max_samples,
+                           min_updates=min_updates,
+                           max_updates=max_updates,
+                           min_epochs=min_epochs,
+                           max_epochs=max_epochs,
+                           lr_decay_param_reset=args.learning_rate_decay_param_reset,
+                           lr_decay_opt_states_reset=args.learning_rate_decay_optimizer_states_reset,
+                           decoder=create_checkpoint_decoder(args, exit_stack, context),
+                                                 mxmonitor_pattern=args.monitor_pattern,
+                                                 mxmonitor_stat_func=args.monitor_stat_func,
+                                                 allow_missing_parameters=args.allow_missing_params or model_config.lhuc,
+                           existing_parameters=args.params)
 
 
 if __name__ == "__main__":

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -456,7 +456,7 @@ class EarlyStoppingTrainer:
             mxmonitor_pattern: Optional[str] = None,
             mxmonitor_stat_func: Optional[str] = None,
             allow_missing_parameters: bool = False,
-            existing_parameters: Optional[str] = None) -> 'TrainState':
+            existing_parameters: Optional[str] = None) -> TrainState:
         """
         Fits model to data given by train_iter using early-stopping w.r.t data given by val_iter.
         Saves all intermediate and final output to output_folder.

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -455,7 +455,7 @@ class EarlyStoppingTrainer:
             mxmonitor_pattern: Optional[str] = None,
             mxmonitor_stat_func: Optional[str] = None,
             allow_missing_parameters: bool = False,
-            existing_parameters: Optional[str] = None):
+            existing_parameters: Optional[str] = None) -> Tuple[float, bool]:
         """
         Fits model to data given by train_iter using early-stopping w.r.t data given by val_iter.
         Saves all intermediate and final output to output_folder.
@@ -488,7 +488,7 @@ class EarlyStoppingTrainer:
         :param allow_missing_parameters: Allow missing parameters when initializing model parameters from file.
         :param existing_parameters: Optional filename of existing/pre-trained parameters to initialize from.
 
-        :return: Best score on validation data observed during training.
+        :return: Best score on validation data observed during training and a flag indicating if early stopping happened.
         """
         self._check_args(metrics, early_stopping_metric, lr_decay_opt_states_reset, lr_decay_param_reset, decoder)
         logger.info("Early stopping by optimizing '%s'", early_stopping_metric)
@@ -522,6 +522,8 @@ class EarlyStoppingTrainer:
 
         speedometer = Speedometer(frequency=C.MEASURE_SPEED_EVERY, auto_reset=False)
         tic = time.time()
+
+        converged = False
 
         next_data_batch = train_iter.next()
         while True:
@@ -619,31 +621,34 @@ class EarlyStoppingTrainer:
                 if 0 <= max_num_not_improved <= self.state.num_not_improved:
                     logger.info("Maximum number of not improved checkpoints (%d) reached: %d",
                                 max_num_not_improved, self.state.num_not_improved)
-                    stop_fit = True
+                    converged = True
 
                     if min_epochs is not None and self.state.epoch < min_epochs:
                         logger.info("Minimum number of epochs (%d) not reached yet: %d",
                                     min_epochs, self.state.epoch)
-                        stop_fit = False
+                        converged = False
 
                     if min_updates is not None and self.state.updates < min_updates:
                         logger.info("Minimum number of updates (%d) not reached yet: %d",
                                     min_updates, self.state.updates)
-                        stop_fit = False
+                        converged = False
 
                     if min_samples is not None and self.state.samples < min_samples:
                         logger.info("Minimum number of samples (%d) not reached yet: %d",
                                     min_samples, self.state.samples)
 
-                    if stop_fit:
+                    if converged:
                         break
 
                 tic = time.time()
 
-        self._cleanup(lr_decay_opt_states_reset, process_manager=process_manager)
-        logger.info("Training finished. Best checkpoint: %d. Best validation %s: %.6f",
+        self._cleanup(lr_decay_opt_states_reset, process_manager=process_manager,
+                      keep_training_state=not converged)
+        logger.info("Training finished%s. Best checkpoint: %d. Best validation %s: %.6f",
+                    ", can be continued later" if not converged else "",
                     self.state.best_checkpoint, early_stopping_metric, self.state.best_metric)
-        return self.state.best_metric
+
+        return self.state.best_metric, converged
 
     def _step(self,
               model: TrainingModel,
@@ -747,7 +752,8 @@ class EarlyStoppingTrainer:
         tf_metrics.update(self.model.params)
         self.tflogger.log_metrics(metrics=tf_metrics, checkpoint=self.state.checkpoint)
 
-    def _cleanup(self, lr_decay_opt_states_reset: str, process_manager: Optional['DecoderProcessManager'] = None):
+    def _cleanup(self, lr_decay_opt_states_reset: str, process_manager: Optional['DecoderProcessManager'] = None,
+                 keep_training_state = False):
         """
         Cleans parameter files, training state directory and waits for remaining decoding processes.
         """
@@ -760,6 +766,9 @@ class EarlyStoppingTrainer:
                 self.state.metrics[decoded_checkpoint - 1].update(decoder_metrics)
                 self.tflogger.log_metrics(decoder_metrics, decoded_checkpoint)
             utils.write_metrics_file(self.state.metrics, self.metrics_fname)
+
+        if keep_training_state:
+            return
 
         final_training_state_dirname = os.path.join(self.model.output_dir, C.TRAINING_STATE_DIRNAME)
         if os.path.exists(final_training_state_dirname):


### PR DESCRIPTION
By default the ```training_state``` folder is deleted even if the training did not converge, i.e. the number of checkpoints did not hit ```--max-num-not-improved```, but the training stopped because of reaching ```--max-samples```, ```--max-num-epochs```, or ```--max-updates```. This changes the behaviour to keeping the folder to allow later training continuation and not enforcing the above parameters to match with the old run. Additionally a full training state is returned (with metrics, number of epochs, convergence status etc.), allowing its processing in a calling code.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

