### PR TITLE
Convert all transformer-relevant layers to Gluon HybridBlocks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.98]
+### Changed
+- Converted several transformer-related layer implementations to Gluon HybridBlocks. No functional change.
+
 ## [1.18.97]
 ### Changed
 - Updated to PyYAML 5.1

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.97'
+__version__ = '1.18.98'

--- a/sockeye/convolution.py
+++ b/sockeye/convolution.py
@@ -88,14 +88,12 @@ class ConvolutionBlock:
 
     def __call__(self,
                  data: mx.sym.Symbol,
-                 data_length: mx.sym.Symbol,
-                 seq_len: int) -> mx.sym.Symbol:
+                 data_length: mx.sym.Symbol) -> mx.sym.Symbol:
         """
         Run the convolutional block.
 
         :param data: Input data. Shape: (batch_size, seq_len, num_hidden).
         :param data_length: Vector with sequence lengths. Shape: (batch_size,).
-        :param seq_len: Maximum sequence length.
         :return: Shape: (batch_size, seq_len, num_hidden).
         """
         if self.pad_type == C.CNN_PAD_LEFT:
@@ -126,11 +124,11 @@ class ConvolutionBlock:
 
         # (batch_size, 2 * num_hidden, seq_len)
         if self.pad_type == C.CNN_PAD_LEFT:
-            data_conv = mx.sym.slice_axis(data=data_conv, axis=2, begin=0, end=seq_len)
+            data_conv = mx.sym.slice_like(data_conv, data, axes=(0, 0, -1))
 
         return self._post_convolution(data_conv)
 
-    def step(self, data):
+    def step(self, data: mx.sym.Symbol) -> mx.sym.Symbol:
         """
         Run convolution over a single position. The data must be exactly as wide as the convolution filters.
 
@@ -158,7 +156,7 @@ class ConvolutionBlock:
         data_conv = mx.sym.expand_dims(data_conv, axis=2)
         return self._post_convolution(data_conv)
 
-    def _post_convolution(self, data_conv):
+    def _post_convolution(self, data_conv: mx.sym.Symbol) -> mx.sym.Symbol:
         # data_conv: (batch_size, pre_activation_num_hidden, seq_len)
         # TODO: add layer norm (can we do this without reshaping?!)
 

--- a/sockeye/coverage.py
+++ b/sockeye/coverage.py
@@ -358,7 +358,7 @@ class ActivationCoverage(Coverage):
             updated_coverage = intermediate + attention_hidden + coverage_hidden
 
             if self.layer_norm is not None:
-                updated_coverage = self.layer_norm(data=updated_coverage)
+                updated_coverage = self.layer_norm(updated_coverage)
 
             # (batch_size, seq_len, coverage_num_hidden)
             coverage = mx.sym.Activation(data=updated_coverage,

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -1086,7 +1086,7 @@ class ConvolutionalDecoder(Decoder):
         for layer, att_layer in zip(self.layers, self.attention_layers):
             # (batch_size, target_seq_len, num_hidden)
             target_hidden = layer(mx.sym.Dropout(target_hidden, p=drop_prob) if drop_prob > 0 else target_hidden,
-                                  target_embed_lengths, target_embed_max_length)
+                                  target_embed_lengths)
 
             # (batch_size, target_seq_len, num_embed)
             context = att_layer(target_hidden, source_encoded, source_encoded_lengths)

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -255,7 +255,7 @@ class TransformerDecoder(Decoder):
         """
 
         # (batch_size * heads, max_length)
-        source_bias = self.valid_length_mask(source_encoded,source_encoded_lengths)
+        source_bias = self.valid_length_mask(source_encoded, source_encoded_lengths)
 
         # (batch_size * heads, 1, max_length)
         source_bias = mx.sym.expand_dims(source_bias, axis=1)

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -1062,7 +1062,7 @@ class TransformerEncoder(Encoder):
         for i, layer in enumerate(self.layers):
             # (batch_size, seq_len, config.model_size)
             data = layer(data, bias)
