### PR TITLE
[Sockeye 2] Max seconds were not part of args check

### DIFF
--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -83,6 +83,7 @@ def check_arg_compatibility(args: argparse.Namespace):
     # Require at least one stopping criteria
     check_condition(any((args.max_samples,
                          args.max_updates,
+                         args.max_seconds,
                          args.max_checkpoints,
                          args.max_num_epochs,
                          args.max_num_checkpoint_not_improved)),


### PR DESCRIPTION
This was blocking runs that only have --max-seconds specified.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

