### PR TITLE
Stop training on checkpoint decoder failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.76]
+### Added
+- Adding the option via the flag `--stop-training-on-decoder-failure` to stop training in case the checkpoint decoder dies (e.g. because there is not enough memory).
+In case this is turned on a checkpoint decoder is launch right when training starts in order to fail as early as possible.
+
+
 ## [1.18.75]
 ### Changed
 - Do not create dropout layers for inference models for performance reasons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ## [1.18.76]
 ### Added
 - Adding the option via the flag `--stop-training-on-decoder-failure` to stop training in case the checkpoint decoder dies (e.g. because there is not enough memory).
-In case this is turned on a checkpoint decoder is launch right when training starts in order to fail as early as possible.
+In case this is turned on a checkpoint decoder is launched right when training starts in order to fail as early as possible.
 
 
 ## [1.18.75]

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.75'
+__version__ = '1.18.76'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1063,6 +1063,11 @@ def add_training_args(params):
                                    'Use a negative number to automatically acquire a GPU. '
                                    'Use a positive number to acquire a specific GPU. Default: %(default)s.')
 
+    train_params.add_argument(C.TRAIN_ARGS_STOP_ON_DECODER_FAILURE,
+                              action="store_true",
+                              help='Stop training as soon as any checkpoint decoder fails (e.g. because there is not '
+                                   'enough GPU memory).')
+
     train_params.add_argument('--seed',
                               type=int,
                               default=13,

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1066,7 +1066,7 @@ def add_training_args(params):
     train_params.add_argument(C.TRAIN_ARGS_STOP_ON_DECODER_FAILURE,
                               action="store_true",
                               help='Stop training as soon as any checkpoint decoder fails (e.g. because there is not '
-                                   'enough GPU memory).')
+                                   'enough GPU memory). Default: %(default)s.')
 
     train_params.add_argument('--seed',
                               type=int,

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -275,6 +275,7 @@ INFERENCE_ARG_INPUT_FACTORS_LONG = "--input-factors"
 INFERENCE_ARG_INPUT_FACTORS_SHORT = "-if"
 TRAIN_ARGS_MONITOR_BLEU = "--decode-and-evaluate"
 TRAIN_ARGS_CHECKPOINT_FREQUENCY = "--checkpoint-frequency"
+TRAIN_ARGS_STOP_ON_DECODER_FAILURE = "--stop-training-on-decoder-failure"
 
 # Used to delimit factors on STDIN for inference
 DEFAULT_FACTOR_DELIMITER = '|'

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -883,7 +883,8 @@ def train(args: argparse.Namespace) -> training.TrainState:
                                                 max_params_files_to_keep=args.keep_last_params,
                                                 keep_initializations=args.keep_initializations,
                                                 source_vocabs=source_vocabs,
-                                                target_vocab=target_vocab)
+                                                target_vocab=target_vocab,
+                                                stop_training_on_decoder_failure=args.stop_training_on_decoder_failure)
 
         training_state = trainer.fit(train_iter=train_iter,
                                      validation_iter=eval_iter,

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -1173,12 +1173,10 @@ class DecoderProcessManager(object):
         """
         self.wait_to_finish()
         if self.decoder_metric_queue.empty():
-            print("queue empty! ", self._results_pending)
             if self._results_pending:
                 self._any_process_died = True
             self._results_pending = False
             return None
-        print("queue not empty")
         decoded_checkpoint, decoder_metrics = self.decoder_metric_queue.get()
         assert self.decoder_metric_queue.empty()
         self._results_pending = False

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -432,8 +432,7 @@ class EarlyStoppingTrainer:
                  keep_initializations: bool,
                  source_vocabs: List[vocab.Vocab],
                  target_vocab: vocab.Vocab,
-                 # TODO set to False
-                 stop_training_on_decoder_failure: bool = True) -> None:
+                 stop_training_on_decoder_failure: bool = False) -> None:
         self.model = model
         self.optimizer_config = optimizer_config
         self.max_params_files_to_keep = max_params_files_to_keep

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -1207,7 +1207,7 @@ class DecoderProcessManager(object):
         return self._any_process_died
 
     def update_process_died_status(self):
-        """ Update the flag indicating whether any process exited  and did not provide a result. """
+        """ Update the flag indicating whether any process exited and did not provide a result. """
 
         # There is a result pending, the process is no longer alive, yet there is no result in the queue
         # This means the decoder process has not succesfully produced metrics

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -1205,11 +1205,11 @@ class DecoderProcessManager(object):
 
     @property
     def any_process_died(self):
-        """ Returns true if any decoder process exited with a non-zero exit code. """
+        """ Returns true if any decoder process exited and did not provide a result. """
         return self._any_process_died
 
     def update_process_died_status(self):
-        """ Update the flag indicating whether any process exited with a non-zero exit code. """
+        """ Update the flag indicating whether any process exited  and did not provide a result. """
 
         # There is a result pending, the process is no longer alive, yet there is no result in the queue
         # This means the decoder process has not succesfully produced metrics

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -186,6 +186,7 @@ def test_model_parameters(test_params, expected_params):
               decode_and_evaluate=500,
               decode_and_evaluate_use_cpu=False,
               decode_and_evaluate_device_id=None,
+              stop_training_on_decoder_failure=False,
               seed=13,
               keep_last_params=-1,
               keep_initializations=False,


### PR DESCRIPTION
Adding the option via the flag `--stop-training-on-decoder-failure` to stop training in case the checkpoint decoder dies (e.g. because there is not enough memory).
In case this is turned on a checkpoint decoder is launch right when training starts in order to fail as early as possible.

#### Pull Request Checklist ##
- [X] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [X] Unit tests pass (`pytest`)
- [X] Passed code style checking (`./style-check.sh`)
- [X] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [X] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