-        data = self.final_process(data=data, prev=None)
+        data = self.final_process(data, None)
         data = utils.uncast_conditionally(data, self.dtype)
         return data, data_length, seq_len
 

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -1046,7 +1046,6 @@ class TransformerEncoder(Encoder, mx.gluon.HybridBlock):
         return self._encode(F, data, data_length)
 
     def _encode(self, F, data: mx.sym.Symbol, data_length: mx.sym.Symbol) -> mx.sym.Symbol:
-
         data = utils.cast_conditionally(F, data, self.dtype)
         if self.config.dropout_prepost > 0.0:
             data = F.Dropout(data=data, p=self.config.dropout_prepost)

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -288,6 +288,7 @@ def get_valid_length_mask_for(data: mx.sym.Symbol,
                               name: str = '') -> mx.sym.Symbol:
     """
     Returns bias/mask for variable sequence lengths.
+
     :param data: Input data to mask. Shape: (batch, seq_len, _).
     :param lengths: Sequence lengths. Shape: (batch,).
     :param num_heads: Number of attention heads.

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -61,7 +61,7 @@ class TransformerConfig(config.Config):
         self.dtype = dtype
 
 
-class TransformerEncoderBlock:
+class TransformerEncoderBlock(mx.gluon.HybridBlock):
     """
     A transformer encoder block consists self-attention and a feed-forward layer with pre/post process blocks
     in between.
@@ -70,51 +70,52 @@ class TransformerEncoderBlock:
     def __init__(self,
                  config: TransformerConfig,
                  prefix: str) -> None:
-        self.pre_self_attention = TransformerProcessBlock(sequence=config.preprocess_sequence,
-                                                          dropout=config.dropout_prepost,
-                                                          prefix="%satt_self_pre_" % prefix)
-        self.self_attention = layers.MultiHeadSelfAttention(depth_att=config.model_size,
-                                                            heads=config.attention_heads,
-                                                            depth_out=config.model_size,
-                                                            dropout=config.dropout_attention,
-                                                            prefix="%satt_self_" % prefix)
-        self.post_self_attention = TransformerProcessBlock(sequence=config.postprocess_sequence,
-                                                           dropout=config.dropout_prepost,
-                                                           prefix="%satt_self_post_" % prefix)
+        super().__init__(prefix=prefix)
 
-        self.pre_ff = TransformerProcessBlock(sequence=config.preprocess_sequence,
-                                              dropout=config.dropout_prepost,
-                                              prefix="%sff_pre_" % prefix)
-        self.ff = TransformerFeedForward(num_hidden=config.feed_forward_num_hidden,
-                                         num_model=config.model_size,
-                                         act_type=config.act_type,
-                                         dropout=config.dropout_act,
-                                         prefix="%sff_" % prefix)
-        self.post_ff = TransformerProcessBlock(sequence=config.postprocess_sequence,
-                                               dropout=config.dropout_prepost,
-                                               prefix="%sff_post_" % prefix)
-        self.lhuc = None
-        if config.use_lhuc:
-            self.lhuc = layers.LHUC(config.model_size, prefix=prefix)
+        with self.name_scope():
+            self.pre_self_attention = TransformerProcessBlock(sequence=config.preprocess_sequence,
+                                                              dropout=config.dropout_prepost,
+                                                              prefix="att_self_pre_")
+            self.self_attention = layers.MultiHeadSelfAttention(depth_att=config.model_size,
+                                                                heads=config.attention_heads,
+                                                                depth_out=config.model_size,
+                                                                dropout=config.dropout_attention,
+                                                                prefix="att_self_")
+            self.post_self_attention = TransformerProcessBlock(sequence=config.postprocess_sequence,
+                                                               dropout=config.dropout_prepost,
+                                                               prefix="att_self_post_")
 
-    def __call__(self, data: mx.sym.Symbol, bias: mx.sym.Symbol) -> mx.sym.Symbol:
+            self.pre_ff = TransformerProcessBlock(sequence=config.preprocess_sequence,
+                                                  dropout=config.dropout_prepost,
+                                                  prefix="ff_pre_")
+            self.ff = TransformerFeedForward(num_hidden=config.feed_forward_num_hidden,
+                                             num_model=config.model_size,
+                                             act_type=config.act_type,
+                                             dropout=config.dropout_act,
+                                             prefix="ff_")
+            self.post_ff = TransformerProcessBlock(sequence=config.postprocess_sequence,
+                                                   dropout=config.dropout_prepost,
+                                                   prefix="ff_post_")
+            self.lhuc = None
+            if config.use_lhuc:
+                self.lhuc = layers.LHUC(config.model_size)
+
+    def hybrid_forward(self, F, data: mx.sym.Symbol, bias: mx.sym.Symbol) -> mx.sym.Symbol:
         # self-attention
