### PR TITLE
No scoring scores checks in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.76]
+### Changed
+- Do not compare scores from translation and scoring in integration tests.
+
 ## [1.18.75]
 ### Changed
 - Do not create dropout layers for inference models for performance reasons.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.75'
+__version__ = '1.18.76'

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -37,6 +37,8 @@ _TEST_LINE_COUNT_EMPTY = 2
 _LINE_MAX_LENGTH = 9
 _TEST_MAX_LENGTH = 20
 
+
+# tuple format: (train_params, translate_params, use_prepared_data, use_source_factors)
 ENCODER_DECODER_SETTINGS = [
     # "Vanilla" LSTM encoder-decoder with attention
     ("--encoder rnn --decoder rnn --num-layers 1 --rnn-cell-type lstm --rnn-num-hidden 8 --num-embed 4 "
@@ -171,11 +173,15 @@ def test_seq_copy(train_params: str,
                             test_max_length=_TEST_MAX_LENGTH,
                             sort_target=False,
                             with_source_factors=use_source_factors) as data:
+        
+        # TODO: Here we temporarily switch off comparing translation and scoring scores, which
+        # sometimes produces inconsistent results for --batch-size > 1 (see issue #639 on github).
         check_train_translate(train_params=train_params,
                               translate_params=translate_params,
                               data=data,
                               use_prepared_data=use_prepared_data,
-                              max_seq_len=_LINE_MAX_LENGTH + C.SPACE_FOR_XOS)
+                              max_seq_len=_LINE_MAX_LENGTH + C.SPACE_FOR_XOS,
+                              compare_translate_vs_scoring_scores=False)
 
 
 TINY_TEST_MODEL = [(" --num-layers 2 --transformer-attention-heads 2 --transformer-model-size 4 --num-embed 4"


### PR DESCRIPTION
This pulls out a part of #626 to temporarily disable the checks that translation and scoring scores are close in integration tests until #639 is fixed. This was causing sporadic failures on different machines and/or Travis.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

