### PR TITLE
Detect divergence and report it with the convergence status in the metrics file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.79]
+### Added
+- Writing of the convergence/divergence status to the metrics file and guarding against numpy.histogram's errors for NaNs during divergent behaviour.
+
 ## [1.18.78]
 ### Changed
 - Dynamic batch sizes: `Translator.translate()` will adjust batch size in beam search to the actual number of inputs without using padding.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.78'
+__version__ = '1.18.79'

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -803,7 +803,7 @@ def train(args: argparse.Namespace) -> training.TrainState:
                       path=os.path.join(output_folder, C.LOG_NAME),
                       level=args.loglevel)
     if hasattr(args, "checkpoint_frequency"):
-        logger.warn("'--checkpoint-frequency' is deprecated, and will be removed in the future.  Please use '--checkpoint-interval'")
+        logger.warning("'--checkpoint-frequency' is deprecated, and will be removed in the future.  Please use '--checkpoint-interval'")
     utils.log_basic_info(args)
     arguments.save_args(args, os.path.join(output_folder, C.ARGS_STATE_NAME))
 

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -591,7 +591,7 @@ class EarlyStoppingTrainer:
                 # (2) determine improvement
                 has_improved = False
                 previous_best = self.state.best_metric
-                # at this point state.self..metrics doesn't have validation results yet
+                # at this point state.self.metrics doesn't have validation results yet
                 current_checkpoint_val_metric = {"%s-val" % name:val for name, val in metric_val.get_name_value()}
                 for checkpoint, metric_dict in enumerate(self.state.metrics + [current_checkpoint_val_metric], 1):
                     value = metric_dict.get("%s-val" % early_stopping_metric, self.state.best_metric)

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -592,8 +592,8 @@ class EarlyStoppingTrainer:
                 has_improved = False
                 previous_best = self.state.best_metric
                 # at this point state.self..metrics doesn't have validation results yet
-                current_checkpoint_val_metric = [{"%s-val" % name:val for name, val in metric_val.get_name_value()}]
-                for checkpoint, metric_dict in enumerate(self.state.metrics + current_checkpoint_val_metric, 1):
+                current_checkpoint_val_metric = {"%s-val" % name:val for name, val in metric_val.get_name_value()}
+                for checkpoint, metric_dict in enumerate(self.state.metrics + [current_checkpoint_val_metric], 1):
                     value = metric_dict.get("%s-val" % early_stopping_metric, self.state.best_metric)
                     if utils.metric_value_is_better(value, self.state.best_metric, early_stopping_metric):
                         self.state.best_metric = value

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -764,9 +764,13 @@ class EarlyStoppingTrainer:
         for name, value in metric_train.get_name_value():
             if np.isfinite(value):
                 checkpoint_metrics["%s-train" % name] = value
+            else:
+                logger.warning("A non-finite value skipped for training metric %s", name)
         for name, value in metric_val.get_name_value():
             if np.isfinite(value):
                 checkpoint_metrics["%s-val" % name] = value
+            else:
+                logger.warning("A non-finite value skipped for validation metric %s", name)
 
         if process_manager is not None:
             result = process_manager.collect_results()

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -634,9 +634,9 @@ class EarlyStoppingTrainer:
                                 early_stopping_metric, self.state.num_not_improved, self.state.best_metric)
 
                 # (5) detect divergence with respect to perplexity value at the last checkpoint
-                if self.state.metrics and not has_improved and early_stopping_metric == C.PERPLEXITY:
+                if self.state.metrics and not has_improved:
                     # perplexity cannot exceed the number of target words, using the double to avoid precision issues
-                    last_ppl_value = self.state.metrics[-1][early_stopping_metric]
+                    last_ppl_value = self.state.metrics[-1][C.PERPLEXITY]
                     if not np.isfinite(last_ppl_value) or last_ppl_value > 2 * len(self.target_vocab):
                         self.state.diverged = True
 

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -634,7 +634,7 @@ class EarlyStoppingTrainer:
 
                 # (4) detect divergence with respect to the perplexity value at the last checkpoint
                 if self.state.metrics and not has_improved:
