### PR TITLE
Decrease dependency on sequence length integers

### DIFF
--- a/sockeye/convolution.py
+++ b/sockeye/convolution.py
@@ -88,14 +88,12 @@ class ConvolutionBlock:
 
     def __call__(self,
                  data: mx.sym.Symbol,
-                 data_length: mx.sym.Symbol,
-                 seq_len: int) -> mx.sym.Symbol:
+                 data_length: mx.sym.Symbol) -> mx.sym.Symbol:
         """
         Run the convolutional block.
 
         :param data: Input data. Shape: (batch_size, seq_len, num_hidden).
         :param data_length: Vector with sequence lengths. Shape: (batch_size,).
-        :param seq_len: Maximum sequence length.
         :return: Shape: (batch_size, seq_len, num_hidden).
         """
         if self.pad_type == C.CNN_PAD_LEFT:
@@ -126,11 +124,11 @@ class ConvolutionBlock:
 
         # (batch_size, 2 * num_hidden, seq_len)
         if self.pad_type == C.CNN_PAD_LEFT:
-            data_conv = mx.sym.slice_axis(data=data_conv, axis=2, begin=0, end=seq_len)
+            data_conv = mx.sym.slice_like(data_conv, data, axes=(0, 0, -1))
 
         return self._post_convolution(data_conv)
 
-    def step(self, data):
+    def step(self, data: mx.sym.Symbol) -> mx.sym.Symbol:
         """
         Run convolution over a single position. The data must be exactly as wide as the convolution filters.
 
@@ -158,7 +156,7 @@ class ConvolutionBlock:
         data_conv = mx.sym.expand_dims(data_conv, axis=2)
         return self._post_convolution(data_conv)
 
-    def _post_convolution(self, data_conv):
+    def _post_convolution(self, data_conv: mx.sym.Symbol) -> mx.sym.Symbol:
         # data_conv: (batch_size, pre_activation_num_hidden, seq_len)
         # TODO: add layer norm (can we do this without reshaping?!)
 

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -1086,7 +1086,7 @@ class ConvolutionalDecoder(Decoder):
         for layer, att_layer in zip(self.layers, self.attention_layers):
             # (batch_size, target_seq_len, num_hidden)
             target_hidden = layer(mx.sym.Dropout(target_hidden, p=drop_prob) if drop_prob > 0 else target_hidden,
-                                  target_embed_lengths, target_embed_max_length)
+                                  target_embed_lengths)
 
             # (batch_size, target_seq_len, num_embed)
             context = att_layer(target_hidden, source_encoded, source_encoded_lengths)

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -288,6 +288,7 @@ def get_valid_length_mask_for(data: mx.sym.Symbol,
                               name: str = '') -> mx.sym.Symbol:
     """
     Returns bias/mask for variable sequence lengths.
+
     :param data: Input data to mask. Shape: (batch, seq_len, _).
     :param lengths: Sequence lengths. Shape: (batch,).
     :param num_heads: Number of attention heads.


### PR DESCRIPTION
requires mxnet==1.4 because of advanced usage of `broadcast_like`.

Gives a slight speedup due to removal of CustomOp.

#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

