### PR TITLE
Do log configuration in CLI only

### DIFF
--- a/sockeye/average.py
+++ b/sockeye/average.py
@@ -21,6 +21,7 @@ works well in practice.
 import argparse
 import itertools
 import os
+import logging
 from typing import Dict, Iterable, List
 
 import mxnet as mx
@@ -30,7 +31,7 @@ from . import arguments
 from . import constants as C
 from . import utils
 
-logger = setup_main_logger(__name__, console=True, file_logging=False)
+logger = logging.getLogger(__name__)
 
 
 def average(param_paths: Iterable[str]) -> Dict[str, mx.nd.NDArray]:
@@ -148,6 +149,7 @@ def main():
     """
     Commandline interface to average parameters.
     """
+    setup_main_logger(console=True, file_logging=False)
     params = argparse.ArgumentParser(description="Averages parameters from multiple models.")
     arguments.add_average_args(params)
     args = params.parse_args()

--- a/sockeye/embeddings.py
+++ b/sockeye/embeddings.py
@@ -17,6 +17,7 @@ Command-line tool to inspect model embeddings.
 import argparse
 import os
 import sys
+import logging
 from typing import Iterable, Tuple
 
 import mxnet as mx
@@ -30,7 +31,7 @@ from .log import setup_main_logger
 from .utils import check_condition
 from .vocab import load_source_vocabs, load_target_vocab, reverse_vocab
 
-logger = setup_main_logger(__name__, file_logging=False)
+logger = logging.getLogger(__name__)
 
 
 def compute_sims(inputs: mx.nd.NDArray, normalize: bool) -> mx.nd.NDArray:
@@ -84,6 +85,7 @@ def main():
     """
     Command-line tool to inspect model embeddings.
     """
+    setup_main_logger(file_logging=False)
     params = argparse.ArgumentParser(description='Shows nearest neighbours of input tokens in the embedding space.')
     params.add_argument('--model', '-m', required=True,
                         help='Model folder to load config from.')

--- a/sockeye/evaluate.py
+++ b/sockeye/evaluate.py
@@ -30,7 +30,7 @@ from . import data_io
 from . import utils
 from .log import setup_main_logger, log_sockeye_version
 
-logger = setup_main_logger(__name__, file_logging=False)
+logger = logging.getLogger(__name__)
 
 
 def raw_corpus_bleu(hypotheses: Iterable[str], references: Iterable[str], offset: Optional[float] = 0.01) -> float:
@@ -91,6 +91,7 @@ def raw_corpus_rougel(hypotheses: Iterable[str], references: Iterable[str]) -> f
 
 
 def main():
+    setup_main_logger(file_logging=False)
     params = argparse.ArgumentParser(description='Evaluate translations by calculating metrics with '
                                                  'respect to a reference set. If multiple hypotheses files are given'
                                                  'the mean and standard deviation of the metrics are reported.')

--- a/sockeye/extract_parameters.py
+++ b/sockeye/extract_parameters.py
@@ -17,6 +17,7 @@ Extract specific parameters.
 
 import argparse
 import os
+import logging
 from typing import Dict, List
 
 import mxnet as mx
@@ -27,7 +28,7 @@ from . import constants as C
 from . import utils
 from .log import setup_main_logger, log_sockeye_version
 
