### PR TITLE
More precise error message about --shared-vocab usage inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.65]
+### Changed
+- More informative error message about inconsistent --shared-vocab setting.
+
 ## [1.18.64]
 ### Added
 - Adding translation sampling via `--sample [N]`. This causes the decoder to sample each next step from the target distribution probabilities at each

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.64'
+__version__ = '1.18.65'

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -713,9 +713,10 @@ def get_prepared_data_iters(prepared_data_dir: str,
     for shard_fname in shard_fnames:
         check_condition(os.path.exists(shard_fname), "Shard %s does not exist." % shard_fname)
 
-    check_condition(shared_vocab == data_info.shared_vocab, "Shared config needed (e.g. for weight tying), but "
-                                                            "data was prepared without a shared vocab. Use %s when "
-                                                            "preparing the data." % C.VOCAB_ARG_SHARED_VOCAB)
+    check_condition(shared_vocab == data_info.shared_vocab, "Shared vocabulary settings need to match these "
+                                                            "of the prepared data (e.g. for weight tying). "
+                                                            "Specify or omit %s consistently when training "
+                                                            "and preparing the data." % C.VOCAB_ARG_SHARED_VOCAB)
 
     source_vocabs = vocab.load_source_vocabs(prepared_data_dir)
     target_vocab = vocab.load_target_vocab(prepared_data_dir)


### PR DESCRIPTION
The message was suggesting that the problem is (only) in the data preparation. Took me some time to realize that it's the training arguments that were missing ```--shared-vocab```, not the data preparation.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

