### PR TITLE
[WIP] No dependency on sequence length as int

### DIFF
--- a/sockeye/convolution.py
+++ b/sockeye/convolution.py
@@ -88,14 +88,12 @@ class ConvolutionBlock:
 
     def __call__(self,
                  data: mx.sym.Symbol,
-                 data_length: mx.sym.Symbol,
-                 seq_len: int) -> mx.sym.Symbol:
+                 data_length: mx.sym.Symbol) -> mx.sym.Symbol:
         """
         Run the convolutional block.
 
         :param data: Input data. Shape: (batch_size, seq_len, num_hidden).
         :param data_length: Vector with sequence lengths. Shape: (batch_size,).
-        :param seq_len: Maximum sequence length.
         :return: Shape: (batch_size, seq_len, num_hidden).
         """
         if self.pad_type == C.CNN_PAD_LEFT:
@@ -126,11 +124,11 @@ class ConvolutionBlock:
 
         # (batch_size, 2 * num_hidden, seq_len)
         if self.pad_type == C.CNN_PAD_LEFT:
-            data_conv = mx.sym.slice_axis(data=data_conv, axis=2, begin=0, end=seq_len)
+            data_conv = mx.sym.slice_like(data_conv, data, axes=(0, 0, -1))
 
         return self._post_convolution(data_conv)
 
-    def step(self, data):
+    def step(self, data: mx.sym.Symbol) -> mx.sym.Symbol:
         """
         Run convolution over a single position. The data must be exactly as wide as the convolution filters.
 
@@ -158,7 +156,7 @@ class ConvolutionBlock:
         data_conv = mx.sym.expand_dims(data_conv, axis=2)
         return self._post_convolution(data_conv)
 
-    def _post_convolution(self, data_conv):
+    def _post_convolution(self, data_conv: mx.sym.Symbol) -> mx.sym.Symbol:
         # data_conv: (batch_size, pre_activation_num_hidden, seq_len)
         # TODO: add layer norm (can we do this without reshaping?!)
 

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -1086,7 +1086,7 @@ class ConvolutionalDecoder(Decoder):
         for layer, att_layer in zip(self.layers, self.attention_layers):
             # (batch_size, target_seq_len, num_hidden)
             target_hidden = layer(mx.sym.Dropout(target_hidden, p=drop_prob) if drop_prob > 0 else target_hidden,
-                                  target_embed_lengths, target_embed_max_length)
+                                  target_embed_lengths)
 
             # (batch_size, target_seq_len, num_embed)
             context = att_layer(target_hidden, source_encoded, source_encoded_lengths)

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -251,11 +251,11 @@ class TransformerDecoder(Decoder):
         """
 
         # (batch_size * heads, max_length)
-        source_bias = transformer.get_variable_length_bias(lengths=source_encoded_lengths,
-                                                           max_length=source_encoded_max_length,
-                                                           num_heads=self.config.attention_heads,
-                                                           fold_heads=True,
-                                                           name="%ssource_bias" % self.prefix)
+        source_bias = transformer.get_valid_length_mask_for(data=source_encoded,
+                                                            lengths=source_encoded_lengths,
+                                                            num_heads=self.config.attention_heads,
+                                                            fold_heads=True,
+                                                            name="%ssource_bias" % self.prefix)
         # (batch_size * heads, 1, max_length)
         source_bias = mx.sym.expand_dims(source_bias, axis=1)
 
@@ -305,11 +305,11 @@ class TransformerDecoder(Decoder):
         target = mx.sym.expand_dims(target_embed_prev, axis=1)
 
         # (batch_size * heads, max_length)
-        source_bias = transformer.get_variable_length_bias(lengths=source_encoded_lengths,
-                                                           max_length=source_encoded_max_length,
-                                                           num_heads=self.config.attention_heads,
-                                                           fold_heads=True,
-                                                           name="%ssource_bias" % self.prefix)
+        source_bias = transformer.get_valid_length_mask_for(data=source_encoded,
+                                                            lengths=source_encoded_lengths,
+                                                            num_heads=self.config.attention_heads,
+                                                            fold_heads=True,
+                                                            name="%ssource_bias" % self.prefix)
         # (batch_size * heads, 1, max_length)
         source_bias = mx.sym.expand_dims(source_bias, axis=1)
 

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -1009,7 +1009,7 @@ class ConvolutionalEncoder(Encoder):
 
         # Multiple layers with residual connections:
         for layer in self.layers:
-            data = data + layer(data, data_length, seq_len)
+            data = data + layer(data, data_length)
         return data, data_length, seq_len
 
     def get_num_hidden(self) -> int:

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -1055,12 +1055,12 @@ class TransformerEncoder(Encoder):
         if self.config.dropout_prepost > 0.0:
             data = mx.sym.Dropout(data=data, p=self.config.dropout_prepost)
 
