### PR TITLE
Sockeye 2 Training: Threshold for improvement when using improvement-based stopping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 - Removed unused training options: Eve, Nadam, RMSProp, Nag, Adagrad, and Adadelta optimizers, `fixed-step` and `fixed-rate-inv-t` learning rate schedulers
 - Updated and renamed learning rate scheduler `fixed-rate-inv-sqrt-t` -> `inv-sqrt-decay`
 - Added script for plotting metrics files: [sockeye_contrib/plot_metrics.py](sockeye_contrib/plot_metrics.py)
-- /TODO/
 
 ### Added
 
@@ -33,6 +32,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 - Added support for MXNet's [Automatic Mixed Precision](https://mxnet.incubator.apache.org/versions/master/tutorials/amp/amp_tutorial.html).  Activate with the `--amp` training flag.  For best results, make sure as many model dimensions are possible are multiples of 8.
 - Added options for making various model dimensions multiples of a given value.  For example, use `--pad-vocab-to-multiple-of 8`, `--bucket-width 8 --no-bucket-scaling`, and `--round-batch-sizes-to-multiple-of 8` with AMP training.
 - Added [GluonNLP](http://gluon-nlp.mxnet.io/)'s BERTAdam optimizer, an implementation of the Adam variant used by Devlin et al. ([2018](https://arxiv.org/pdf/1810.04805.pdf)).  Use `--optimizer bertadam`.
+- Added training option `--checkpoint-improvement-threshold` to set the amount of metric improvement required over the window of previous checkpoints to be considered actual model improvement (used with `--max-num-checkpoint-not-improved`).
 
 ## [1.18.103]
 ### Added

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -769,6 +769,11 @@ def add_training_args(params):
                               help='Maximum number of checkpoints the model is allowed to not improve in '
                                    '<optimized-metric> on validation data before training is stopped. '
                                    'Default: %(default)s.')
+    train_params.add_argument('--checkpoint-improvement-threshold',
+                              type=float,
+                              default=0.,
+                              help='Improvement in <optimized-metric> over specified number of checkpoints must exceed'
+                                   'this value to be considered actual improvement. Default: %(default)s.')
 
     train_params.add_argument('--min-num-epochs',
                               type=int,

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -823,6 +823,7 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
             keep_initializations=args.keep_initializations,
             checkpoint_interval=args.checkpoint_interval,
             max_num_checkpoint_not_improved=args.max_num_checkpoint_not_improved,
+            checkpoint_improvement_threshold=args.checkpoint_improvement_threshold,
             max_checkpoints=args.max_checkpoints,
             min_samples=args.min_samples,
             max_samples=args.max_samples,

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -151,6 +151,7 @@ def test_inference_args(test_params, expected_params):
               optimized_metric=C.PERPLEXITY,
               checkpoint_interval=4000,
               max_num_checkpoint_not_improved=None,
+              checkpoint_improvement_threshold=0.,
               max_checkpoints=None,
               embed_dropout=(.0, .0),
               transformer_dropout_attention=0.1,


### PR DESCRIPTION
This commit adds a `--checkpoint-improvement-threshold` option that works with the `--max-num-checkpoint-not-improved` option.  If the metric improvement over the given number of checkpoints does not exceed the threshold, training stops.  Setting the threshold to zero (default value) preserves the current behavior.  Setting the threshold higher generally leads to shorter training but may degrade quality.  A threshold of 0.002 tends to work well with no quality loss for WMT data.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

