### PR TITLE
Stop after n checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.85]
+### Fixed
+- Added parameter to force training to stop after a given number of checkpoints. Useful when forced to share limited GPU resources.
+
 ## [1.18.84]
 ### Fixed
 - Fixed lexical constraints bugs that broke batching and caused large drop in BLEU.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.84'
+__version__ = '1.18.85'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -876,10 +876,10 @@ def add_training_args(params):
                               help='Maximum number of checkpoints the model is allowed to not improve in '
                                    '<optimized-metric> on validation data before training is stopped. '
                                    'Default: %(default)s.')
-    train_params.add_argument('--max-num-checkpoint',
+    train_params.add_argument('--max-checkpoints',
                               type=int,
                               default=None,
-                              help='Absolute maximum number of checkpoints to continue training the model '
+                              help='Maximum number of checkpoints to continue training the model '
                                    'before training is stopped. '
                                    'Default: %(default)s.')
     train_params.add_argument('--min-num-epochs',

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -876,6 +876,12 @@ def add_training_args(params):
                               help='Maximum number of checkpoints the model is allowed to not improve in '
                                    '<optimized-metric> on validation data before training is stopped. '
                                    'Default: %(default)s.')
+    train_params.add_argument('--max-num-checkpoint',
+                              type=int,
+                              default=None,
+                              help='Absolute maximum number of checkpoints to continue training the model '
+                                   'before training is stopped. '
+                                   'Default: %(default)s.')
     train_params.add_argument('--min-num-epochs',
                               type=int,
                               default=None,

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -258,7 +258,7 @@ ARGS_MAY_DIFFER = ["overwrite_output", "use_tensorboard", "quiet",
                    "keep_last_params", "seed",
                    "max_updates", "min_updates",
                    "max_num_epochs", "min_num_epochs",
-                   "max_samples", "min_samples"]
+                   "max_samples", "min_samples", "max_num_checkpoint"]
 
 # Other argument constants
 TRAINING_ARG_SOURCE = "--source"

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -258,7 +258,7 @@ ARGS_MAY_DIFFER = ["overwrite_output", "use_tensorboard", "quiet",
                    "keep_last_params", "seed",
                    "max_updates", "min_updates",
                    "max_num_epochs", "min_num_epochs",
-                   "max_samples", "min_samples", "max_num_checkpoint"]
+                   "max_samples", "min_samples", "max_checkpoints"]
 
 # Other argument constants
 TRAINING_ARG_SOURCE = "--source"

--- a/sockeye/image_captioning/train.py
+++ b/sockeye/image_captioning/train.py
@@ -346,18 +346,17 @@ def train(args: argparse.Namespace):
         min_samples = args.min_samples
         max_samples = args.max_samples
         max_num_checkpoint_not_improved = args.max_num_checkpoint_not_improved
-        max_num_checkpoint = args.max_num_checkpoint
         min_epochs = args.min_num_epochs
         max_epochs = args.max_num_epochs
         if min_epochs is not None and max_epochs is not None:
             check_condition(min_epochs <= max_epochs,
                             "Minimum number of epochs must be smaller than maximum number of epochs")
+            
         # Fixed training schedule always runs for a set number of updates
         if args.learning_rate_schedule:
             min_updates = None
             max_updates = sum(num_updates for (_, num_updates) in args.learning_rate_schedule)
             max_num_checkpoint_not_improved = -1
-            max_num_checkpoint = None
             min_samples = None
             max_samples = None
             min_epochs = None
@@ -382,7 +381,7 @@ def train(args: argparse.Namespace):
                     metrics=args.metrics,
                     checkpoint_interval=args.checkpoint_interval,
                     max_num_not_improved=max_num_checkpoint_not_improved,
-                    max_num_checkpoint=max_num_checkpoint,
+                    max_checkpoints=args.max_checkpoints,
                     min_samples=min_samples,
                     max_samples=max_samples,
                     min_updates=min_updates,

--- a/sockeye/image_captioning/train.py
+++ b/sockeye/image_captioning/train.py
@@ -346,6 +346,7 @@ def train(args: argparse.Namespace):
         min_samples = args.min_samples
         max_samples = args.max_samples
         max_num_checkpoint_not_improved = args.max_num_checkpoint_not_improved
+        max_num_checkpoint = args.max_num_checkpoint
         min_epochs = args.min_num_epochs
         max_epochs = args.max_num_epochs
         if min_epochs is not None and max_epochs is not None:
@@ -356,6 +357,7 @@ def train(args: argparse.Namespace):
             min_updates = None
             max_updates = sum(num_updates for (_, num_updates) in args.learning_rate_schedule)
             max_num_checkpoint_not_improved = -1
+            max_num_checkpoint = None
             min_samples = None
             max_samples = None
             min_epochs = None
@@ -380,6 +382,7 @@ def train(args: argparse.Namespace):
                     metrics=args.metrics,
                     checkpoint_interval=args.checkpoint_interval,
                     max_num_not_improved=max_num_checkpoint_not_improved,
+                    max_num_checkpoint=max_num_checkpoint,
                     min_samples=min_samples,
                     max_samples=max_samples,
                     min_updates=min_updates,

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -892,18 +892,17 @@ def train(args: argparse.Namespace) -> training.TrainState:
         min_samples = args.min_samples
         max_samples = args.max_samples
         max_num_checkpoint_not_improved = args.max_num_checkpoint_not_improved
