### PR TITLE
Fix:Always initialize the multiprocessing context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+
+## [1.18.100]
+### Fixed
+- Always initializing the multiprocessing context. This should fix issues observed when running `sockeye-train`.
+
 ## [1.18.99]
 ### Changed
 - Updated to [MXNet 1.4.1](https://github.com/apache/incubator-mxnet/tree/1.4.1)

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.99'
+__version__ = '1.18.100'

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -17,9 +17,8 @@ Simple Training CLI.
 
 # Start the forkserver. It is important that this is done before any other imports so that the forkserver is in a clean
 # state.
-if __name__ == "__main__":
-    import sockeye.multiprocessing_utils as mp
-    mp.initialize()
+import sockeye.multiprocessing_utils as mp
+mp.initialize()
 
 
 import argparse


### PR DESCRIPTION
With this change we will always initialize the multiprocessing context to address https://github.com/awslabs/sockeye/issues/684. As the multiprocessing context initialization code checks whether it has been called before and if not simply returns this should not change existing behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

