### PR TITLE
Fixing arguments that are allowed to differ for training continuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.66]
+### Fixed
+- Fix to argument names that are allowed to differ for resuming training.
+
 ## [1.18.65]
 ### Changed
 - More informative error message about inconsistent --shared-vocab setting.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.65'
+__version__ = '1.18.66'

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -236,12 +236,12 @@ TRAINING_STATE_PARAMS_NAME = "params"
 ARGS_STATE_NAME = "args.yaml"
 
 # Arguments that may differ and still resume training
-ARGS_MAY_DIFFER = ["overwrite_output", "use-tensorboard", "quiet",
+ARGS_MAY_DIFFER = ["overwrite_output", "use_tensorboard", "quiet",
                    "align_plot_prefix", "sure_align_threshold",
                    "keep_last_params", "seed",
-                   "max-updates", "min-updates",
-                   "max-num-epochs", "min-num-epochs",
-                   "max-samples", "min-samples"]
+                   "max_updates", "min_updates",
+                   "max_num_epochs", "min_num_epochs",
+                   "max_samples", "min_samples"]
 
 # Other argument constants
 TRAINING_ARG_SOURCE = "--source"

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -513,4 +513,4 @@ def test_config_file_required(config_command_line, config_contents):
 
 def test_arguments_allowed_to_differ():
     for arg in C.ARGS_MAY_DIFFER:
-        assert re.match(r'^[a-zA-z0-9_]*$', arg)
+        assert re.match(r'^[a-zA-Z0-9_]*$', arg)

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -15,6 +15,7 @@ import argparse
 import pytest
 import tempfile
 import os
+import re
 import yaml
 
 import sockeye.arguments as arguments
@@ -509,3 +510,7 @@ def test_config_file_required(config_command_line, config_contents):
             # Parse args and cast to dicts directly
             config_file_argparse.parse_args(
                 args=(config_command_line + (" --config %s" % fp.name)).split())
+
+def test_arguments_allowed_to_differ():
+    for arg in C.ARGS_MAY_DIFFER:
+        assert re.match(r'^[a-zA-z0-9_]*$', arg)


### PR DESCRIPTION
Fixing typos introduced in #581 and adding a small test to prevent similar errors.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

