### PR TITLE
Removed use_mxnet_topk flag from utils.topk()

### DIFF
--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1181,10 +1181,7 @@ class Translator:
             if self.skip_topk:
                 self._top = partial(utils.top1, offset=self.offset)  # type: Callable
             else:
-                self._top = partial(utils.topk,
-                                    k=self.beam_size,
-                                    offset=self.offset,
-                                    use_mxnet_topk=True)  # type: Callable
+                self._top = partial(utils.topk, k=self.beam_size, offset=self.offset)  # type: Callable
         else:
             if self.skip_topk:
                 self._top = Top1(k=self.beam_size,


### PR DESCRIPTION
As mentioned in #585 `use_mxnet_topk` in `utils.topk()` was set to True constantly by now. This PR removes the flag but keeps the numpy implementation for testing.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