-        # (batch_size * heads, 1, max_length)
-        bias = mx.sym.expand_dims(transformer.get_variable_length_bias(lengths=data_length,
-                                                                       max_length=seq_len,
-                                                                       num_heads=self.config.attention_heads,
-                                                                       fold_heads=True,
-                                                                       name="%sbias" % self.prefix), axis=1)
+        # (batch_size * heads, 1, seq_len)
+        bias = mx.sym.expand_dims(transformer.get_valid_length_mask_for(data,
+                                                                        data_length,
+                                                                        num_heads=self.config.attention_heads,
+                                                                        fold_heads=True,
+                                                                        name="%sbias" % self.prefix), axis=1)
         bias = utils.cast_conditionally(bias, self.dtype)
         for i, layer in enumerate(self.layers):
             # (batch_size, seq_len, config.model_size)

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -300,7 +300,7 @@ def get_valid_length_mask_for(data: mx.sym.Symbol,
     # (batch, 1)
     zeros = mx.sym.reshape(mx.sym.zeros_like(lengths), shape=(-1, 1))
     # (batch, seq_len)
-    zeros = mx.sym.broadcast_like(zeros, mx.sym.BlockGrad(data), lhs_axes=(1,), rhs_axes=(1,))
+    zeros = mx.sym.broadcast_like(zeros, data, lhs_axes=(1,), rhs_axes=(1,))
     # (batch_size, max_length)
     x = mx.sym.SequenceMask(data=zeros,
                             use_sequence_length=True,

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -282,75 +282,32 @@ class TransformerFeedForward:
         return y
 
 
-class VariableLengthBias(mx.operator.CustomOp):
-    """
-    Returns bias/mask given a vector of sequence lengths.
-    """
-
-    def __init__(self, max_length: int) -> None:
-        super().__init__()
-        self.max_length = max_length
-
-    def forward(self, is_train, req, in_data, out_data, aux):
-        # lengths: (batch_size,)
-        lengths = in_data[0]
-        dtype = lengths.dtype
-        dtype_str = np.dtype(dtype).name
-
-        # (batch_size, max_length)
-        data = mx.nd.zeros((lengths.shape[0], self.max_length), dtype=dtype, ctx=lengths.context)
-        data = mx.nd.SequenceMask(data=data,
-                                  use_sequence_length=True,
-                                  sequence_length=lengths,
-                                  axis=1,
-                                  value=-C.LARGE_VALUES[dtype_str])
-        self.assign(out_data[0], req[0], data)
-
-    def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
-        pass
-
-
-@mx.operator.register("variable_length_bias")
-class VariableLengthBiasProp(mx.operator.CustomOpProp):
-
-    def __init__(self, max_length: str) -> None:
-        super().__init__()
-        self.max_length = int(max_length)
-
-    def list_arguments(self):
-        return ['data']
-
-    def list_outputs(self):
-        return ['output']
-
-    def infer_shape(self, in_shape):
-        batch_size = in_shape[0][0]
-        return in_shape, [(batch_size, self.max_length)], []
-
-    def infer_type(self, in_type):
-        return in_type, in_type, []
-
-    def create_operator(self, ctx, shapes, dtypes):
-        return VariableLengthBias(max_length=self.max_length)
-
-
-def get_variable_length_bias(lengths: mx.sym.Symbol,
-                             max_length: int,
-                             num_heads: Optional[int] = None,
-                             fold_heads: bool = True,
-                             name: str = '') -> mx.sym.Symbol:
+def get_valid_length_mask_for(data: mx.sym.Symbol,
+                              lengths: mx.sym.Symbol,
+                              num_heads: Optional[int] = None,
+                              fold_heads: bool = True,
+                              name: str = '') -> mx.sym.Symbol:
     """
     Returns bias/mask for variable sequence lengths.
 
+    :param data: Input data to mask. Shape: (batch, seq_len, _).
     :param lengths: Sequence lengths. Shape: (batch,).
-    :param max_length: Maximum sequence length.
     :param num_heads: Number of attention heads.
     :param fold_heads: Whether to fold heads dimension into batch dimension.
     :param name: Name of symbol.
-    :return: Bias symbol.
+    :return: Bias symbol. Shape: (batch, seq_len)
     """
+    # (batch, 1)
+    zeros = mx.sym.reshape(mx.sym.zeros_like(lengths), shape=(-1, 1))
+    # (batch, seq_len)
+    zeros = mx.sym.broadcast_like(zeros, mx.sym.BlockGrad(data), lhs_axes=(1,), rhs_axes=(1,))
     # (batch_size, max_length)
-    x = mx.symbol.Custom(data=lengths, max_length=max_length, op_type='variable_length_bias')
+    x = mx.sym.SequenceMask(data=zeros,
+                            use_sequence_length=True,
+                            sequence_length=lengths,
+                            axis=1,
+                            value=C.LARGE_NEGATIVE_VALUE)
+
     if num_heads is not None:
         # (batch_size, heads, max_length) if fold_heads == False else (batch_size * heads, max_length)
         x = layers.broadcast_to_heads(x, num_heads, ndim=2, fold_heads=fold_heads)


### PR DESCRIPTION
Our APIs currently require knowing the size of the sequence dimension as an integer. This is preventing us to convert our layer implementations to Gluon blocks eventually: HybridBlocks do not take integer arguments.

This is a first step to get rid of this dependency by removing the dependency on `seq_len` for RNNEncoder and CNNEncoders. 

This PR is on top of the MXNet 1.4 change for now.

#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

