### PR TITLE
Data statistics at training time now compute mean and standard deviation of length ratios per bucket.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.87]
+### Added
+- Data statistics at training time now compute mean and standard deviation of length ratios per bucket.
+  This information is stored in the model's config, but not used at the moment.
+
 ## [1.18.86]
 ### Added
 - Added the `--fixed-param-strategy` option that allows fixing various model parameters during training via named strategies.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.86'
+__version__ = '1.18.87'

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -228,13 +228,7 @@ def calculate_length_statistics(source_iterables: Sequence[Iterable[Any]],
         length_ratio = target_len / source_len
         mean_and_variance.update(length_ratio)
 
-    num_sents = mean_and_variance.count
-    mean = mean_and_variance.mean
-    if not math.isnan(mean_and_variance.variance):
-        std = math.sqrt(mean_and_variance.variance)
-    else:
-        std = 0.0
-    return LengthStatistics(num_sents, mean, std)
+    return LengthStatistics(mean_and_variance.count, mean_and_variance.mean, mean_and_variance.std)
 
 
 def analyze_sequence_lengths(sources: List[str],
@@ -305,6 +299,7 @@ class DataStatisticsAccumulator:
         self.max_observed_len_source = 0
         self.max_observed_len_target = 0
         self._mean_len_target_per_bucket = [OnlineMeanAndVariance() for _ in range(num_buckets)]
+        self._length_ratio_per_bucket = [OnlineMeanAndVariance() for _ in range(num_buckets)]
 
     def sequence_pair(self,
                       source: List[int],
@@ -316,8 +311,10 @@ class DataStatisticsAccumulator:
 
         source_len = len(source)
         target_len = len(target)
+        length_ratio = target_len / (source_len if source_len else 1.)
 
         self._mean_len_target_per_bucket[bucket_idx].update(target_len)
+        self._length_ratio_per_bucket[bucket_idx].update(length_ratio)
 
         self.num_sents += 1
         self.num_tokens_source += source_len
@@ -333,6 +330,11 @@ class DataStatisticsAccumulator:
     def mean_len_target_per_bucket(self) -> List[Optional[float]]:
         return [mean_and_variance.mean if mean_and_variance.count > 0 else None
                 for mean_and_variance in self._mean_len_target_per_bucket]
+
+    @property
+    def length_ratio_stats_per_bucket(self) -> List[Tuple[Optional[float], Optional[float]]]:
+        return [(mean_and_variance.mean, mean_and_variance.std) if mean_and_variance.count > 0 else (None, None)
+                for mean_and_variance in self._length_ratio_per_bucket]
 
     @property
     def statistics(self):
@@ -351,7 +353,8 @@ class DataStatisticsAccumulator:
                               length_ratio_std=self.length_ratio_std,
                               buckets=self.buckets,
                               num_sents_per_bucket=num_sents_per_bucket,
-                              mean_len_target_per_bucket=self.mean_len_target_per_bucket)
+                              mean_len_target_per_bucket=self.mean_len_target_per_bucket,
+                              length_ratio_stats_per_bucket=self.length_ratio_stats_per_bucket)
 
 
 def shard_data(source_fnames: List[str],
@@ -973,7 +976,8 @@ class DataStatistics(config.Config):
                  length_ratio_std,
                  buckets: List[Tuple[int, int]],
                  num_sents_per_bucket: List[int],
-                 mean_len_target_per_bucket: List[Optional[float]]) -> None:
+                 mean_len_target_per_bucket: List[Optional[float]],
+                 length_ratio_stats_per_bucket: List[Tuple[Optional[float], Optional[float]]]) -> None:
         super().__init__()
         self.num_sents = num_sents
         self.num_discarded = num_discarded
@@ -987,6 +991,7 @@ class DataStatistics(config.Config):
         self.size_vocab_target = size_vocab_target
         self.length_ratio_mean = length_ratio_mean
         self.length_ratio_std = length_ratio_std
+        self.length_ratio_stats_per_bucket = length_ratio_stats_per_bucket
         self.buckets = buckets
         self.num_sents_per_bucket = num_sents_per_bucket
         self.average_len_target_per_bucket = mean_len_target_per_bucket
