### PR TITLE
Move compatibility checks for inference configuration variables into API functions (Translator.init() & load_models())

### DIFF
--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -49,26 +49,13 @@ def run_translate(args: argparse.Namespace):
                                    file_logging=True,
                                    path="%s.%s" % (args.output, C.LOG_NAME))
 
-    if args.checkpoints is not None:
-        check_condition(len(args.checkpoints) == len(args.models), "must provide checkpoints for each model")
-
-    if args.skip_topk:
-        check_condition(args.beam_size == 1, "--skip-topk has no effect if beam size is larger than 1")
-        check_condition(len(args.models) == 1, "--skip-topk has no effect for decoding with more than 1 model")
-
-    if args.nbest_size > 1:
-        check_condition(args.beam_size >= args.nbest_size,
-                        "Size of nbest list (--nbest-size) must be smaller or equal to beam size (--beam-size).")
-        check_condition(args.beam_search_stop == C.BEAM_SEARCH_STOP_ALL,
-                        "--nbest-size > 1 requires beam search to only stop after all hypotheses are finished "
-                        "(--beam-search-stop all)")
-        if args.output_type != C.OUTPUT_HANDLER_NBEST:
-            logger.warning("For nbest translation, output handler must be '%s', overriding option --output-type.",
-                       C.OUTPUT_HANDLER_NBEST)
-            args.output_type = C.OUTPUT_HANDLER_NBEST
-
     log_basic_info(args)
 
+    if args.nbest_size > 1:
+        if args.output_type != C.OUTPUT_HANDLER_NBEST:
+            logger.warning("For nbest translation, output handler must be '%s', overriding option --output-type.",
+                           C.OUTPUT_HANDLER_NBEST)
+            args.output_type = C.OUTPUT_HANDLER_NBEST
     output_handler = get_output_handler(args.output_type,
                                         args.output,
                                         args.sure_align_threshold)
@@ -81,11 +68,6 @@ def run_translate(args: argparse.Namespace):
                                     lock_dir=args.lock_dir,
                                     exit_stack=exit_stack)[0]
         logger.info("Translate Device: %s", context)
-
-        if args.override_dtype == C.DTYPE_FP16:
-            logger.warning('Experimental feature \'--override-dtype float16\' has been used. '
-                           'This feature may be removed or change its behaviour in future. '
-                           'DO NOT USE IT IN PRODUCTION!')
 
         models, source_vocabs, target_vocab = inference.load_models(
             context=context,

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -16,7 +16,6 @@ A set of utility methods.
 """
 import binascii
 import errno
-import portalocker
 import glob
 import gzip
 import itertools
@@ -32,6 +31,7 @@ from typing import Mapping, Any, List, Iterator, Iterable, Set, Tuple, Dict, Opt
 
 import mxnet as mx
 import numpy as np
+import portalocker
 
 from . import __version__, constants as C
 from .log import log_sockeye_version, log_mxnet_version


### PR DESCRIPTION
... and some more cleanups.

This is a proposal PR for moving various compatibility checks for inference configuration into the respective API functions, e.g. the Translator constructor and `load_models()`, instead of having them in `translate.py::run_translate()` which depends on commandline variables. 
I think this would make it a bit easier for users to launch inference with compatible settings in their custom code.
The original idea of having the checks immediately after argparsing was to fail early in case of incompatible settings, but I think this is still early enough.



#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

