### PR TITLE
Set ParallelModel threads to daemons, nicer parameter printing, re-enable tensorboard logging

### DIFF
--- a/sockeye/parallel.py
+++ b/sockeye/parallel.py
@@ -120,7 +120,7 @@ class Parallel(object):
 
         arg = (self._in_queue, self._out_queue, self._parallizable)
         for _ in range(num_workers):
-            thread = threading.Thread(target=_worker, args=arg)
+            thread = threading.Thread(target=_worker, args=arg, daemon=True)
             self._threads.append(thread)
             thread.start()
 

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -160,8 +160,8 @@ class TrainState:
         self.gradients = {}
 
 
-
 class GluonEarlyStoppingTrainer:
+
     def __init__(self,
                  config: TrainerConfig,
                  optimizer_config: OptimizerConfig,
@@ -189,6 +189,7 @@ class GluonEarlyStoppingTrainer:
         self.state = None  # type: Optional[TrainState]
         self._speedometer = Speedometer(frequency=C.MEASURE_SPEED_EVERY, auto_reset=False)
         self._custom_metrics_logger = custom_metrics_logger
+        self._tflogger = TensorboardLogger(logdir=os.path.join(self.config.output_dir, C.TENSORBOARD_NAME))
         self.checkpoint_callback = checkpoint_callback
 
     def fit(self,
@@ -209,15 +210,16 @@ class GluonEarlyStoppingTrainer:
             self.state = TrainState(self.config.early_stopping_metric)
             self.model.save_config(self.config.output_dir)
             self.model.save_version(self.config.output_dir)
-            #~ self._save_training_state(train_iter)
-            #self._save_trainer_states(self.best_optimizer_states_fname) # not saving due to deferred initialization
+            # self._save_training_state(train_iter)
+            # self._save_trainer_states(self.best_optimizer_states_fname)  # not saving due to deferred initialization
             logger.info("Training started.")
 
         tic = time.time()
 
         if self.config.max_checkpoints is not None:
             self.config.max_updates = self.state.updates + self.config.max_checkpoints * self.config.checkpoint_interval
-            logger.info("Resetting max_updates to %d + %d * %d = %d in order to implement stopping after (an additional) %d checkpoints.",
+            logger.info("Resetting max_updates to %d + %d * %d = %d in order to implement stopping "
+                        "after (an additional) %d checkpoints.",
                         self.state.updates,
                         self.config.max_checkpoints,
                         self.config.checkpoint_interval,
@@ -538,11 +540,7 @@ class GluonEarlyStoppingTrainer:
         self.state.metrics.append(data)
         utils.write_metrics_file(self.state.metrics, self.metrics_fname)
 
-        # TODO: Tensorboard logging
-        # tf_metrics = data.copy()
-        # tf_metrics.update({"%s_grad" % n: v for n, v in self.state.gradients.items()})
-        # tf_metrics.update(self.model.params)
-        #self.tflogger.log_metrics(metrics=tf_metrics, checkpoint=self.state.checkpoint)
+        self._tflogger.log_metrics(metrics=data, checkpoint=self.state.checkpoint)
 
     def _update_best_params(self):
         """
@@ -758,43 +756,45 @@ class TensorboardLogger:
         try:
             import mxboard
             logger.info("Logging training events for Tensorboard at '%s'", self.logdir)
-            self.sw = mxboard.SummaryWriter(logdir=self.logdir, flush_secs=60, verbose=False)
+            self._writer = mxboard.SummaryWriter(logdir=self.logdir, flush_secs=60, verbose=False)
         except ImportError:
             logger.info("mxboard not found. Consider 'pip install mxboard' to log events to Tensorboard.")
-            self.sw = None
+            self._writer = None
 
     def log_metrics(self, metrics: Dict[str, Union[float, int, mx.nd.NDArray]], checkpoint: int):
-        if self.sw is None:
+        if self._writer is None:
             return
 
         for name, value in metrics.items():
             if isinstance(value, mx.nd.NDArray):
                 if mx.nd.contrib.isfinite(value).sum().asscalar() == value.size:
-                    self.sw.add_histogram(tag=name, values=value, bins=100, global_step=checkpoint)
+                    self._writer.add_histogram(tag=name, values=value, bins=100, global_step=checkpoint)
                 else:
                     logger.warning("Histogram of %s not logged to tensorboard because of infinite data.")
+            elif value is None:
+                continue
             else:
-                self.sw.add_scalar(tag=name, value=value, global_step=checkpoint)
+                self._writer.add_scalar(tag=name, value=value, global_step=checkpoint)
 
     def log_graph(self, symbol: mx.sym.Symbol):
-        if self.sw is None:
+        if self._writer is None:
             return
-        self.sw.add_graph(symbol)
+        self._writer.add_graph(symbol)
 
     def log_source_embedding(self, embedding: mx.nd.NDArray, checkpoint: int):
-        if self.sw is None or self.source_labels is None:
+        if self._writer is None or self.source_labels is None:
             return
-        self.sw.add_embedding(tag="source", embedding=embedding, labels=self.source_labels, global_step=checkpoint)
+        self._writer.add_embedding(tag="source", embedding=embedding, labels=self.source_labels, global_step=checkpoint)
 
     def log_target_embedding(self, embedding: mx.nd.NDArray, checkpoint: int):
-        if self.sw is None or self.target_labels is None:
+        if self._writer is None or self.target_labels is None:
             return
-        self.sw.add_embedding(tag="target", embedding=embedding, labels=self.target_labels, global_step=checkpoint)
+        self._writer.add_embedding(tag="target", embedding=embedding, labels=self.target_labels, global_step=checkpoint)
 
     def log_output_embedding(self, embedding: mx.nd.NDArray, checkpoint: int):
-        if self.sw is None or self.target_labels is None:
+        if self._writer is None or self.target_labels is None:
             return
-        self.sw.add_embedding(tag="output", embedding=embedding, labels=self.target_labels, global_step=checkpoint)
+        self._writer.add_embedding(tag="output", embedding=embedding, labels=self.target_labels, global_step=checkpoint)
 
 
 class Speedometer:

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -22,6 +22,7 @@ import itertools
 import logging
 import math
 import os
+import pprint
 import random
 import shutil
 import subprocess
@@ -764,6 +765,18 @@ def split(data: mx.nd.NDArray,
     return ndarray_or_list
 
 
+_DTYPE_TO_STRING = {
+    np.float32: 'float32',
+    np.float16: 'float16',
+    np.int8: 'int8',
+    np.int32: 'int32'
+}
+
+
+def _print_dtype(dtype):
+    return _DTYPE_TO_STRING.get(dtype, str(dtype))
+
+
 def log_parameters(params: mx.gluon.ParameterDict):
     """
     Logs information about model parameters.
@@ -774,16 +787,15 @@ def log_parameters(params: mx.gluon.ParameterDict):
     learned_parameter_names = []
     #info = []  # type: List[str]
     for name, param in sorted(params.items()):
-        repr = "%s [%s, %s]" % (name, param.shape, param.dtype)
-        #info.append("%s shape=%s, dtype=%s" % (name, param.shape, param.dtype))
+        repr = "%s [%s, %s]" % (name, param.shape, _print_dtype(param.dtype))
         if param.grad_req == 'null':
             fixed_parameter_names.append(repr)
         else:
             learned_parameter_names.append(repr)
     #percent_fixed = 100 * (fixed_parameters / max(1, total_parameters))
     #percent_learned = 100 * (learned_parameters / max(1, total_parameters))
-    logger.info("Trainable parameters: %s", ", ".join(learned_parameter_names))
-    logger.info("Fixed model parameters: %s", ", ".join(fixed_parameter_names))
+    logger.info("Trainable parameters:\n%s", pprint.pformat(learned_parameter_names))
+    logger.info("Fixed model parameters:\n%s", pprint.pformat(fixed_parameter_names))
     #logger.info("Fixing %d parameters (%0.2f%%)", fixed_parameters, percent_fixed)
     #logger.info("Learning %d parameters (%0.2f%%)", learned_parameters, percent_learned)
     #logger.info("Total # of parameters: %d", total_parameters)


### PR DESCRIPTION
- Re-enables tensorboard logging
- nicer parameter logging for `sockeye.train`
- make ParallelModel threads daemons, causing them to stop once main thread exits (e.g. via KeyboardInterrupt).


#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

