### PR TITLE
Switching to portalocker for Windows compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.59]
+### Changed
+- Switched to portalocker for locking files (Windows compatibility).
+
 ## [1.18.58]
 ### Added
 - Added nbest translation, exposed as `--nbest-size`. Nbest translation means to not only output the most probable translation according to a model, but the top n most probable hypotheses. If `--nbest-size > 1` and the option `--output-type` is not explicitly specified, the output type will be changed to one JSON list of nbest translations per line. `--nbest-size` can never be larger than `--beam-size`.

--- a/requirements/requirements.gpu-cu75.txt
+++ b/requirements/requirements.gpu-cu75.txt
@@ -2,3 +2,4 @@ pyyaml==3.12
 mxnet-cu75mkl==1.3.0.post0
 numpy>=1.14
 typing
+portalocker

--- a/requirements/requirements.gpu-cu80.txt
+++ b/requirements/requirements.gpu-cu80.txt
@@ -2,3 +2,4 @@ pyyaml==3.12
 mxnet-cu80mkl==1.3.0.post0
 numpy>=1.14
 typing
+portalocker

--- a/requirements/requirements.gpu-cu90.txt
+++ b/requirements/requirements.gpu-cu90.txt
@@ -2,3 +2,4 @@ pyyaml==3.12
 mxnet-cu90mkl==1.3.0.post0
 numpy>=1.14
 typing
+portalocker

--- a/requirements/requirements.gpu-cu91.txt
+++ b/requirements/requirements.gpu-cu91.txt
@@ -2,3 +2,4 @@ pyyaml==3.12
 mxnet-cu91mkl==1.3.0.post0
 numpy>=1.14
 typing
+portalocker

--- a/requirements/requirements.gpu-cu92.txt
+++ b/requirements/requirements.gpu-cu92.txt
@@ -2,3 +2,4 @@ pyyaml==3.12
 mxnet-cu92mkl==1.3.0.post0
 numpy>=1.14
 typing
+portalocker

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,3 +2,4 @@ pyyaml==3.12
 mxnet-mkl==1.3.0.post0
 numpy>=1.14
 typing
+portalocker

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.58'
+__version__ = '1.18.59'

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -718,7 +718,7 @@ class GpuFileLock:
             except portalocker.LockException as e:
                 # portalocker packages the original exception,
                 # we dig it out and raise if unrelated to us
-                if e.args[0].errno != errno.EAGAIN:
+                if e.args[0].errno != errno.EAGAIN:  # pylint: disable=no-member
                     logger.error("Failed acquiring GPU lock.", exc_info=True)
                     raise e.args[0]
                 else:

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -16,7 +16,7 @@ A set of utility methods.
 """
 import binascii
 import errno
-import fcntl
+import portalocker
 import glob
 import gzip
 import itertools
@@ -702,7 +702,7 @@ class GpuFileLock:
                     continue
             try:
                 # exclusive non-blocking lock
-                fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                portalocker.lock(lock_file, portalocker.LOCK_EX | portalocker.LOCK_NB)
                 # got the lock, let's write our PID into it:
                 lock_file.write("%d\n" % os.getpid())
                 lock_file.flush()
@@ -715,11 +715,12 @@ class GpuFileLock:
                 logger.info("Acquired GPU {}.".format(gpu_id))
 
                 return gpu_id
-            except IOError as e:
-                # raise on unrelated IOErrors
-                if e.errno != errno.EAGAIN:
+            except portalocker.LockException as e:
+                # portalocker packages the original exception,
+                # we dig it out and raise if unrelated to us
+                if e.args[0].errno != errno.EAGAIN:
                     logger.error("Failed acquiring GPU lock.", exc_info=True)
-                    raise
+                    raise e.args[0]
                 else:
                     logger.debug("GPU {} is currently locked.".format(gpu_id))
         return None
@@ -729,7 +730,7 @@ class GpuFileLock:
             logger.info("Releasing GPU {}.".format(self.gpu_id))
         if self.lock_file is not None:
             if self._acquired_lock:
-                fcntl.flock(self.lock_file, fcntl.LOCK_UN)
+                portalocker.lock(self.lock_file, portalocker.LOCK_UN)
             self.lock_file.close()
             os.remove(self.lockfile_path)
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -64,7 +64,7 @@ def test_expand_requested_device_ids(requested_device_ids, num_gpus_available, e
 
 
 @pytest.mark.parametrize("requested_device_ids, num_gpus_available, expected", device_params)
-def test_aquire_gpus(tmpdir, requested_device_ids, num_gpus_available, expected):
+def test_acquire_gpus(tmpdir, requested_device_ids, num_gpus_available, expected):
     with utils.acquire_gpus(requested_device_ids, lock_dir=str(tmpdir),
                             num_gpus_available=num_gpus_available) as acquired_gpus:
         assert set(acquired_gpus) == set(expected)
@@ -91,7 +91,7 @@ def test_expand_requested_device_ids_exception(requested_device_ids, num_gpus_av
 
 
 @pytest.mark.parametrize("requested_device_ids, num_gpus_available", device_params_expected_exception)
-def test_aquire_gpus_exception(tmpdir, requested_device_ids, num_gpus_available):
+def test_acquire_gpus_exception(tmpdir, requested_device_ids, num_gpus_available):
     with pytest.raises(ValueError):
         with utils.acquire_gpus(requested_device_ids, lock_dir=str(tmpdir),
                                 num_gpus_available=num_gpus_available) as _:
@@ -104,7 +104,7 @@ device_params_1_locked = [([-4, 3, 5], 7, [0, 2, 3, 4, 5, 6]),
 
 
 @pytest.mark.parametrize("requested_device_ids, num_gpus_available, expected", device_params_1_locked)
-def test_aquire_gpus_1_locked(tmpdir, requested_device_ids, num_gpus_available, expected):
+def test_acquire_gpus_1_locked(tmpdir, requested_device_ids, num_gpus_available, expected):
     gpu_1 = 1
     with utils.GpuFileLock([gpu_1], str(tmpdir)) as lock:
         with utils.acquire_gpus(requested_device_ids, lock_dir=str(tmpdir),


### PR DESCRIPTION
This addresses #567 by replacing ```fcntl``` with ```portalocker``` to get compatibility with Windows in file-locking. On POSIX hosts ```portalocker``` still uses ```fcntl``` under the hood. 

Not tested under Windows, but @hanayashiki from #567 reports positive experience with it.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

