### PR TITLE
Support for an external custom metrics logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.104]
+### Added
+- Added support for a possibility to have a custom metrics logger - a function passed as an extra parameter. If supplied, the logger is called during training.
+
 ## [1.18.103]
 ### Added
 - Added ability to score image-sentence pairs by extending the scoring feature originally implemented for machine 

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.103'
+__version__ = '1.18.104'

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -28,7 +28,7 @@ import sys
 import tempfile
 import logging
 from contextlib import ExitStack
-from typing import Any, cast, Optional, Dict, List, Tuple
+from typing import Any, cast, Optional, Dict, List, Tuple, Callable
 
 import mxnet as mx
 
@@ -831,7 +831,12 @@ def main():
     train(args)
 
 
-def train(args: argparse.Namespace) -> training.TrainState:
+def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = None) -> training.TrainState:
+    """
+    :param custom_metrics_logger: Optional custom metrics logging function. If supplied, takes care of metrics produced
+                                  during training in a custom way. It should accept a list or a dictionary of
+                                  (metric name, metric value) pairs, and an optional global_step/checkpoint parameter.
+    """
     if args.dry_run:
         # Modify arguments so that we write to a temporary directory and
         # perform 0 training iterations
@@ -937,7 +942,8 @@ def train(args: argparse.Namespace) -> training.TrainState:
                                                 keep_initializations=args.keep_initializations,
                                                 source_vocabs=source_vocabs,
                                                 target_vocab=target_vocab,
-                                                stop_training_on_decoder_failure=args.stop_training_on_decoder_failure)
+                                                stop_training_on_decoder_failure=args.stop_training_on_decoder_failure,
+                                                custom_metrics_logger=custom_metrics_logger)
 
         training_state = trainer.fit(train_iter=train_iter,
                                      validation_iter=eval_iter,

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -21,7 +21,7 @@ import random
 import shutil
 import time
 from functools import reduce
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, Callable
 
 import mxnet as mx
 import numpy as np
@@ -475,6 +475,23 @@ def global_norm(ndarrays: List[mx.nd.NDArray]) -> float:
     return sqrt(sum(norm.asscalar() for norm in norms))
 
 
+def safe_custom_metrics_logger(logging_function, attribute_value_mapping, global_step=None):
+    """
+    A thin wrapper for calling a custom metrics logging function, if supplied. As it uses an external function,
+    it should never throw an exception. If there is no logging_function supplied, the function does nothing.
+
+    :param logging_function: The function supplied by a caller of sockeye.train
+    :param attribute_value_mapping: A list or a dictionary of (metric name, metric value) pairs.
+    :param global_step: Optional argument, which can be used e.g. by Tensorboard.
+    """
+    if logging_function is None:
+        return
+    try:
+        logging_function(attribute_value_mapping, global_step)
+    except Exception as e:
+        logger.warning("Didn't use custom metrics logger, exception '{}' occured".format(str(e)))
+
+
 class TrainState:
     """
     Stores the state an EarlyStoppingTrainer instance.
@@ -538,7 +555,8 @@ class EarlyStoppingTrainer:
                  keep_initializations: bool,
                  source_vocabs: List[vocab.Vocab],
                  target_vocab: vocab.Vocab,
-                 stop_training_on_decoder_failure: bool = False) -> None:
+                 stop_training_on_decoder_failure: bool = False,
+                 custom_metrics_logger: Optional[Callable] = None) -> None:
         self.model = model
         self.optimizer_config = optimizer_config
         self.max_params_files_to_keep = max_params_files_to_keep
@@ -550,6 +568,7 @@ class EarlyStoppingTrainer:
         self.target_vocab = target_vocab
         self.state = None  # type: Optional[TrainState]
         self.stop_training_on_decoder_failure = stop_training_on_decoder_failure
+        self.custom_metrics_logger = custom_metrics_logger
 
     def fit(self,
             train_iter: data_io.BaseParallelSampleIter,
@@ -700,9 +719,13 @@ class EarlyStoppingTrainer:
                             self.state.samples, time_cost, checkpoint_interval / time_cost)
                 for name, val in metric_train.get_name_value():
                     logger.info('Checkpoint [%d]\tTrain-%s=%f', self.state.checkpoint, name, val)
+                safe_custom_metrics_logger(self.custom_metrics_logger, metric_train.get_name_value(),
+                                           global_step=self.state.checkpoint)
                 self._evaluate(validation_iter, metric_val)
                 for name, val in metric_val.get_name_value():
                     logger.info('Checkpoint [%d]\tValidation-%s=%f', self.state.checkpoint, name, val)
+                safe_custom_metrics_logger(self.custom_metrics_logger, metric_val.get_name_value(),
+                                           global_step=self.state.checkpoint)
 
                 # (2) wait for checkpoint decoder results and fill self.state.metrics
                 if process_manager is not None:
@@ -714,6 +737,8 @@ class EarlyStoppingTrainer:
                             self.state.metrics[decoded_checkpoint - 1].update(decoder_metrics)
                             self.tflogger.log_metrics(decoder_metrics, decoded_checkpoint)
                             utils.write_metrics_file(self.state.metrics, self.metrics_fname)
+                            safe_custom_metrics_logger(self.custom_metrics_logger, decoder_metrics,
+                                                       global_step=decoded_checkpoint)
                     # Start the decoder for the next checkpoint
                     process_manager.start_decoder(self.state.checkpoint)
 


### PR DESCRIPTION
Added a possibility to pass an external custom metrics logger to Sockeye, which is called during training, if supplied.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

