### PR TITLE
fix pytest-cov to 2.6.0 for Travis

### DIFF
--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -4,7 +4,7 @@ pillow
 check-manifest
 matplotlib
 mypy==0.610
-pylint==2.0.1
+pylint
 setuptools>=38.6.0
 twine>=1.11.0
 wheel>=0.31.0

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -1,5 +1,5 @@
 pytest
-pytest-cov
+pytest-cov<2.6.0
 pillow
 check-manifest
 matplotlib

--- a/sockeye/image_captioning/utils.py
+++ b/sockeye/image_captioning/utils.py
@@ -186,7 +186,7 @@ def zero_pad_features(features: List[np.ndarray],
         elif len(feature_shape) > len(target_shape):
             raise ValueError("Provided target shape must be bigger then the original "
                              "shape. (provided: {}, original {})".format(len(target_shape), len(feature_shape)))
-        diff_shape = np.subtract(target_shape, feature_shape)
+        diff_shape = np.subtract(target_shape, feature_shape)  # pylint: disable=assignment-from-no-return
         if np.any(diff_shape < 0):
             raise ValueError("Provided target values must be bigger then the original "
                              "values for each dimension. (provided: {}, original {})".format(target_shape, feature_shape))


### PR DESCRIPTION
We've seen travis builds failing for Py3.4 and Py3.6 recently with the following error message:
```
Traceback (most recent call last):
  File "/opt/python/3.4.6/lib/python3.4/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/python/3.4.6/lib/python3.4/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pytest.py", line 17, in <module>
    raise SystemExit(pytest.main())
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/config.py", line 47, in main
    config = _prepareconfig(args, plugins)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/config.py", line 156, in _prepareconfig
    pluginmanager=pluginmanager, args=args)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/vendored_packages/pluggy.py", line 745, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/vendored_packages/pluggy.py", line 339, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/vendored_packages/pluggy.py", line 334, in <lambda>
    _MultiCall(methods, kwargs, hook.spec_opts).execute()
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/vendored_packages/pluggy.py", line 613, in execute
    return _wrapped_call(hook_impl.function(*args), self.execute)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/vendored_packages/pluggy.py", line 250, in _wrapped_call
    wrap_controller.send(call_outcome)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/helpconfig.py", line 32, in pytest_cmdline_parse
    config = outcome.get_result()
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/vendored_packages/pluggy.py", line 279, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/vendored_packages/pluggy.py", line 265, in __init__
    self.result = func()
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/vendored_packages/pluggy.py", line 614, in execute
    res = hook_impl.function(*args)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/config.py", line 924, in pytest_cmdline_parse
    self.parse(args)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/config.py", line 1082, in parse
    self._preparse(args, addopts=addopts)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/config.py", line 1044, in _preparse
    self.pluginmanager.load_setuptools_entrypoints(entrypoint_name)
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/vendored_packages/pluggy.py", line 515, in load_setuptools_entrypoints
    "Plugin %r could not be loaded: %s!" % (ep.name, e))
_pytest.vendored_packages.pluggy.PluginValidationError: Plugin 'pytest_cov' could not be loaded: (pytest 3.0.7 (/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages), Requirement.parse('pytest>=3.6'))!
The command "if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then python -m pytest --maxfail=1 test/system; fi" exited with 1.
```

This [issue](https://github.com/pywbem/pywbem/issues/1371#issuecomment-418785850) seems related, so I tried their fix in our requirements.dev.txt: fixing pytest-cov version to 2.6.0

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

