### PR TITLE
Prepare data logging fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.113]
+### Fixed
+- Added logging arguments for prepare_data CLI.
+
 ## [1.18.112]
 ### Added
 - Option to suppress creation of logfiles for CLIs (`--no-logfile`).

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.112'
+__version__ = '1.18.113'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -495,6 +495,8 @@ def add_prepare_data_cli_args(params):
                         required=True,
                         help='Folder where the prepared and possibly sharded data is written to.')
 
+    add_logging_args(params)
+
 
 def add_device_args(params):
     device_params = params.add_argument_group("Device parameters")

--- a/sockeye/prepare_data.py
+++ b/sockeye/prepare_data.py
@@ -28,7 +28,6 @@ logger = logging.getLogger(__name__)
 def main():
     params = argparse.ArgumentParser(description='Preprocesses and shards training data.')
     arguments.add_prepare_data_cli_args(params)
-    arguments.add_logging_args(params)
     args = params.parse_args()
     prepare_data(args)
 

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -395,7 +395,7 @@ def test_tutorial_prepare_data_cli_args(test_params, expected_params):
           num_samples_per_shard=1000000,
           seed=13,
           output='prepared_data',
-	  quiet=False,
+          quiet=False,
           loglevel='INFO',
           no_logfile=False
           ))

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -367,7 +367,10 @@ def test_tutorial_averaging_args(test_params, expected_params, expected_params_p
           min_num_shards=1,
           num_samples_per_shard=1000000,
           seed=13,
-          output='train_data'
+          output='train_data',
+          quiet=False,
+          loglevel='INFO',
+          no_logfile=False
           ))
 ])
 def test_tutorial_prepare_data_cli_args(test_params, expected_params):
@@ -391,7 +394,10 @@ def test_tutorial_prepare_data_cli_args(test_params, expected_params):
           min_num_shards=1,
           num_samples_per_shard=1000000,
           seed=13,
-          output='prepared_data'
+          output='prepared_data',
+	  quiet=False,
+          loglevel='INFO',
+          no_logfile=False
           ))
 ])
 def test_prepare_data_cli_args(test_params, expected_params):


### PR DESCRIPTION
Added a call add_logging_args for prepare_data CLI. This was causing a failure of the call to setup_main_logger with the "console = not args.quiet". Thanks Jonay (@trenous) for signaling it.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

