### PR TITLE
Serialize metrics file with final BLEU for training continuation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.81]
+### Fixed
+- Making sure the training pickled training state contains the checkpoint decoder's BLEU score of the last checkpoint.
+
 ## [1.18.80]
 ### Fixed
 - Fixed a bug introduced in 1.18.77 where blank lines in the training data resulted in failure.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.80'
+__version__ = '1.18.81'


### PR DESCRIPTION
The training state pickle did not contain the final BLEU score. When continuing training this lead to the metrics file missing the BLEU score of the checkpoint at which the training was terminated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