-        data_self_att = self.self_attention(inputs=self.pre_self_attention(data, None),
-                                            bias=bias,
-                                            cache=None)
+        data_self_att = self.self_attention(self.pre_self_attention(data, None), None, bias, None)
         data = self.post_self_attention(data_self_att, data)
 
         # feed-forward
         data_ff = self.ff(self.pre_ff(data, None))
         data = self.post_ff(data_ff, data)
 
-        if self.lhuc:
+        if self.lhuc is not None:
             data = self.lhuc(data)
 
         return data
 
 
-class TransformerDecoderBlock:
+class TransformerDecoderBlock(mx.gluon.HybridBlock):
     """
     A transformer encoder block consists self-attention, encoder attention, and a feed-forward layer
     with pre/post process blocks in between.
@@ -123,63 +124,60 @@ class TransformerDecoderBlock:
     def __init__(self,
                  config: TransformerConfig,
                  prefix: str) -> None:
-        self.prefix = prefix
-        self.pre_self_attention = TransformerProcessBlock(sequence=config.preprocess_sequence,
-                                                          dropout=config.dropout_prepost,
-                                                          prefix="%satt_self_pre_" % prefix)
-        self.self_attention = layers.MultiHeadSelfAttention(depth_att=config.model_size,
-                                                            heads=config.attention_heads,
-                                                            depth_out=config.model_size,
-                                                            dropout=config.dropout_attention,
-                                                            prefix="%satt_self_" % prefix)
-        self.post_self_attention = TransformerProcessBlock(sequence=config.postprocess_sequence,
-                                                           dropout=config.dropout_prepost,
-                                                           prefix="%satt_self_post_" % prefix)
+        super().__init__(prefix=prefix)
+        with self.name_scope():
+            self.pre_self_attention = TransformerProcessBlock(sequence=config.preprocess_sequence,
+                                                              dropout=config.dropout_prepost,
+                                                              prefix="att_self_pre_")
+            self.self_attention = layers.MultiHeadSelfAttention(depth_att=config.model_size,
+                                                                heads=config.attention_heads,
+                                                                depth_out=config.model_size,
+                                                                dropout=config.dropout_attention,
+                                                                prefix="att_self_")
+            self.post_self_attention = TransformerProcessBlock(sequence=config.postprocess_sequence,
+                                                               dropout=config.dropout_prepost,
+                                                               prefix="att_self_post_")
 
-        self.pre_enc_attention = TransformerProcessBlock(sequence=config.preprocess_sequence,
-                                                         dropout=config.dropout_prepost,
-                                                         prefix="%satt_enc_pre_" % prefix)
-        self.enc_attention = layers.MultiHeadAttention(depth_att=config.model_size,
-                                                       heads=config.attention_heads,
-                                                       depth_out=config.model_size,
-                                                       dropout=config.dropout_attention,
-                                                       prefix="%satt_enc_" % prefix)
-        self.post_enc_attention = TransformerProcessBlock(sequence=config.postprocess_sequence,
-                                                          dropout=config.dropout_prepost,
-                                                          prefix="%satt_enc_post_" % prefix)
+            self.pre_enc_attention = TransformerProcessBlock(sequence=config.preprocess_sequence,
+                                                             dropout=config.dropout_prepost,
+                                                             prefix="att_enc_pre_")
+            self.enc_attention = layers.MultiHeadAttention(depth_att=config.model_size,
+                                                           heads=config.attention_heads,
+                                                           depth_out=config.model_size,
+                                                           dropout=config.dropout_attention,
+                                                           prefix="att_enc_")
+            self.post_enc_attention = TransformerProcessBlock(sequence=config.postprocess_sequence,
+                                                              dropout=config.dropout_prepost,
+                                                              prefix="att_enc_post_")
 
-        self.pre_ff = TransformerProcessBlock(sequence=config.preprocess_sequence,
-                                              dropout=config.dropout_prepost,
-                                              prefix="%sff_pre_" % prefix)
-        self.ff = TransformerFeedForward(num_hidden=config.feed_forward_num_hidden,
-                                         num_model=config.model_size,
-                                         act_type=config.act_type,
-                                         dropout=config.dropout_act,
-                                         prefix="%sff_" % prefix)
-        self.post_ff = TransformerProcessBlock(sequence=config.postprocess_sequence,
-                                               dropout=config.dropout_prepost,
-                                               prefix="%sff_post_" % prefix)
+            self.pre_ff = TransformerProcessBlock(sequence=config.preprocess_sequence,
+                                                  dropout=config.dropout_prepost,
+                                                  prefix="ff_pre_")
+            self.ff = TransformerFeedForward(num_hidden=config.feed_forward_num_hidden,
+                                             num_model=config.model_size,
+                                             act_type=config.act_type,
+                                             dropout=config.dropout_act,
+                                             prefix="ff_")
+            self.post_ff = TransformerProcessBlock(sequence=config.postprocess_sequence,
+                                                   dropout=config.dropout_prepost,
+                                                   prefix="ff_post_")
 
-        self.lhuc = None
-        if config.use_lhuc:
-            self.lhuc = layers.LHUC(config.model_size, prefix=prefix)
+            self.lhuc = None
+            if config.use_lhuc:
+                self.lhuc = layers.LHUC(config.model_size)
 
-    def __call__(self,
-                 target: mx.sym.Symbol,
-                 target_bias: mx.sym.Symbol,
-                 source: mx.sym.Symbol,
-                 source_bias: mx.sym.Symbol,
-                 cache: Optional[Dict[str, Optional[mx.sym.Symbol]]] = None) -> mx.sym.Symbol:
+    def hybrid_forward(self, F,
+                       target: mx.sym.Symbol,
+                       target_bias: mx.sym.Symbol,
+                       source: mx.sym.Symbol,
+                       source_bias: mx.sym.Symbol,
+                       cache: Optional[Dict[str, Optional[mx.sym.Symbol]]] = None) -> mx.sym.Symbol:
         # self-attention
-        target_self_att = self.self_attention(inputs=self.pre_self_attention(target, None),
-                                              bias=target_bias,
-                                              cache=cache)
+        target_self_att = self.self_attention(self.pre_self_attention(target, None), None, target_bias, cache)
         target = self.post_self_attention(target_self_att, target)
 
         # encoder attention
-        target_enc_att = self.enc_attention(queries=self.pre_enc_attention(target, None),
-                                            memory=source,
-                                            bias=source_bias)
+        target_enc_att = self.enc_attention(self.pre_enc_attention(target, None), source, None, source_bias)
         target = self.post_enc_attention(target_enc_att, target)
 
         # feed-forward
@@ -192,7 +190,7 @@ class TransformerDecoderBlock:
         return target
 
 
-class TransformerProcessBlock:
+class TransformerProcessBlock(mx.gluon.nn.HybridBlock):
     """
     Block to perform pre/post processing on layer inputs.
     The processing steps are determined by the sequence argument, which can contain one of the three operations:
