### PR TITLE
Test selection through testpaths.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
-addopts = sockeye test/unit test/integration -v
+addopts = -v
+testpaths = test/unit test/integration


### PR DESCRIPTION
Small modification to pytest. By moving the directory subselection to `testpaths` we still only run the unit and integration tests as before. The advantage is that one can run single tests in IDEs  instead of having to always run all unit and integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

