### PR TITLE
Correctly use initial optimizer states on learning rate decay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.68]
+### Added
+- Fixed training crashes with `--learning-rate-decay-optimizer-states-reset initial` option.
+
 ## [1.18.67]
 ### Added
 - Added `fertility` as a further type of attention coverage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
 ## [1.18.68]
-### Added
+### Fixed
 - Fixed training crashes with `--learning-rate-decay-optimizer-states-reset initial` option.
 
 ## [1.18.67]

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.67'
+__version__ = '1.18.68'

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -512,6 +512,7 @@ class EarlyStoppingTrainer:
             self._save_params()
             self._update_best_params_link()
             self._save_training_state(train_iter)
+            self._save_initial_optimizer_states(lr_decay_opt_states_reset)
             self._update_best_optimizer_states(lr_decay_opt_states_reset)
             self.tflogger.log_graph(self.model.current_module.symbol)
             logger.info("Training started.")
@@ -778,6 +779,10 @@ class EarlyStoppingTrainer:
                 best_opt_states_fname = os.path.join(self.model.output_dir, C.OPT_STATES_BEST)
                 if os.path.exists(best_opt_states_fname):
                     os.remove(best_opt_states_fname)
+            if lr_decay_opt_states_reset == C.LR_DECAY_OPT_STATES_RESET_INITIAL:
+                initial_opt_states_fname = os.path.join(self.model.output_dir, C.OPT_STATES_INITIAL)
+                if os.path.exists(initial_opt_states_fname):
+                    os.remove(initial_opt_states_fname)
 
     def _initialize_parameters(self, params: Optional[str], allow_missing_params: bool):
         self.model.initialize_parameters(self.optimizer_config.initializer, allow_missing_params)


### PR DESCRIPTION
This pull request fixes a bug with the `--learning-rate-decay-optimizer-states-reset initial` option, where training would crash when attempting to access the initial optimizer states since they were not saved to disk at the start of training.


#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`) 
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