@@ -205,16 +203,13 @@ class TransformerProcessBlock:
                  sequence: str,
                  dropout: float,
                  prefix: str) -> None:
+        super().__init__(prefix=prefix)
         self.sequence = sequence
         self.dropout = dropout
-        self.prefix = prefix
-        self.layer_norm = None
-        if "n" in sequence:
-            self.layer_norm = layers.LayerNormalization(prefix="%snorm" % self.prefix)
+        with self.name_scope():
+            self.layer_norm = layers.LayerNormalization(prefix="norm") if 'n' in sequence else None
 
-    def __call__(self,
-                 data: mx.sym.Symbol,
-                 prev: Optional[mx.sym.Symbol]) -> mx.sym.Symbol:
+    def hybrid_forward(self, F, data: mx.sym.Symbol, prev: Optional[mx.sym.Symbol]) -> mx.sym.Symbol:
         """
         Apply processing sequence to data with optional previous input.
 
@@ -231,23 +226,23 @@ class TransformerProcessBlock:
         for step in self.sequence:
 
             if step == "r":
-                data = mx.sym._internal._plus(data, prev, name="%sresidual" % self.prefix)
+                data = F._internal._plus(data, prev)
 
             elif step == "n":
-                data = self.layer_norm(data=data)
+                data = self.layer_norm(data)
 
             elif step == "d":
                 if self.dropout > 0.0:
-                    data = mx.sym.Dropout(data, p=self.dropout, name="%sdropout" % self.prefix)
+                    data = F.Dropout(data, p=self.dropout)
             else:
                 raise ValueError("Unknown step in sequence: %s" % step)
 
         return data
 
 
-class TransformerFeedForward:
+class TransformerFeedForward(mx.gluon.HybridBlock):
     """
