### PR TITLE
Disabled dynamic batch sizing by default in Translator.translate due …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.85]
+### Changed
+- Disabled dynamic batching for `Translator.translate()` by default due to increased memory usage. The default is to
+  fill-up batches to `Translator.max_batch_size`.
+  Dynamic batching can still be enabled if `fill_up_batches` is set to False.
+
 ## [1.18.84]
 ### Fixed
 - Fixed lexical constraints bugs that broke batching and caused large drop in BLEU.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.84'
+__version__ = '1.18.85'

--- a/sockeye/image_captioning/inference.py
+++ b/sockeye/image_captioning/inference.py
@@ -105,7 +105,7 @@ class ImageCaptioner(Translator):
         :param trans_inputs: List of TranslatorInputs as returned by make_input().
         :return: List of translation results.
         """
-        batch_size = len(trans_inputs)
+        batch_size = self.max_batch_size
         # translate in batch-sized blocks over input chunks
         translations = []
         for batch_id, batch in enumerate(utils.grouper(trans_inputs, batch_size)):
@@ -113,7 +113,7 @@ class ImageCaptioner(Translator):
             # underfilled batch will be filled to a full batch size with copies of the 1st input
             rest = batch_size - len(batch)
             if rest > 0:
-                logger.debug("Extending the last batch to the full batch size (%d)", self.batch_size)
+                logger.debug("Extending the last batch to the full batch size (%d)", batch_size)
                 batch = batch + [batch[0]] * rest
             batch_translations = self._translate_nd(*self._get_inference_input(batch))
             # truncate to remove filler translations


### PR DESCRIPTION
…to increased memory usage

Dynamic batching as introduced in #641 can lead to increased memory usage as MXNet doesn't seem to share memory well in this case. Until this is resolved, we disable dynamic batching by default and use padding as before.
Dynamic batching can still be turned on if the flag `fill_up_batches` is set to False in the `Translator.translate()` method.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

