### PR TITLE
Support multiple lexicons for vocabulary selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.91]
+### Changed
+- Multiple lexicons can now be specified with the `--restrict-lexicon` option:
+  - For a single lexicon: `--restrict-lexicon /path/to/lexicon`.
+  - For multiple lexicons: `--restrict-lexicon key1:/path/to/lexicon1 key2:/path/to/lexicon2 ...`.
+  - Use `--json-input` to specify the lexicon to use for each input, ex: `{"text": "some input string", "restrict_lexicon": "key1"}`.
+
+
 ## [1.18.90]
 ### Changed
 - Updated to [MXNet 1.4.0](https://github.com/apache/incubator-mxnet/tree/1.4.0)

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -12,4 +12,4 @@
 # permissions and limitations under the License.
 
 
-__version__ = '1.18.90'
+__version__ = '1.18.91'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1309,10 +1309,16 @@ def add_inference_args(params):
                                     'to calculate maximum output length for beam search for each sentence. '
                                     'Default: %(default)s.')
     decode_params.add_argument('--restrict-lexicon',
-                               type=str,
+                               nargs='+',
+                               type=multiple_values(num_values=2, data_type=str),
                                default=None,
-                               help="Specify top-k lexicon to restrict output vocabulary based on source. See lexicon "
-                                    "module. Default: %(default)s.")
+                               help="Specify top-k lexicon to restrict output vocabulary to the k most likely context-"
+                                    "free translations of the source words in each sentence (Devlin, 2017). See the "
+                                    "lexicon module for creating top-k lexicons. To use multiple lexicons, provide "
+                                    "'--restrict-lexicon key1:path1 key2:path2 ...' and use JSON input to specify the "
+                                    "lexicon for each sentence: "
+                                    "{\"text\": \"some input string\", \"restrict_lexicon\": \"key\"}. "
+                                    "Default: %(default)s.")
     decode_params.add_argument('--restrict-lexicon-topk',
                                type=int,
                                default=None,

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -214,6 +214,7 @@ BEAM_SEARCH_STOP_ALL = 'all'
 # Inference Input JSON constants
 JSON_TEXT_KEY = "text"
 JSON_FACTORS_KEY = "factors"
+JSON_RESTRICT_LEXICON_KEY = "restrict_lexicon"
 JSON_CONSTRAINTS_KEY = "constraints"
 JSON_AVOID_KEY = "avoid"
 JSON_ENCODING = "utf-8"

--- a/sockeye/image_captioning/inference.py
+++ b/sockeye/image_captioning/inference.py
@@ -25,6 +25,7 @@ from . import utils as utils_image
 from .. import constants as C
 from .. import data_io
 from .. import lexical_constraints as constrained
+from .. import lexicon
 from .. import model
 from .. import utils
 from .. import vocab
@@ -130,6 +131,7 @@ class ImageCaptioner(Translator):
     def _get_inference_input(self,
                              trans_inputs: List[TranslatorInput]) -> Tuple[mx.nd.NDArray,
                                                                            int,
+                                                                           Optional[lexicon.TopKLexicon],
                                                                            List[
                                                                                Optional[constrained.RawConstraintList]],
                                                                            List[
@@ -146,6 +148,7 @@ class ImageCaptioner(Translator):
         """
         batch_size = len(trans_inputs)
         image_paths = [None for _ in range(batch_size)]  # type: List[Optional[str]]
+        restrict_lexicon = None  # type: Optional[lexicon.TopKLexicon]
         raw_constraints = [None for _ in range(batch_size)]  # type: List[Optional[constrained.RawConstraintList]]
         raw_avoid_list = [None for _ in range(batch_size)]  # type: List[Optional[constrained.RawConstraintList]]
         for j, trans_input in enumerate(trans_inputs):
@@ -165,9 +168,8 @@ class ImageCaptioner(Translator):
 
         max_input_length = 0
         max_output_lengths = [self.models[0].get_max_output_length(max_input_length)] * len(image_paths)
-        return mx.nd.array(images), max_input_length, raw_constraints, raw_avoid_list, mx.nd.array(max_output_lengths,
-                                                                                                   ctx=self.context,
-                                                                                                   dtype='int32')
+        return mx.nd.array(images), max_input_length, restrict_lexicon, raw_constraints, raw_avoid_list, \
+                mx.nd.array(max_output_lengths, ctx=self.context, dtype='int32')
 
 
 def load_models(context: mx.context.Context,

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1603,7 +1603,8 @@ class Translator:
                     logger.warning("Sentence %s: %s was found in the list of phrases to avoid; "
                                    "this may indicate improper preprocessing.", trans_input.sentence_id, C.UNK_SYMBOL)
 
-        return source, bucket_key, restrict_lexicon, raw_constraints, raw_avoid_list, mx.nd.array(max_output_lengths, ctx=self.context, dtype='int32')
+        return source, bucket_key, restrict_lexicon, raw_constraints, raw_avoid_list, \
+                mx.nd.array(max_output_lengths, ctx=self.context, dtype='int32')
 
     def _make_result(self,
                      trans_input: TranslatorInput,

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -621,22 +621,31 @@ class TranslatorInput:
     :param sentence_id: Sentence id.
     :param tokens: List of input tokens.
     :param factors: Optional list of additional factor sequences.
+    :param restrict_lexicon: Optional lexicon for vocabulary selection.
     :param constraints: Optional list of target-side constraints.
     :param pass_through_dict: Optional raw dictionary of arbitrary input data.
     """
 
-    __slots__ = ('sentence_id', 'tokens', 'factors', 'constraints', 'avoid_list', 'pass_through_dict')
+    __slots__ = ('sentence_id',
+                 'tokens',
+                 'factors',
+                 'restrict_lexicon',
+                 'constraints',
+                 'avoid_list',
+                 'pass_through_dict')
 
     def __init__(self,
                  sentence_id: SentenceId,
                  tokens: Tokens,
                  factors: Optional[List[Tokens]] = None,
+                 restrict_lexicon: Optional[lexicon.TopKLexicon] = None,
                  constraints: Optional[List[Tokens]] = None,
                  avoid_list: Optional[List[Tokens]] = None,
                  pass_through_dict: Optional[Dict] = None) -> None:
         self.sentence_id = sentence_id
         self.tokens = tokens
         self.factors = factors
+        self.restrict_lexicon = restrict_lexicon
         self.constraints = constraints
         self.avoid_list = avoid_list
         self.pass_through_dict = pass_through_dict
@@ -679,6 +688,7 @@ class TranslatorInput:
             yield TranslatorInput(sentence_id=self.sentence_id,
                                   tokens=self.tokens[i:i + chunk_size],
                                   factors=factors,
+                                  restrict_lexicon=self.restrict_lexicon,
                                   constraints=constraints,
                                   avoid_list=self.avoid_list,
                                   pass_through_dict=pass_through_dict)
@@ -691,6 +701,7 @@ class TranslatorInput:
                                tokens=self.tokens + [C.EOS_SYMBOL],
                                factors=[factor + [C.EOS_SYMBOL] for factor in
                                         self.factors] if self.factors is not None else None,
+                               restrict_lexicon=self.restrict_lexicon,
                                constraints=self.constraints,
                                avoid_list=self.avoid_list,
                                pass_through_dict=self.pass_through_dict)
@@ -718,7 +729,9 @@ def make_input_from_plain_string(sentence_id: SentenceId, string: str) -> Transl
     return TranslatorInput(sentence_id, tokens=list(data_io.get_tokens(string)), factors=None)
 
 
-def make_input_from_json_string(sentence_id: SentenceId, json_string: str) -> TranslatorInput:
+def make_input_from_json_string(sentence_id: SentenceId,
+                                json_string: str,
+                                translator: 'Translator') -> TranslatorInput:
     """
     Returns a TranslatorInput object from a JSON object, serialized as a string.
 
@@ -727,18 +740,21 @@ def make_input_from_json_string(sentence_id: SentenceId, json_string: str) -> Tr
            and optionally a key "factors" that maps to a list of strings, each of which representing a factor sequence
            for the input text. Constraints and an avoid list can also be added through the "constraints" and "avoid"
            keys.
+    :param translator: A translator object.
     :return: A TranslatorInput.
     """
     try:
         jobj = json.loads(json_string, encoding=C.JSON_ENCODING)
-        return make_input_from_dict(sentence_id, jobj)
+        return make_input_from_dict(sentence_id, jobj, translator)
 
     except Exception as e:
         logger.exception(e, exc_info=True) if not is_python34() else logger.error(e)  # type: ignore
         return _bad_input(sentence_id, reason=json_string)
 
 
-def make_input_from_dict(sentence_id: SentenceId, input_dict: Dict) -> TranslatorInput:
+def make_input_from_dict(sentence_id: SentenceId,
+                         input_dict: Dict,
+                         translator: 'Translator') -> TranslatorInput:
     """
     Returns a TranslatorInput object from a JSON object, serialized as a string.
 
@@ -746,6 +762,7 @@ def make_input_from_dict(sentence_id: SentenceId, input_dict: Dict) -> Translato
     :param input_dict: A dict that must contain a key "text", mapping to the input text, and optionally a key "factors"
            that maps to a list of strings, each of which representing a factor sequence for the input text.
            Constraints and an avoid list can also be added through the "constraints" and "avoid" keys.
+    :param translator: A translator object.
     :return: A TranslatorInput.
     """
     try:
@@ -757,6 +774,23 @@ def make_input_from_dict(sentence_id: SentenceId, input_dict: Dict) -> Translato
             lengths = [len(f) for f in factors]
             if not all(length == len(tokens) for length in lengths):
                 logger.error("Factors have different length than input text: %d vs. %s", len(tokens), str(lengths))
+                return _bad_input(sentence_id, reason=str(input_dict))
+
+        # Lexicon for vocabulary selection/restriction:
+        # This is only populated when using multiple lexicons, in which case the
+        # restrict_lexicon key must exist and the value (name) must map to one
+        # of the translator's known lexicons.
+        restrict_lexicon = None
+        restrict_lexicon_name = input_dict.get(C.JSON_RESTRICT_LEXICON_KEY)
+        if isinstance(translator.restrict_lexicon, dict):
+            if restrict_lexicon_name is None:
+                logger.error("Must specify restrict_lexicon when using multiple lexicons. Choices: %s"
+                             % ' '.join(sorted(translator.restrict_lexicon)))
+                return _bad_input(sentence_id, reason=str(input_dict))
+            restrict_lexicon = translator.restrict_lexicon.get(restrict_lexicon_name, None)
+            if restrict_lexicon is None:
+                logger.error("Unknown restrict_lexicon '%s'. Choices: %s"
+                             % (restrict_lexicon_name, ' '.join(sorted(translator.restrict_lexicon))))
                 return _bad_input(sentence_id, reason=str(input_dict))
 
         # List of phrases to prevent from occuring in the output
@@ -781,7 +815,8 @@ def make_input_from_dict(sentence_id: SentenceId, input_dict: Dict) -> Translato
             constraints = [list(data_io.get_tokens(constraint)) for constraint in constraints]
 
         return TranslatorInput(sentence_id=sentence_id, tokens=tokens, factors=factors,
-                               constraints=constraints, avoid_list=avoid_list, pass_through_dict=input_dict)
+                               restrict_lexicon=restrict_lexicon, constraints=constraints,
+                               avoid_list=avoid_list, pass_through_dict=input_dict)
 
     except Exception as e:
         logger.exception(e, exc_info=True) if not is_python34() else logger.error(e)  # type: ignore
@@ -1182,7 +1217,8 @@ class Translator:
     :param source_vocabs: Source vocabularies.
     :param target_vocab: Target vocabulary.
     :param nbest_size: Size of nbest list of translations.
-    :param restrict_lexicon: Top-k lexicon to use for target vocabulary restriction.
+    :param restrict_lexicon: Top-k lexicon to use for target vocabulary selection. Can be a dict of
+                             of named lexicons.
     :param avoid_list: Global list of phrases to exclude from the output.
     :param store_beam: If True, store the beam search history and return it in the TranslatorOutput.
     :param strip_unknown_words: If True, removes any <unk> symbols from outputs.
@@ -1201,7 +1237,7 @@ class Translator:
                  source_vocabs: List[vocab.Vocab],
                  target_vocab: vocab.Vocab,
                  nbest_size: int = 1,
-                 restrict_lexicon: Optional[lexicon.TopKLexicon] = None,
+                 restrict_lexicon: Optional[Union[lexicon.TopKLexicon, Dict[str, lexicon.TopKLexicon]]] = None,
                  avoid_list: Optional[str] = None,
                  store_beam: bool = False,
                  strip_unknown_words: bool = False,
@@ -1497,6 +1533,7 @@ class Translator:
     def _get_inference_input(self,
                              trans_inputs: List[TranslatorInput]) -> Tuple[mx.nd.NDArray,
                                                                            int,
+                                                                           Optional[lexicon.TopKLexicon],
                                                                            List[Optional[constrained.RawConstraintList]],
                                                                            List[Optional[constrained.RawConstraintList]],
                                                                            mx.nd.NDArray]:
@@ -1508,12 +1545,14 @@ class Translator:
 
         :param trans_inputs: List of TranslatorInputs.
         :return NDArray of source ids (shape=(batch_size, bucket_key, num_factors)),
-                bucket key, list of raw constraint lists, and list of phrases to avoid,
-                and an NDArray of maximum output lengths.
+                bucket key, lexicon for vocabulary restriction, list of raw constraint
+                lists, and list of phrases to avoid, and an NDArray of maximum output
+                lengths.
         """
         batch_size = len(trans_inputs)
         bucket_key = data_io.get_bucket(max(len(inp.tokens) for inp in trans_inputs), self.buckets_source)
         source = mx.nd.zeros((batch_size, bucket_key, self.num_source_factors), ctx=self.context)
+        restrict_lexicon = None  # type: Optional[lexicon.TopKLexicon]
         raw_constraints = [None] * batch_size  # type: List[Optional[constrained.RawConstraintList]]
         raw_avoid_list = [None] * batch_size  # type: List[Optional[constrained.RawConstraintList]]
 
@@ -1533,6 +1572,26 @@ class Translator:
 
                 source[j, :num_tokens, i] = data_io.tokens2ids(factor, self.source_vocabs[i])[:num_tokens]
 
+            # Check if vocabulary selection/restriction is enabled:
+            # - First, see if the translator input provides a lexicon (used for multiple lexicons)
+            # - If not, see if the translator itself provides a lexicon (used for single lexicon)
+            # - The same lexicon must be used for all inputs in the batch.
+            if trans_input.restrict_lexicon is not None:
+                if restrict_lexicon is not None and restrict_lexicon is not trans_input.restrict_lexicon:
+                    logger.warning("Sentence %s: different restrict_lexicon specified, will overrule previous. "
+                                   "All inputs in batch must use same lexicon." % trans_input.sentence_id)
+                restrict_lexicon = trans_input.restrict_lexicon
+            elif self.restrict_lexicon is not None:
+                if isinstance(self.restrict_lexicon, dict):
+                    # This code should not be reachable since the case is checked when creating
+                    # translator inputs. It is included here to guarantee that the translator can
+                    # handle any valid input regardless of whether it was checked at creation time.
+                    logger.warning("Sentence %s: no restrict_lexicon specified for input when using multiple lexicons, "
+                                   "defaulting to first lexicon for entire batch." % trans_input.sentence_id)
+                    restrict_lexicon = list(self.restrict_lexicon.values())[0]
+                else:
+                    restrict_lexicon = self.restrict_lexicon
+
             if trans_input.constraints is not None:
                 raw_constraints[j] = [data_io.tokens2ids(phrase, self.vocab_target) for phrase in
                                       trans_input.constraints]
@@ -1544,7 +1603,7 @@ class Translator:
                     logger.warning("Sentence %s: %s was found in the list of phrases to avoid; "
                                    "this may indicate improper preprocessing.", trans_input.sentence_id, C.UNK_SYMBOL)
 
-        return source, bucket_key, raw_constraints, raw_avoid_list, mx.nd.array(max_output_lengths, ctx=self.context, dtype='int32')
+        return source, bucket_key, restrict_lexicon, raw_constraints, raw_avoid_list, mx.nd.array(max_output_lengths, ctx=self.context, dtype='int32')
 
     def _make_result(self,
                      trans_input: TranslatorInput,
@@ -1600,6 +1659,7 @@ class Translator:
     def _translate_nd(self,
                       source: mx.nd.NDArray,
                       source_length: int,
+                      restrict_lexicon: Optional[lexicon.TopKLexicon],
                       raw_constraints: List[Optional[constrained.RawConstraintList]],
                       raw_avoid_list: List[Optional[constrained.RawConstraintList]],
                       max_output_lengths: mx.nd.NDArray) -> List[Translation]:
@@ -1608,12 +1668,14 @@ class Translator:
 
         :param source: Source ids. Shape: (batch_size, bucket_key, num_factors).
         :param source_length: Bucket key.
+        :param restrict_lexicon: Lexicon to use for vocabulary restriction.
         :param raw_constraints: A list of optional constraint lists.
 
         :return: Sequence of translations.
         """
         return self._get_best_from_beam(*self._beam_search(source,
                                                            source_length,
+                                                           restrict_lexicon,
                                                            raw_constraints,
                                                            raw_avoid_list,
                                                            max_output_lengths))
@@ -1701,6 +1763,7 @@ class Translator:
     def _beam_search(self,
                      source: mx.nd.NDArray,
                      source_length: int,
+                     restrict_lexicon: Optional[lexicon.TopKLexicon],
                      raw_constraint_list: List[Optional[constrained.RawConstraintList]],
                      raw_avoid_list: List[Optional[constrained.RawConstraintList]],
                      max_output_lengths: mx.nd.NDArray) -> Tuple[np.ndarray,
@@ -1715,6 +1778,7 @@ class Translator:
 
         :param source: Source ids. Shape: (batch_size, bucket_key, num_factors).
         :param source_length: Max source length.
+        :param restrict_lexicon: Lexicon to use for vocabulary restriction.
         :param raw_constraint_list: A list of optional lists containing phrases (as lists of target word IDs)
                that must appear in each output.
         :param raw_avoid_list: A list of optional lists containing phrases (as lists of target word IDs)
@@ -1777,11 +1841,11 @@ class Translator:
         models_output_layer_w = list()
         models_output_layer_b = list()
         vocab_slice_ids = None  # type: mx.nd.NDArray
-        if self.restrict_lexicon:
+        if restrict_lexicon:
             source_words = utils.split(source, num_outputs=self.num_source_factors, axis=2, squeeze_axis=True)[0]
             # TODO: See note in method about migrating to pure MXNet when set operations are supported.
             #       We currently convert source to NumPy and target ids back to NDArray.
-            vocab_slice_ids = self.restrict_lexicon.get_trg_ids(source_words.astype("int32").asnumpy())
+            vocab_slice_ids = restrict_lexicon.get_trg_ids(source_words.astype("int32").asnumpy())
             if any(raw_constraint_list):
                 # Add the constraint IDs to the list of permissibled IDs, and then project them into the reduced space
                 constraint_ids = np.array([word_id for sent in raw_constraint_list for phr in sent for word_id in phr])
@@ -1877,7 +1941,7 @@ class Translator:
                     scores_accumulated)
 
             # Map from restricted to full vocab ids if needed
-            if self.restrict_lexicon:
+            if restrict_lexicon:
                 best_word_indices = vocab_slice_ids.take(best_word_indices)
 
             # (4) Reorder fixed-size beam data according to best_hyp_indices (ascending)

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -19,7 +19,7 @@ import sys
 import time
 import logging
 from contextlib import ExitStack
-from typing import Generator, Optional, List
+from typing import Dict, Generator, List, Optional, Union
 
 from sockeye.lexicon import TopKLexicon
 from sockeye.log import setup_main_logger


### PR DESCRIPTION
This allows multiple lexicons to be used for vocabulary selection/restriction.  Valid options are now:
- `--restrict-lexicon /path/to/lexicon` to specify a single lexicon, same as before.
- `--restrict-lexicon key1:/path/to/lexicon1 key2:/path/to/lexicon2` to specify multiple lexicons and requires `--json-input` to also be set.

When using multiple lexicons, the lexicon for each input is specified using JSON:
```json
{"text": "some input text", "restrict_lexicon": "key1"}
{"text": "another input text", "restrict_lexicon": "key2"}
```
All sentences in the same batch must use the same lexicon.

Main code changes:
- `Translator.restrict_lexicon` can now be a dictionary of `TopKLexicon` objects.
- `TranslatorInput` objects can now have a reference to a `TopKLexicon` object.
- When the current translator has multiple lexicons, `make_input_from_dict()` looks for the "restrict_lexicon" key and matches it against one of the translator's lexicons.
- Possible error cases related to this matching are handled with warnings or returning `BadTranslatorInput`.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Unit tests updated
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