-    Position-wise feed-forward network with activation.
+    Position-wise feed-forward block with activation.
     """
 
     def __init__(self,
@@ -256,28 +251,19 @@ class TransformerFeedForward:
                  act_type: str,
                  dropout: float,
                  prefix: str) -> None:
-        self.num_hidden = num_hidden
-        self.num_model = num_model
+        super().__init__(prefix=prefix)
         self.dropout = dropout
-        self.prefix = prefix
-        self.act_type = act_type
-        self.w_i2h = mx.sym.Variable('%si2h_weight' % prefix)
-        self.b_i2h = mx.sym.Variable('%si2h_bias' % prefix)
-        self.w_h2o = mx.sym.Variable('%sh2o_weight' % prefix)
-        self.b_h2o = mx.sym.Variable('%sh2o_bias' % prefix)
+        with self.name_scope():
+            self.ff1 = mx.gluon.nn.Dense(units=num_hidden, flatten=False, prefix='i2h_')
+            self.act = layers.get_activation(act_type)
+            self.ff2 = mx.gluon.nn.Dense(units=num_model, flatten=False, prefix='h2o_')
 
-    def __call__(self, x) -> mx.sym.Symbol:
-        """
-        Position-wise feed-forward network with activation.
-
-        :param x: Symbol of shape (batch_size, seq_len, num_hidden)
-        :return: Symbol of shape (batch_size, seq_len, num_hidden)
-        """
-        h = mx.sym.FullyConnected(data=x, num_hidden=self.num_hidden, weight=self.w_i2h, bias=self.b_i2h, flatten=False)
-        h = layers.activation(h, act_type=self.act_type)
+    def hybrid_forward(self, F, x):
+        h = self.ff1(x)
+        h = self.act(h)
         if self.dropout > 0.0:
-            h = mx.sym.Dropout(h, p=self.dropout)
-        y = mx.sym.FullyConnected(data=h, num_hidden=self.num_model, weight=self.w_h2o, bias=self.b_h2o, flatten=False)
+            h = F.Dropout(h, p=self.dropout)
+        y = self.ff2(h)
         return y
 
 
@@ -316,7 +302,7 @@ def get_valid_length_mask_for(data: mx.sym.Symbol,
 
     if num_heads is not None:
         # (batch_size, heads, max_length) if fold_heads == False else (batch_size * heads, max_length)
-        x = layers.broadcast_to_heads(x, num_heads, ndim=2, fold_heads=fold_heads)
+        x = layers.broadcast_to_heads(mx.sym, x, num_heads, ndim=2, fold_heads=fold_heads)
     return mx.sym.BlockGrad(x, name='%sbias' % name)
 
 

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -295,7 +295,7 @@ class TransformerValidLengthMask(mx.gluon.HybridBlock):
             # mxnet 1.3.1's broadcast_like operator does not support individual axes yet. This branch uses another way
             # of creating the required zeros array.
             # (batch, seq_len)
-            mask = F.sym.sum(F.sym.zeros_like(data), axis=2, keepdims=False)
+            mask = F.sum(F.zeros_like(data), axis=2, keepdims=False)
         else:
             # (batch, 1)
             mask = F.reshape(F.zeros_like(lengths), shape=(-1, 1))
@@ -311,7 +311,7 @@ class TransformerValidLengthMask(mx.gluon.HybridBlock):
             # (batch_size, heads, max_length) if fold_heads == False else (batch_size * heads, max_length)
             mask = layers.broadcast_to_heads(F, mask, self.num_heads, ndim=2, fold_heads=self.fold_heads)
 
-        return mx.sym.BlockGrad(mask)
+        return F.BlockGrad(mask)
 
 
 def get_autoregressive_bias(max_length: int, dtype: str = C.DTYPE_FP32) -> mx.sym.Symbol:

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -937,7 +937,7 @@ def cleanup_params_files(output_folder: str, max_to_keep: int, checkpoint: int, 
                 os.remove(param_fname_n)
 
 
-def cast_conditionally(data: mx.sym.Symbol, dtype: str) -> mx.sym.Symbol:
+def cast_conditionally(F, data: mx.sym.Symbol, dtype: str) -> mx.sym.Symbol:
     """
     Workaround until no-op cast will be fixed in MXNet codebase.
     Creates cast symbol only if dtype is different from default one, i.e. float32.