-logger = setup_main_logger(__name__, console=True, file_logging=False)
+logger = logging.getLogger(__name__)
 
 
 def _extract(param_names: List[str],
@@ -92,6 +93,7 @@ def main():
     """
     Commandline interface to extract parameters.
     """
+    setup_main_logger(console=True, file_logging=False)
     params = argparse.ArgumentParser(description="Extract specific parameters.")
     arguments.add_extract_args(params)
     args = params.parse_args()

--- a/sockeye/image_captioning/captioner.py
+++ b/sockeye/image_captioning/captioner.py
@@ -17,6 +17,7 @@ Image captioning CLI.
 import argparse
 import os
 import tempfile
+import logging
 from contextlib import ExitStack
 
 import mxnet as mx
@@ -36,7 +37,7 @@ from ..log import setup_main_logger
 from ..translate import read_and_translate
 from ..utils import check_condition, log_basic_info, determine_context
 
-logger = setup_main_logger(__name__, file_logging=False)
+logger = logging.getLogger(__name__)
 
 
 def get_pretrained_caption_net(args: argparse.Namespace,
@@ -116,11 +117,11 @@ def caption(args: argparse.Namespace):
     image_preextracted_features = not args.extract_image_features
 
     if args.output is not None:
-        global logger
-        logger = setup_main_logger(__name__,
-                                   console=not args.quiet,
+        setup_main_logger(console=not args.quiet,
                                    file_logging=True,
                                    path="%s.%s" % (args.output, C.LOG_NAME))
+    else:
+        setup_main_logger(file_logging=False)
 
     if args.checkpoints is not None:
         check_condition(len(args.checkpoints) == len(args.models),

--- a/sockeye/image_captioning/extract_features.py
+++ b/sockeye/image_captioning/extract_features.py
@@ -17,6 +17,7 @@ CLI for extracting image features.
 import argparse
 import os
 import pickle
+import logging
 from contextlib import ExitStack
 from typing import List, Tuple
 
@@ -32,7 +33,7 @@ from ..utils import check_condition, determine_context
 
 # Temporary logger, the real one (logging to a file probably, will be created
 # in the main function)
-logger = setup_main_logger(__name__, file_logging=False, console=True)
+logger = logging.getLogger(__name__)
 
 
 def batching(iterable, n=1):
@@ -96,6 +97,7 @@ def read_list_file(inp: str) -> List[str]:
 
 
 def main():
+    setup_main_logger(file_logging=False, console=True)
     params = argparse.ArgumentParser(description='CLI to extract features from images.')
     arguments.add_image_extract_features_cli_args(params)
     args = params.parse_args()

--- a/sockeye/image_captioning/train.py
+++ b/sockeye/image_captioning/train.py
@@ -26,6 +26,7 @@ import argparse
 import json
 import os
 import pickle
+import logging
 from contextlib import ExitStack
 from typing import cast, Dict, List, Tuple, Optional
 
@@ -53,7 +54,7 @@ from ..train import check_resume, check_arg_compatibility, create_decoder_config
 from ..utils import check_condition
 
 # Temporary logger, the real one (logging to a file probably, will be created in the main function)
-logger = setup_main_logger(__name__, file_logging=False, console=True)
+logger = logging.getLogger(__name__)
 
 
 def read_feature_shape(path):
@@ -282,10 +283,8 @@ def train(args: argparse.Namespace):
     output_folder = os.path.abspath(args.output)
     resume_training = check_resume(args, output_folder)
 
-    global logger
-    logger = setup_main_logger(__name__,
-                               file_logging=True,
-                               console=not args.quiet, path=os.path.join(output_folder, C.LOG_NAME))
+    setup_main_logger(file_logging=True,
+                      console=not args.quiet, path=os.path.join(output_folder, C.LOG_NAME))
     utils.log_basic_info(args)
     with open(os.path.join(output_folder, C.ARGS_STATE_NAME), "w") as fp:
         json.dump(vars(args), fp)

--- a/sockeye/image_captioning/utils.py
+++ b/sockeye/image_captioning/utils.py
@@ -15,6 +15,7 @@
 A set of utility methods for images.
 """
 import os
+import logging
 from shutil import copyfile
 from typing import List, Optional
 
@@ -24,7 +25,7 @@ from ..log import setup_main_logger
 
 # Temporary logger, the real one (logging to a file probably, will be created
 # in the main function)
-logger = setup_main_logger(__name__, file_logging=False, console=True)
+logger = logging.getLogger(__name__)
 
 try:  # Try to import pillow
     from PIL import Image  # pylint: disable=import-error

--- a/sockeye/init_embedding.py
+++ b/sockeye/init_embedding.py
@@ -58,6 +58,7 @@ Optional arguments:
 
 import argparse
 import sys
+import logging
 from typing import Dict
 
 import numpy as np
@@ -68,7 +69,7 @@ from . import arguments
 from . import utils
 from . import vocab
 
-logger = setup_main_logger(__name__, console=True, file_logging=False)
+logger = logging.getLogger(__name__)
 
 
 def init_weight(weight: np.ndarray,
@@ -123,6 +124,7 @@ def main():
     """
     Commandline interface to initialize Sockeye embedding weights with pretrained word representations.
     """
+    setup_main_logger(console=True, file_logging=False)
     params = argparse.ArgumentParser(description='Quick usage: python3 -m sockeye.init_embedding '
                                                  '-w embed-in-src.npy embed-in-tgt.npy '
                                                  '-i vocab-in-src.json vocab-in-tgt.json '

--- a/sockeye/lexicon.py
+++ b/sockeye/lexicon.py
@@ -15,6 +15,7 @@ import argparse
 import os
 import sys
 import time
+import logging
 from itertools import groupby
 from operator import itemgetter
 from typing import Dict, Generator, Tuple, Optional
@@ -28,7 +29,7 @@ from . import vocab
 from .data_io import smart_open, get_tokens, tokens2ids
 from .log import setup_main_logger, log_sockeye_version
 
-logger = setup_main_logger(__name__, console=True, file_logging=False)
+logger = logging.getLogger(__name__)
 
 
 def lexicon_iterator(path: str,
@@ -197,8 +198,9 @@ class TopKLexicon:
 
 
 def create(args):
+    setup_main_logger(console=not args.quiet, file_logging=True, path=args.output + ".log")
     global logger
-    logger = setup_main_logger('create', console=not args.quiet, file_logging=True, path=args.output + ".log")
+    logger = logging.getLogger('create')
     log_sockeye_version(logger)
     logger.info("Creating top-k lexicon from \"%s\"", args.input)
     logger.info("Reading source and target vocab from \"%s\"", args.model)
@@ -211,8 +213,9 @@ def create(args):
 
 
 def inspect(args):
+    setup_main_logger(console=True, file_logging=False)
     global logger
-    logger = setup_main_logger('inspect', console=True, file_logging=False)
+    logger = logging.getLogger('inspect')
     log_sockeye_version(logger)
     logger.info("Inspecting top-k lexicon at \"%s\"", args.lexicon)
     vocab_source = vocab.load_source_vocabs(args.model)[0]

--- a/sockeye/log.py
+++ b/sockeye/log.py
@@ -102,11 +102,10 @@ def is_python34() -> bool:
     return version[0] == 3 and version[1] == 4
 
 
-def setup_main_logger(name: str, file_logging=True, console=True, path: Optional[str] = None) -> logging.Logger:
+def setup_main_logger(file_logging=True, console=True, path: Optional[str] = None):
     """
-    Return a logger that configures logging for the main application.
+    Configures logging for the main application.
 
-    :param name: Name of the returned logger.
     :param file_logging: Whether to log to a file.
     :param console: Whether to log to the console.
     :param path: Optional path to write logfile to.
@@ -122,20 +121,17 @@ def setup_main_logger(name: str, file_logging=True, console=True, path: Optional
         log_config["handlers"]["rotating"]["filename"] = path  # type: ignore
 
     logging.config.dictConfig(log_config)
-    logger = logging.getLogger(name)
 
     def exception_hook(exc_type, exc_value, exc_traceback):
         if is_python34():
             # Python3.4 does not seem to handle logger.exception() well
             import traceback
             traceback = "".join(traceback.format_tb(exc_traceback)) + exc_type.name
-            logger.error("Uncaught exception\n%s", traceback)
+            logging.error("Uncaught exception\n%s", traceback)
         else:
-            logger.exception("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
+            logging.exception("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
 
     sys.excepthook = exception_hook
-
-    return logger
 
 
 def log_sockeye_version(logger):

--- a/sockeye/prepare_data.py
+++ b/sockeye/prepare_data.py
@@ -13,6 +13,7 @@
 
 import argparse
 import os
+import logging
 
 from . import arguments
 from . import constants as C
@@ -21,7 +22,7 @@ from . import utils
 from . import vocab
 from .log import setup_main_logger
 
-logger = setup_main_logger(__name__, file_logging=False, console=True)
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -34,8 +35,7 @@ def main():
 def prepare_data(args: argparse.Namespace):
     output_folder = os.path.abspath(args.output)
     os.makedirs(output_folder, exist_ok=True)
-    global logger
-    logger = setup_main_logger(__name__, file_logging=True, path=os.path.join(output_folder, C.LOG_NAME))
+    setup_main_logger(file_logging=True, path=os.path.join(output_folder, C.LOG_NAME))
 
     utils.seed_rngs(args.seed)
 

--- a/sockeye/rerank.py
+++ b/sockeye/rerank.py
@@ -17,6 +17,7 @@ CLI to rerank an nbest list of translations.
 
 import argparse
 import json
+import logging
 from typing import Any, Dict, List
 
 import numpy as np
@@ -27,7 +28,7 @@ from . import constants as C
 from . import log
 from . import utils
 
-logger = log.setup_main_logger(__name__, console=True, file_logging=False)
+logger = logging.getLogger(__name__)
 
 
 class Reranker:
@@ -111,6 +112,7 @@ def main():
     """
     Commandline interface to rerank nbest lists.
     """
+    log.setup_main_logger(console=True, file_logging=False)
     log.log_sockeye_version(logger)
 
     params = argparse.ArgumentParser(description="Rerank nbest lists of translations."

--- a/sockeye/score.py
+++ b/sockeye/score.py
@@ -16,6 +16,7 @@ Simple Training CLI.
 """
 import argparse
 import os
+import logging
 from contextlib import ExitStack
 from typing import Optional, List, Tuple
 
@@ -32,10 +33,11 @@ from .output_handler import get_output_handler
 from .utils import check_condition
 
 # Temporary logger, the real one (logging to a file probably, will be created in the main function)
-logger = setup_main_logger(__name__, file_logging=False, console=True)
+logger = logging.getLogger(__name__)
 
 
 def main():
+    setup_main_logger(file_logging=False, console=True)
     params = arguments.ConfigArgumentParser(description='Score data with an existing model.')
     arguments.add_score_cli_args(params)
     args = params.parse_args()
@@ -98,8 +100,6 @@ def get_data_iters_and_vocabs(args: argparse.Namespace,
 
 
 def score(args: argparse.Namespace):
-    global logger
-    logger = setup_main_logger(__name__, file_logging=False)
 
     utils.log_basic_info(args)
 

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -27,6 +27,7 @@ import os
 import shutil
 import sys
 import tempfile
+import logging
 from contextlib import ExitStack
 from typing import Any, cast, Optional, Dict, List, Tuple
 
@@ -57,7 +58,7 @@ from .optimizers import OptimizerConfig
 from .utils import check_condition
 
 # Temporary logger, the real one (logging to a file probably, will be created in the main function)
-logger = setup_main_logger(__name__, file_logging=False, console=True)
+logger = logging.getLogger(__name__)
 
 
 def none_if_negative(val):
@@ -799,10 +800,8 @@ def train(args: argparse.Namespace) -> training.TrainState:
     output_folder = os.path.abspath(args.output)
     resume_training = check_resume(args, output_folder)
 
-    global logger
-    logger = setup_main_logger(__name__,
-                               file_logging=True,
-                               console=not args.quiet, path=os.path.join(output_folder, C.LOG_NAME))
+    setup_main_logger(file_logging=True,
+                      console=not args.quiet, path=os.path.join(output_folder, C.LOG_NAME))
     utils.log_basic_info(args)
     arguments.save_args(args, os.path.join(output_folder, C.ARGS_STATE_NAME))
 

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -17,6 +17,7 @@ Translation CLI.
 import argparse
 import sys
 import time
+import logging
 from contextlib import ExitStack
 from math import ceil
 from typing import Generator, Optional, List
@@ -31,7 +32,7 @@ from . import data_io
 from . import inference
 from . import utils
 
-logger = setup_main_logger(__name__, file_logging=False)
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -47,11 +48,11 @@ def run_translate(args: argparse.Namespace):
     utils.seed_rngs(args.seed if args.seed is not None else int(time.time()))
 
     if args.output is not None:
-        global logger
-        logger = setup_main_logger(__name__,
-                                   console=not args.quiet,
+        setup_main_logger(console=not args.quiet,
                                    file_logging=True,
                                    path="%s.%s" % (args.output, C.LOG_NAME))
+    else:
+        setup_main_logger(file_logging=False)
 
     log_basic_info(args)
 

--- a/sockeye/vocab.py
+++ b/sockeye/vocab.py
@@ -20,8 +20,8 @@ from contextlib import ExitStack
 from itertools import chain, islice
 from typing import Dict, Iterable, List, Optional, Tuple
 
+from sockeye.log import setup_main_logger
 from . import constants as C
-from . import log
 from . import utils
 
 logger = logging.getLogger(__name__)
@@ -328,9 +328,8 @@ def main():
     utils.check_condition(word_min_count == word_min_count_other,
                           "Vocabulary CLI only allows a common value for --word-min-count")
 
-    global logger
-    logger = log.setup_main_logger("build_vocab", file_logging=True, console=True,
-                                   path="%s.%s" % (args.output, C.LOG_NAME))
+    setup_main_logger(file_logging=True, console=True,
+                      path="%s.%s" % (args.output, C.LOG_NAME))
 
     vocab = build_from_paths(args.inputs,
                              num_words=num_words,


### PR DESCRIPTION
Avoid logging configuration at module level. This will lead to logging configuration problems when Sockeye is used as a library.
Moved the logging configuration to CLI only  

#### Pull Request Checklist ##
- [YES ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [YES] Unit tests pass (`pytest`)
- [NO] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [YES] System tests pass (`pytest test/system`)
- [YES] Passed code style checking (`./style-check.sh`)
- [NO] You have considered writing a test
- [ NO] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [NO] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

