### PR TITLE
Bump prepared data version

### DIFF
--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -434,7 +434,7 @@ SHARD_TARGET = SHARD_NAME + ".target"
 DATA_INFO = "data.info"
 DATA_CONFIG = "data.config"
 PREPARED_DATA_VERSION_FILE = "data.version"
-PREPARED_DATA_VERSION = 2
+PREPARED_DATA_VERSION = 3
 
 # reranking
 RERANK_BLEU = "bleu"


### PR DESCRIPTION
#665 changed the format of the DataStatistics object and existing prepared data folders are not compatible. This PR bumps the data version to make this incompatibility clear.

#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