-        max_num_checkpoint = args.max_num_checkpoint
         min_epochs = args.min_num_epochs
         max_epochs = args.max_num_epochs
         if min_epochs is not None and max_epochs is not None:
             check_condition(min_epochs <= max_epochs,
                             "Minimum number of epochs must be smaller than maximum number of epochs")
+
         # Fixed training schedule always runs for a set number of updates
         if args.learning_rate_schedule:
             min_updates = None
             max_updates = sum(num_updates for (_, num_updates) in args.learning_rate_schedule)
             max_num_checkpoint_not_improved = -1
-            max_num_checkpoint = None
             min_samples = None
             max_samples = None
             min_epochs = None
@@ -923,7 +922,7 @@ def train(args: argparse.Namespace) -> training.TrainState:
                                      metrics=args.metrics,
                                      checkpoint_interval=args.checkpoint_interval,
                                      max_num_not_improved=max_num_checkpoint_not_improved,
-                                     max_num_checkpoint=max_num_checkpoint,
+                                     max_checkpoints=args.max_checkpoints,
                                      min_samples=min_samples,
                                      max_samples=max_samples,
                                      min_updates=min_updates,

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -892,6 +892,7 @@ def train(args: argparse.Namespace) -> training.TrainState:
         min_samples = args.min_samples
         max_samples = args.max_samples
         max_num_checkpoint_not_improved = args.max_num_checkpoint_not_improved
+        max_num_checkpoint = args.max_num_checkpoint
         min_epochs = args.min_num_epochs
         max_epochs = args.max_num_epochs
         if min_epochs is not None and max_epochs is not None:
@@ -902,6 +903,7 @@ def train(args: argparse.Namespace) -> training.TrainState:
             min_updates = None
             max_updates = sum(num_updates for (_, num_updates) in args.learning_rate_schedule)
             max_num_checkpoint_not_improved = -1
+            max_num_checkpoint = None
             min_samples = None
             max_samples = None
             min_epochs = None
@@ -921,6 +923,7 @@ def train(args: argparse.Namespace) -> training.TrainState:
                                      metrics=args.metrics,
                                      checkpoint_interval=args.checkpoint_interval,
                                      max_num_not_improved=max_num_checkpoint_not_improved,
+                                     max_num_checkpoint=max_num_checkpoint,
                                      min_samples=min_samples,
                                      max_samples=max_samples,
                                      min_updates=min_updates,

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -452,6 +452,7 @@ class EarlyStoppingTrainer:
             metrics: List[str],
             checkpoint_interval: int,
             max_num_not_improved: int,
+            max_num_checkpoint: int,
             min_samples: Optional[int] = None,
             max_samples: Optional[int] = None,
             min_updates: Optional[int] = None,
@@ -478,6 +479,8 @@ class EarlyStoppingTrainer:
 
         :param max_num_not_improved: Stop training if early_stopping_metric did not improve for this many checkpoints.
                Use -1 to disable stopping based on early_stopping_metric.
+        :param max_num_checkpoint: Stop training after this many checkpoints, if for no other reason.
+               Use None to disable.
         :param min_samples: Optional minimum number of samples.
         :param max_samples: Optional maximum number of samples.
         :param min_updates: Optional minimum number of update steps.
@@ -537,6 +540,10 @@ class EarlyStoppingTrainer:
         speedometer = Speedometer(frequency=C.MEASURE_SPEED_EVERY, auto_reset=False)
         tic = time.time()
 
+        max_checkpoint = None
+        if max_num_checkpoint is not None:
+            max_checkpoint = max_num_checkpoint + self.state.checkpoint
+
         next_data_batch = train_iter.next()
         while True:
 
@@ -550,6 +557,10 @@ class EarlyStoppingTrainer:
 
             if max_samples is not None and self.state.samples >= max_samples:
                 logger.info("Maximum # of samples (%s) reached", max_samples)
+                break
+
+            if max_checkpoint is not None and self.state.checkpoint >= max_checkpoint:
+                logger.info("Maximum # of checkpoints (%s) reached", max_num_checkpoint)
                 break
 
             ######

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -140,7 +140,7 @@ def test_model_parameters(test_params, expected_params):
               optimized_metric=C.PERPLEXITY,
               checkpoint_interval=4000,
               max_num_checkpoint_not_improved=32,
-              max_num_checkpoint=None,
+              max_checkpoints=None,
               embed_dropout=(.0, .0),
               transformer_dropout_attention=0.1,
               transformer_dropout_act=0.1,

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -140,6 +140,7 @@ def test_model_parameters(test_params, expected_params):
               optimized_metric=C.PERPLEXITY,
               checkpoint_interval=4000,
               max_num_checkpoint_not_improved=32,
+              max_num_checkpoint=None,
               embed_dropout=(.0, .0),
               transformer_dropout_attention=0.1,
               transformer_dropout_act=0.1,


### PR DESCRIPTION

This change add the ability to stop training after a given number of checkpoints.
Useful for situations where one is required to share scarce GPU resources.
Added a new command line argument '--max-num-checkpoint'

#### Pull Request Checklist ##
- [y] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [y] Unit tests pass (`pytest`)
- [n] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [y] System tests pass (`pytest test/system`)
- [y, as far as any files I touched] Passed code style checking (`./style-check.sh`)
- [y] You have considered writing a test
- [y] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [y] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

