### PR TITLE
Update to pyyaml 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.97]
+### Changed
+- Updated to PyYAML 5.1
+
 ## [1.18.96]
 ### Changed
 - Extracted prepare vocab functionality in the build vocab step into its own function. This matches the pattern in prepare data and train where the main() function only has argparsing, and it invokes a separate function to do the work. This is to allow modules that import this one to circumvent the command line. 

--- a/requirements/requirements.docs.txt
+++ b/requirements/requirements.docs.txt
@@ -2,4 +2,4 @@ sphinx>=1.7.4
 sphinx_rtd_theme
 sphinx-autodoc-typehints>=1.3.0
 recommonmark
-pyyaml==3.12
+pyyaml>=5.1

--- a/requirements/requirements.gpu-cu100.txt
+++ b/requirements/requirements.gpu-cu100.txt
@@ -1,4 +1,4 @@
-pyyaml==3.12
+pyyaml>=5.1
 mxnet-cu100mkl==1.4.0
 numpy>=1.14
 typing

--- a/requirements/requirements.gpu-cu80.txt
+++ b/requirements/requirements.gpu-cu80.txt
@@ -1,4 +1,4 @@
-pyyaml==3.12
+pyyaml>=5.1
 mxnet-cu80mkl==1.4.0
 numpy>=1.14
 typing

--- a/requirements/requirements.gpu-cu90.txt
+++ b/requirements/requirements.gpu-cu90.txt
@@ -1,4 +1,4 @@
-pyyaml==3.12
+pyyaml>=5.1
 mxnet-cu90mkl==1.4.0
 numpy>=1.14
 typing

--- a/requirements/requirements.gpu-cu92.txt
+++ b/requirements/requirements.gpu-cu92.txt
@@ -1,4 +1,4 @@
-pyyaml==3.12
+pyyaml>=5.1
 mxnet-cu92mkl==1.4.0
 numpy>=1.14
 typing

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-pyyaml==3.12
+pyyaml>=5.1
 mxnet-mkl==1.4.0
 numpy>=1.14
 typing

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.96'
+__version__ = '1.18.97'

--- a/sockeye/config.py
+++ b/sockeye/config.py
@@ -34,7 +34,7 @@ class Config(yaml.YAMLObject, metaclass=TaggedYamlObjectMetaclass):
     Base configuration object that supports freezing of members and YAML (de-)serialization.
     Actual Configuration should subclass this object.
     """
-    yaml_loader = yaml.UnsafeLoader
+    yaml_loader = yaml.UnsafeLoader  # type: ignore
 
     def __init__(self):
         self.__add_frozen()
@@ -121,7 +121,7 @@ class Config(yaml.YAMLObject, metaclass=TaggedYamlObjectMetaclass):
         :return: Configuration.
         """
         with open(fname) as inp:
-            obj = yaml.load(inp, Loader=yaml.UnsafeLoader)
+            obj = yaml.load(inp, Loader=yaml.UnsafeLoader)  # type: ignore
             obj.__add_frozen()
             return obj
 

--- a/sockeye/config.py
+++ b/sockeye/config.py
@@ -34,6 +34,8 @@ class Config(yaml.YAMLObject, metaclass=TaggedYamlObjectMetaclass):
     Base configuration object that supports freezing of members and YAML (de-)serialization.
     Actual Configuration should subclass this object.
     """
+    yaml_loader = yaml.UnsafeLoader
+
     def __init__(self):
         self.__add_frozen()
 
@@ -119,7 +121,7 @@ class Config(yaml.YAMLObject, metaclass=TaggedYamlObjectMetaclass):
         :return: Configuration.
         """
         with open(fname) as inp:
-            obj = yaml.load(inp)
+            obj = yaml.load(inp, Loader=yaml.UnsafeLoader)
             obj.__add_frozen()
             return obj
 


### PR DESCRIPTION
This should remove the github security warnings. As we need to load custom objects using yaml, we are bound to use the `UnsafeLoader`.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

