### PR TITLE
Correct sorting of more than 10 source vocabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.102]
+### Fixed
+- Fixed loading of more than 10 source vocabulary files to be in the right, numerical order.
+
 ## [1.18.101]
 ### Changed
 - Update to Sacrebleu 1.3.6

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.101'
+__version__ = '1.18.102'

--- a/sockeye/vocab.py
+++ b/sockeye/vocab.py
@@ -178,6 +178,11 @@ def save_target_vocab(target_vocab: Vocab, folder: str):
     vocab_to_json(target_vocab, os.path.join(folder, C.VOCAB_TRG_NAME % 0))
 
 
+def _get_sorted_source_vocab_fnames(folder) -> List[str]:
+    _key = lambda x: int(x.split('.', 3)[-2])
+    return sorted([f for f in os.listdir(folder) if f.startswith(C.VOCAB_SRC_PREFIX)], key=_key)
+
+
 def load_source_vocabs(folder: str) -> List[Vocab]:
     """
     Loads source vocabularies from folder. The first element in the list is the primary source vocabulary.
@@ -186,8 +191,7 @@ def load_source_vocabs(folder: str) -> List[Vocab]:
     :param folder: Source folder.
     :return: List of vocabularies.
     """
-    return [vocab_from_json(os.path.join(folder, fname)) for fname in
-            sorted([f for f in os.listdir(folder) if f.startswith(C.VOCAB_SRC_PREFIX)])]
+    return [vocab_from_json(os.path.join(folder, fname)) for fname in _get_sorted_source_vocab_fnames(folder)]
 
 
 def load_target_vocab(folder: str) -> Vocab:

--- a/test/unit/test_vocab.py
+++ b/test/unit/test_vocab.py
@@ -12,9 +12,10 @@
 # permissions and limitations under the License.
 
 import pytest
+from unittest import mock
 
 import sockeye.constants as C
-from sockeye.vocab import build_vocab, get_ordered_tokens_from_vocab, is_valid_vocab
+from sockeye.vocab import build_vocab, get_ordered_tokens_from_vocab, is_valid_vocab, _get_sorted_source_vocab_fnames
 
 test_vocab = [
         # Example 1
@@ -100,3 +101,11 @@ def test_get_ordered_tokens_from_vocab(vocab, expected_output):
 )
 def test_verify_valid_vocab(vocab, expected_result):
     assert is_valid_vocab(vocab) == expected_result
+
+
+def test_get_sorted_source_vocab_fnames():
+    expected_fnames = [C.VOCAB_SRC_NAME % i for i in [1, 2, 10]]
+    with mock.patch('os.listdir') as mocked_listdir:
+        mocked_listdir.return_value = [C.VOCAB_SRC_NAME % i for i in [2, 1, 10]]
+        fnames = _get_sorted_source_vocab_fnames(None)
+        assert fnames == expected_fnames


### PR DESCRIPTION
Fixes #703 as identified and described by @rudinger.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

