### PR TITLE
Informative error message when --max-seq-len is too small.

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -424,7 +424,7 @@ def add_bucketing_args(params):
                         default=10,
                         help='Width of buckets in tokens. Default: %(default)s.')
 
-    params.add_argument('--max-seq-len',
+    params.add_argument(C.TRAINING_ARG_MAX_SEQ_LEN,
                         type=multiple_values(num_values=2, greater_or_equal=1),
                         default=(99, 99),
                         help='Maximum sequence length in tokens.'

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -247,6 +247,7 @@ ARGS_MAY_DIFFER = ["overwrite_output", "use-tensorboard", "quiet",
 TRAINING_ARG_SOURCE = "--source"
 TRAINING_ARG_TARGET = "--target"
 TRAINING_ARG_PREPARED_DATA = "--prepared-data"
+TRAINING_ARG_MAX_SEQ_LEN = "--max-seq-len"
 
 VOCAB_ARG_SHARED_VOCAB = "--shared-vocab"
 

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -780,7 +780,8 @@ def get_training_data_iters(sources: List[str],
                             max_seq_len_target: int,
                             bucketing: bool,
                             bucket_width: int,
-                            permute: bool = True) -> Tuple['BaseParallelSampleIter',
+                            permute: bool = True,
+                            allow_empty: bool = False) -> Tuple['BaseParallelSampleIter',
                                                            Optional['BaseParallelSampleIter'],
                                                            'DataConfig', 'DataInfo']:
     """
@@ -803,6 +804,7 @@ def get_training_data_iters(sources: List[str],
     :param max_seq_len_target: Maximum target sequence length.
     :param bucketing: Whether to use bucketing.
     :param bucket_width: Size of buckets.
+    :param allow_empty: Unless True if no sentences are below or equal to the maximum length an exception is raised.
     :return: Tuple of (training data iterator, validation data iterator, data config).
     """
     logger.info("===============================")
@@ -812,9 +814,10 @@ def get_training_data_iters(sources: List[str],
     length_statistics = analyze_sequence_lengths(sources, target, source_vocabs, target_vocab,
                                                  max_seq_len_source, max_seq_len_target)
 
-    check_condition(length_statistics.num_sents > 0,
-                    "No training sequences found with length smaller or equal than the maximum sequence length."
-                    "Consider increasing %s" % C.TRAINING_ARG_MAX_SEQ_LEN)
+    if not allow_empty:
+        check_condition(length_statistics.num_sents > 0,
+                        "No training sequences found with length smaller or equal than the maximum sequence length."
+                        "Consider increasing %s" % C.TRAINING_ARG_MAX_SEQ_LEN)
 
     # define buckets
     buckets = define_parallel_buckets(max_seq_len_source, max_seq_len_target, bucket_width,

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -533,6 +533,9 @@ def prepare_data(source_fnames: List[str],
     length_statistics = analyze_sequence_lengths(source_fnames, target_fname, source_vocabs, target_vocab,
                                                  max_seq_len_source, max_seq_len_target)
 
+    check_condition(length_statistics.num_sents > 0, "0 training sentence within maximum length, consider increasing "
+                                                     "the %s." % C.TRAINING_ARG_MAX_SEQ_LEN)
+
     # define buckets
     buckets = define_parallel_buckets(max_seq_len_source, max_seq_len_target, bucket_width,
                                       length_statistics.length_ratio_mean) if bucketing else [
@@ -644,6 +647,10 @@ def get_validation_data_iter(data_loader: RawParallelDatasetLoader,
     validation_length_statistics = analyze_sequence_lengths(validation_sources, validation_target,
                                                             source_vocabs, target_vocab,
                                                             max_seq_len_source, max_seq_len_target)
+
+    check_condition(validation_length_statistics.num_sents > 0, "0 validation sentence within maximum length, consider"
+                                                                " increasing the %s." % C.TRAINING_ARG_MAX_SEQ_LEN)
+
     validation_sources_sentences, validation_target_sentences = create_sequence_readers(validation_sources,
                                                                                         validation_target,
                                                                                         source_vocabs, target_vocab)
@@ -802,6 +809,10 @@ def get_training_data_iters(sources: List[str],
     # Pass 1: get target/source length ratios.
     length_statistics = analyze_sequence_lengths(sources, target, source_vocabs, target_vocab,
                                                  max_seq_len_source, max_seq_len_target)
+
+    check_condition(length_statistics.num_sents > 0, "0 training sentence within maximum length, consider increasing "
+                                                     "the %s." % C.TRAINING_ARG_MAX_SEQ_LEN)
+
     # define buckets
     buckets = define_parallel_buckets(max_seq_len_source, max_seq_len_target, bucket_width,
                                       length_statistics.length_ratio_mean) if bucketing else [

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -533,8 +533,9 @@ def prepare_data(source_fnames: List[str],
     length_statistics = analyze_sequence_lengths(source_fnames, target_fname, source_vocabs, target_vocab,
                                                  max_seq_len_source, max_seq_len_target)
 
-    check_condition(length_statistics.num_sents > 0, "0 training sentence within maximum length, consider increasing "
-                                                     "the %s." % C.TRAINING_ARG_MAX_SEQ_LEN)
+    check_condition(length_statistics.num_sents > 0,
+                    "No training sequences found with length smaller or equal than the maximum sequence length."
+                    "Consider increasing %s" % C.TRAINING_ARG_MAX_SEQ_LEN)
 
     # define buckets
     buckets = define_parallel_buckets(max_seq_len_source, max_seq_len_target, bucket_width,
@@ -648,8 +649,9 @@ def get_validation_data_iter(data_loader: RawParallelDatasetLoader,
                                                             source_vocabs, target_vocab,
                                                             max_seq_len_source, max_seq_len_target)
 
-    check_condition(validation_length_statistics.num_sents > 0, "0 validation sentence within maximum length, consider"
-                                                                " increasing the %s." % C.TRAINING_ARG_MAX_SEQ_LEN)
+    check_condition(validation_length_statistics.num_sents > 0,
+                    "No validation sequences found with length smaller or equal than the maximum sequence length."
+                    "Consider increasing %s" % C.TRAINING_ARG_MAX_SEQ_LEN)
 
     validation_sources_sentences, validation_target_sentences = create_sequence_readers(validation_sources,
                                                                                         validation_target,
@@ -810,8 +812,9 @@ def get_training_data_iters(sources: List[str],
     length_statistics = analyze_sequence_lengths(sources, target, source_vocabs, target_vocab,
                                                  max_seq_len_source, max_seq_len_target)
 
-    check_condition(length_statistics.num_sents > 0, "0 training sentence within maximum length, consider increasing "
-                                                     "the %s." % C.TRAINING_ARG_MAX_SEQ_LEN)
+    check_condition(length_statistics.num_sents > 0,
+                    "No training sequences found with length smaller or equal than the maximum sequence length."
+                    "Consider increasing %s" % C.TRAINING_ARG_MAX_SEQ_LEN)
 
     # define buckets
     buckets = define_parallel_buckets(max_seq_len_source, max_seq_len_target, bucket_width,

--- a/sockeye/score.py
+++ b/sockeye/score.py
@@ -91,7 +91,8 @@ def get_data_iters_and_vocabs(args: argparse.Namespace,
         max_seq_len_source=max_seq_len_source,
         max_seq_len_target=max_seq_len_target,
         bucketing=False,
-        bucket_width=args.bucket_width)
+        bucket_width=args.bucket_width,
+        allow_empty=True)
 
     return train_iter, config_data, source_vocabs, target_vocab, model_config
 


### PR DESCRIPTION
Just adding a small check to fail with an informative error message if none of the sentence fits, for example because `--max-seq-len` was set incorrectly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