@@ -947,11 +947,11 @@ def cast_conditionally(data: mx.sym.Symbol, dtype: str) -> mx.sym.Symbol:
     :return: Cast symbol or just data symbol.
     """
     if dtype != C.DTYPE_FP32:
-        return mx.sym.cast(data=data, dtype=dtype)
+        return F.cast(data=data, dtype=dtype)
     return data
 
 
-def uncast_conditionally(data: mx.sym.Symbol, dtype: str) -> mx.sym.Symbol:
+def uncast_conditionally(F, data: mx.sym.Symbol, dtype: str) -> mx.sym.Symbol:
     """
     Workaround until no-op cast will be fixed in MXNet codebase.
     Creates cast to float32 symbol only if dtype is different from default one, i.e. float32.
@@ -961,7 +961,7 @@ def uncast_conditionally(data: mx.sym.Symbol, dtype: str) -> mx.sym.Symbol:
     :return: Cast symbol or just data symbol.
     """
     if dtype != C.DTYPE_FP32:
-        return mx.sym.cast(data=data, dtype=C.DTYPE_FP32)
+        return F.cast(data=data, dtype=C.DTYPE_FP32)
     return data
 
 

--- a/test/unit/test_encoder.py
+++ b/test/unit/test_encoder.py
@@ -121,7 +121,8 @@ def test_get_transformer_encoder():
     assert encoder.encoders[1].__dict__.items() >= dict(num_embed=6, prefix='test_encoder_char_', dtype='float32').items()
 
     assert type(encoder.encoders[2]) == sockeye.encoder.TransformerEncoder
-    assert encoder.encoders[2].__dict__.items() >= dict(prefix='test_encoder_transformer_', dtype='float16').items()
+    assert encoder.encoders[2].prefix == "test_encoder_transformer_"
+    assert encoder.encoders[2].dtype == 'float16'
 
 
 def test_get_convolutional_encoder():


### PR DESCRIPTION
This is a rather large no-op change :)
Specifically, it converts all Transformer-related layer implementations (Layer Normalization, LHUC, TransformerFeedForward, TransformerProcess, MultiHead(Self)Attention) into Gluon HybridBlocks, even though they are not yet used as Gluon Blocks. 

Since one can call HybridBlocks with Symbols as input and receives Symbols, technically nothing changes for now using our Module-based training and inference.

I checked that the parameter names created from the symbol blocks are the same as before (the logic with how prefixes are passed onto child blocks is a bit smarter in Gluon). 

Some minor hacks required nevertheless:
- We use LayerNormalization also for RNN cells that may pass in an existing parameter Variable. For these cases I had to branch on whether the HybridBlock itself creates a parameter or its already passed in. This complicated logic can be removed if we move to Gluon at some point.
- Gluon HybridBlocks have some involved way of passing inputs (and parameters) through when `__call__` is called, passing to `forward()`, passing to `hybrid_forward`. I had to remove keyword-based argument passing in a couple of places to make this work.

This should be safe to merge without bumping any major version, but is a first step towards Gluon-based Sockeye.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

