### PR TITLE
Fix BLEU score for decodings with restrict-lexicon in system tests

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -593,7 +593,9 @@ def run_train_translate(train_params: str,
 
         bleu_restrict = None
         if restrict_lexicon:
-            bleu_restrict = raw_corpus_bleu(hypotheses=hypotheses, references=references, offset=0.01)
+            with open(out_restrict_path) as out:
+                hypotheses_restrict = out.readlines()
+            bleu_restrict = raw_corpus_bleu(hypotheses=hypotheses_restrict, references=references, offset=0.01)
 
         # Run evaluate cli
         eval_params = "{} {} ".format(sockeye.evaluate.__file__,

--- a/test/system/test_seq_copy_sys.py
+++ b/test/system/test_seq_copy_sys.py
@@ -69,9 +69,9 @@ COMMON_TRAINING_PARAMS = " --checkpoint-frequency 1000 --optimizer adam --initia
      "--encoder rnn --decoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 64 --num-embed 32 "
      " --rnn-attention-type mlp --rnn-attention-num-hidden 32 "
      " --batch-size 80 --batch-type word "
-     " --max-updates 5000  "
+     " --max-updates 5000 "
      " --rnn-dropout-states 0.0:0.1 --embed-dropout 0.1:0.0 --layer-normalization" + COMMON_TRAINING_PARAMS,
-     "--beam-size 5 --batch-size 2 --beam-prune 1 --beam-search-stop first",
+     "--beam-size 5 --batch-size 2 --beam-prune 1",
      True,
      1.01,
      0.99),


### PR DESCRIPTION
Relevant to the recent note in #590 about the ugliness of `run_train_translate()` for testing: `bleu` and `bleu_restrict` variables computed at the end for asserting on scores in system tests were always holding the same value, because we passed the regular hypotheses produced without lexicon-restriction into the bleu calculation, even for `bleu-restrict`. This fixes it. 
I can't easily trace the origin of this bug; seems like it was always there :)

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