-                    last_ppl_value = metric_val[C.PERPLEXITY]
+                    last_ppl_value = current_checkpoint_val_metric["%s-val" % C.PERPLEXITY]
                     # using a double of uniform distribution's value as a threshold
                     if not np.isfinite(last_ppl_value) or last_ppl_value > 2 * len(self.target_vocab):
                         logger.warning("Model optimization diverged. Last checkpoint's perplexity: %f",

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -762,15 +762,9 @@ class EarlyStoppingTrainer:
 
         # copy values from checkpoint_metrics, skipping NaNs and infinities that break numpy's histograms
         for name, value in metric_train.get_name_value():
-            if np.isfinite(value):
-                checkpoint_metrics["%s-train" % name] = value
-            else:
-                logger.warning("A non-finite value skipped for training metric %s", name)
+            checkpoint_metrics["%s-train" % name] = value
         for name, value in metric_val.get_name_value():
-            if np.isfinite(value):
-                checkpoint_metrics["%s-val" % name] = value
-            else:
-                logger.warning("A non-finite value skipped for validation metric %s", name)
+            checkpoint_metrics["%s-val" % name] = value
 
         if process_manager is not None:
             result = process_manager.collect_results()
@@ -1079,7 +1073,7 @@ class TensorboardLogger:
             return
 
         for name, value in metrics.items():
-            if isinstance(value, mx.nd.NDArray):
+            if isinstance(value, mx.nd.NDArray) and mx.ndarray.contrib.isfinite(value).sum() == value.size():
                 self.sw.add_histogram(tag=name, values=value, bins=100, global_step=checkpoint)
             else:
                 self.sw.add_scalar(tag=name, value=value, global_step=checkpoint)

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -607,6 +607,7 @@ class EarlyStoppingTrainer:
                     if min_samples is not None and self.state.samples < min_samples:
                         logger.info("Minimum number of samples (%d) not reached yet: %d",
                                     min_samples, self.state.samples)
+                        self.state.converged = False
 
                 # (3) update training metrics as the last step to capture the converged status
                 self._update_metrics(metric_train, metric_val, process_manager)
@@ -636,7 +637,7 @@ class EarlyStoppingTrainer:
                 # (5) detect divergence with respect to perplexity value at the last checkpoint
                 if self.state.metrics and not has_improved:
                     # perplexity cannot exceed the number of target words, using the double to avoid precision issues
-                    last_ppl_value = self.state.metrics[-1][C.PERPLEXITY]
+                    last_ppl_value = self.state.metrics[-1]["%s-val" % C.PERPLEXITY]
                     if not np.isfinite(last_ppl_value) or last_ppl_value > 2 * len(self.target_vocab):
                         self.state.diverged = True
 

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -1077,7 +1077,8 @@ class TensorboardLogger:
 
         for name, value in metrics.items():
             if isinstance(value, mx.nd.NDArray):
-                if mx.ndarray.contrib.isfinite(value).sum() == value.size():
+                # TODO: switch to mx.ndarray.contrib.isfinite after upgrade to MxNet 1.4.*
+                if utils.isfinite(value).sum() == value.size():
                     self.sw.add_histogram(tag=name, values=value, bins=100, global_step=checkpoint)
                 else:
                     logger.warning("Not adding the histogram of %s to tensorboard because some of its values are not finite.")

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -791,7 +791,7 @@ def write_metrics_file(metrics: List[Dict[str, Any]], path: str):
     """
     with open(path, 'w') as metrics_out:
         for checkpoint, metric_dict in enumerate(metrics, 1):
-            metrics_str = "\t".join(["{}={}".format(name, value) for name, value in sorted(metric_dict.items())])
+            metrics_str = "\t".join(["{}={:f}".format(name, value) for name, value in sorted(metric_dict.items())])
             metrics_out.write("{}\t{}\n".format(checkpoint, metrics_str))
 
 

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -777,7 +777,10 @@ def read_metrics_file(path: str) -> List[Dict[str, Any]]:
             metric = dict()
             for field in fields[1:]:
                 key, value = field.split("=", 1)
-                metric[key] = float(value)
+                if value == 'True' or value == 'False':
+                    metric[key] = bool(value)
+                else:
+                    metric[key] = float(value)
             metrics.append(metric)
     return metrics
 
@@ -791,7 +794,7 @@ def write_metrics_file(metrics: List[Dict[str, Any]], path: str):
     """
     with open(path, 'w') as metrics_out:
         for checkpoint, metric_dict in enumerate(metrics, 1):
-            metrics_str = "\t".join(["{}={:f}".format(name, value) for name, value in sorted(metric_dict.items())])
+            metrics_str = "\t".join(["{}={}".format(name, value) for name, value in sorted(metric_dict.items())])
             metrics_out.write("{}\t{}\n".format(checkpoint, metrics_str))
 
 

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -774,7 +774,7 @@ def read_metrics_file(path: str) -> List[Dict[str, Any]]:
             checkpoint = int(fields[0])
             check_condition(i == checkpoint,
                             "Line (%d) and loaded checkpoint (%d) do not align." % (i, checkpoint))
-            metric = dict()
+            metric = dict()  # type: Dict[str, Any]
             for field in fields[1:]:
                 key, value = field.split("=", 1)
                 if value == 'True' or value == 'False':

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -990,3 +990,12 @@ def inflect(word: str,
         return 'was' if count == 1 else 'were'
     else:
         return word + '(s)'
+
+
+def isfinite(data: mx.nd.NDArray) -> mx.nd.NDArray:
+    """Performs an element-wise check to determine if the NDArray contains an infinite element or not.
+       TODO: remove this funciton after upgrade to MXNet 1.4.* in favor of mx.ndarray.contrib.isfinite()
+    """
+    is_data_not_nan = data == data
+    is_data_not_infinite = data.abs() != np.inf
+    return mx.nd.logical_and(is_data_not_infinite, is_data_not_nan)


### PR DESCRIPTION
Sometimes training diverges with average training and validation perplexities sky-rocketing. To detect this early, we can test if the average validation perplexity surpasses double the the target vocabulary size and stop training. Additionally, we report the convergence and divergence status in the metrics file to provide some more information on why training stopped: because it actually converged, diverged or stopped for some the reason, like, hitting one of the max_{epochs, updates} limits.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

