### PR TITLE
put prepare_vocab outside main argparsing function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.96]
+### Changed
+- Extracted prepare vocab functionality in the build vocab step into its own function. This matches the pattern in prepare data and train where the main() function only has argparsing, and it invokes a separate function to do the work. This is to allow modules that import this one to circumvent the command line. 
+
 ## [1.18.95]
 ### Changed
 - Removed custom operators from transformer models and replaced them with symbolic operators.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.95'
+__version__ = '1.18.96'

--- a/sockeye/vocab.py
+++ b/sockeye/vocab.py
@@ -318,7 +318,9 @@ def main():
     params = argparse.ArgumentParser(description='CLI to build source and target vocab(s).')
     arguments.add_build_vocab_args(params)
     args = params.parse_args()
+    prepare_vocab(args)
 
+def prepare_vocab(args: argparse.Namespace):
     num_words, num_words_other = args.num_words
     num_words = num_words if num_words > 0 else None
     num_words_other = num_words_other if num_words_other > 0 else None


### PR DESCRIPTION
Match the pattern in sockeye.prepare_data and sockeye.train where the main() function only has argparsing, and it invokes a separate prepare_vocab() function to do the work. This is to allow modules that import this one to circumvent the command line.

(description of the change)

#### Pull Request Checklist ##
- [y ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [y ] Unit tests pass (`pytest`) NOTE: Unrelated tests in test/unit/test_data_io.py fail (test_parallel_sample_iter and test_sharded_parallel_sample_iter) because allow_pickle=False but I didn't update them to pass in this commit.
- [n ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs? 
- [y ] System tests pass (`pytest test/system`)
- [y ] Passed code style checking (`./style-check.sh`)
- [n ] You have considered writing a test
- [y ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [y ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
