### PR TITLE
Add checkpoint callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.111]
+### Added
+- Added an optional checkpoint callback for the train function.
+
+### Changed
+- Excluded gradients from pickled fields of TrainState
+
 ## [1.18.110]
 ### Changed
 - We now guard against failures to run `nvidia-smi` for GPU memory monitoring.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.110'
+__version__ = '1.18.111'

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -838,11 +838,14 @@ def main():
     train(args)
 
 
-def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = None) -> training.TrainState:
+def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = None,
+         checkpoint_callback: Optional[Callable] = None) -> training.TrainState:
     """
     :param custom_metrics_logger: Optional custom metrics logging function. If supplied, takes care of metrics produced
                                   during training in a custom way. It should accept a dictionary of
                                   metric name -> metric value pairs and a global_step/checkpoint parameter.
+    :param checkpoint_callback: An optional callback function (int -> None). The function will be called
+                                each time a checkpoint has been reached 
     """
     if args.dry_run:
         # Modify arguments so that we write to a temporary directory and
@@ -951,7 +954,8 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
                                                 source_vocabs=source_vocabs,
                                                 target_vocab=target_vocab,
                                                 stop_training_on_decoder_failure=args.stop_training_on_decoder_failure,
-                                                custom_metrics_logger=custom_metrics_logger)
+                                                custom_metrics_logger=custom_metrics_logger,
+                                                checkpoint_callback=checkpoint_callback)
 
         training_state = trainer.fit(train_iter=train_iter,
                                      validation_iter=eval_iter,


### PR DESCRIPTION
Add a checkpoint callback to the train function.
Exclude the gradient from the training state pickle file since it is not needed when training is resumed

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs? No change
- [ ] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`) (Already not passing)
- [ ] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