@@ -1010,14 +1015,18 @@ def describe_data_and_buckets(data_statistics: DataStatistics, bucket_batch_size
     check_condition(len(bucket_batch_sizes) == len(data_statistics.buckets),
                     "Number of bucket batch sizes (%d) does not match number of buckets in statistics (%d)."
                     % (len(bucket_batch_sizes), len(data_statistics.buckets)))
-    for bucket_batch_size, num_seq in zip(bucket_batch_sizes, data_statistics.num_sents_per_bucket):
+    for bucket_batch_size, num_seq, (lr_mean, lr_std) in zip(bucket_batch_sizes,
+                                                             data_statistics.num_sents_per_bucket,
+                                                             data_statistics.length_ratio_stats_per_bucket):
         if num_seq > 0:
-            logger.info("Bucket %s: %d samples in %d batches of %d, ~%.1f tokens/batch.",
+            logger.info("Bucket %s: %d samples in %d batches of %d, ~%.1f tokens/batch, "
+                        "trg/src length ratio: %.2f (+-%.2f)",
                         bucket_batch_size.bucket,
                         num_seq,
                         math.ceil(num_seq / bucket_batch_size.batch_size),
                         bucket_batch_size.batch_size,
-                        bucket_batch_size.average_words_per_batch)
+                        bucket_batch_size.average_words_per_batch,
+                        lr_mean, lr_std)
 
 
 class DataInfo(config.Config):

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -18,6 +18,7 @@ import binascii
 import errno
 import glob
 import gzip
+import math
 import itertools
 import logging
 import os
@@ -252,6 +253,11 @@ class OnlineMeanAndVariance:
             return float('nan')
         else:
             return self._M2 / self._count
+
+    @property
+    def std(self) -> float:
+        variance = self.variance
+        return math.sqrt(variance) if not math.isnan(variance) else 0.0
 
 
 def top1(scores: mx.nd.NDArray,


### PR DESCRIPTION
This information is stored in the model's config, but not used at the moment.
Example how this looks in a `model/config`:
```
length_ratio_mean: 0.9903531803518332
    length_ratio_stats_per_bucket:
    - !!python/tuple
      - 0.9939539246857091
      - 0.20038819302107716
    - !!python/tuple
      - 0.9973577501225213
      - 0.16934383816565493
    - !!python/tuple
      - 0.9903578426136428
      - 0.15920479304889934
    - !!python/tuple
      - 0.9831536409028283
      - 0.15727179777659359
    - !!python/tuple
      - 0.9774844872459133
      - 0.16751809994046238
    - !!python/tuple
      - 0.9754752513809977
      - 0.4807451024696842
    - !!python/tuple
      - 0.9714944941617623
      - 0.2888059310353186
    - !!python/tuple
      - 0.9931385915935655
      - 0.27796734059145933
    - !!python/tuple
      - 0.973863585804995
      - 0.24824717971512
    - !!python/tuple
      - 1.0526102581390215
      - 0.3940537680249827
    length_ratio_std: 0.18062165217641143
```

These statistics are now also logged when creating the training iterators:
```
[INFO:sockeye.data_io] Bucket (10, 10): 21058 samples in 165 batches of 128, ~876.0 tokens/batch, trg/src length ratio: 0.99 (+-0.20)
[INFO:sockeye.data_io] Bucket (20, 20): 61403 samples in 480 batches of 128, ~1907.5 tokens/batch, trg/src length ratio: 1.00 (+-0.17)
[INFO:sockeye.data_io] Bucket (30, 30): 63915 samples in 500 batches of 128, ~3022.4 tokens/batch, trg/src length ratio: 0.99 (+-0.16)
[INFO:sockeye.data_io] Bucket (40, 40): 34918 samples in 273 batches of 128, ~4165.1 tokens/batch, trg/src length ratio: 0.98 (+-0.16)
[INFO:sockeye.data_io] Bucket (50, 50): 13815 samples in 108 batches of 128, ~5319.3 tokens/batch, trg/src length ratio: 0.98 (+-0.17)
[INFO:sockeye.data_io] Bucket (60, 60): 4026 samples in 32 batches of 128, ~6411.6 tokens/batch, trg/src length ratio: 0.98 (+-0.48)
[INFO:sockeye.data_io] Bucket (70, 70): 1045 samples in 9 batches of 128, ~7531.7 tokens/batch, trg/src length ratio: 0.97 (+-0.29)
[INFO:sockeye.data_io] Bucket (80, 80): 322 samples in 3 batches of 128, ~8634.0 tokens/batch, trg/src length ratio: 0.99 (+-0.28)
[INFO:sockeye.data_io] Bucket (90, 90): 141 samples in 2 batches of 128, ~9877.8 tokens/batch, trg/src length ratio: 0.97 (+-0.25)
[INFO:sockeye.data_io] Bucket (100, 100): 64 samples in 1 batches of 128, ~10984.0 tokens/batch, trg/src length ratio: 1.05 (+-0.39)
```
FYI @artemsok 

This could potentially be used to compute more fine-grained max output lengths at inference time, addressing the issue that length ratios are significantly different for short and long sequence pairs.
The open question for this is how to make use of training-time bucket information in inference, when ensembles are used. We currently do not use training-time bucket information at all and it may differ for multiple models when used in ensembling.
Another issue might be how to maintain backwards compatibility.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

