### PR TITLE
[WIP] Sockeye 2 Performance Optimizations

### DIFF
--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -31,6 +31,10 @@ logger = logging.getLogger(__name__)
 class _Inference(ABC):
 
     @abstractmethod
+    def state_structure(self):
+        raise NotImplementedError()
+
+    @abstractmethod
     def encode_and_initialize(self,
                               inputs: mx.nd.NDArray,
                               valid_length: Optional[mx.nd.NDArray] = None):
@@ -91,7 +95,7 @@ class _EnsembleInference(_Inference):
     def state_structure(self) -> str:
         structure = ''
         for model in self._models:
-            structure.append(model.state_structure())
+            structure += model.state_structure()
         return structure
 
     def encode_and_initialize(self, inputs: mx.nd.NDArray, valid_length: Optional[mx.nd.NDArray] = None):

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -270,14 +270,6 @@ class CandidateScorer(mx.gluon.HybridBlock):
         return (scores + bp) * self._lp(lengths)
 
 
-class SortByIndex(mx.gluon.HybridBlock):
-    """
-    A HybridBlock that sorts args by the given indices.
-    """
-    def hybrid_forward(self, F, indices, *args):
-        return [F.take(arg, indices) for arg in args]
-
-
 class SortNormalizeAndUpdateFinished(mx.gluon.HybridBlock):
     """
     A HybridBlock for normalizing newly finished hypotheses scores with LengthPenalty.
@@ -407,15 +399,22 @@ def _repeat_states(states: List, beam_size) -> List:
     return repeated_states
 
 
-def _sort_states(states: List, best_hyp_indices: mx.nd.NDArray) -> List:
-    sorted_states = []
-    for i in range(len(states)):
-        if i < 2:
-            state = mx.nd.take(states[i], best_hyp_indices)
-        else:
-            state = mx.nd.take(states[i], best_hyp_indices, axis=1)
-        sorted_states.append(state)
-    return sorted_states
+class SortStates(mx.gluon.HybridBlock):
+    def hybrid_forward(self, F, best_hyp_indices, *states):
+        sorted_states = []
+        for i in range(len(states)):
+            if i < 2:
+                # Steps and source_bias have batch dimension on axis 0
+                state = F.take(states[i], best_hyp_indices)
+            elif i >= ((len(states) - 2) // 2) + 2:
+                # Decoder layer states have batch dimension on axis 1
+                state = F.take(states[i], best_hyp_indices, axis=1)
+            else:
+                # No need for takes on encoder layer states
+                state = states[i]
+            sorted_states.append(state)
+        return sorted_states
+
 
 
 # TODO (fhieber): add full fp16 decoding with mxnet > 1.5
@@ -457,7 +456,7 @@ class BeamSearch(mx.gluon.Block):
         self.global_avoid_trie = global_avoid_trie
 
         with self.name_scope():
-            self._sort_by_index = SortByIndex(prefix='sort_by_index_')
+            self._sort_states = SortStates(prefix='sort_states_')
             self._update_scores = UpdateScores(prefix='update_scores_')
             self._scorer = scorer
             self._sort_norm_and_update_finished = SortNormalizeAndUpdateFinished(
@@ -671,7 +670,7 @@ class BeamSearch(mx.gluon.Block):
                 break
 
             # (5) update models' state with winning hypotheses (ascending)
-            model_states = _sort_states(model_states, best_hyp_indices)
+            model_states = self._sort_states(best_hyp_indices, *model_states)
 
         logger.debug("Finished after %d out of %d steps.", t, max_iterations)
 

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -64,8 +64,10 @@ class _SingleModelInference(_Inference):
                     states: List,
                     vocab_slice_ids: Optional[mx.nd.NDArray] = None):
         logits, states, _ = self._model.decode_step(step_input, states, vocab_slice_ids)
-        logits = logits.astype('float32', copy=False)
-        scores = -logits if self._skip_softmax else -logits.log_softmax(axis=-1)
+        # TODO: change back to casting first when fp32 safe accumulation is fixed
+        if not self._skip_softmax:
+            logits = logits.log_softmax(axis=-1)
+        scores = -logits.astype('float32', copy=False)
         return scores, states
 
 

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -396,26 +396,22 @@ class SampleK(mx.gluon.HybridBlock):
 
 def _repeat_states(states: List, beam_size) -> List:
     repeated_states = []
-    for state in states:
-        if isinstance(state, List):
-            state = _repeat_states(state, beam_size)
-        elif isinstance(state, mx.nd.NDArray):
-            state = state.repeat(repeats=beam_size, axis=0)
+    for i in range(len(states)):
+        if i < 2:
+            state = states[i].repeat(repeats=beam_size, axis=0)
         else:
-            ValueError("state list can only be nested list or NDArrays")
+            state = states[i].repeat(repeats=beam_size, axis=1)
         repeated_states.append(state)
     return repeated_states
 
 
 def _sort_states(states: List, best_hyp_indices: mx.nd.NDArray) -> List:
     sorted_states = []
-    for state in states:
-        if isinstance(state, List):
-            state = _sort_states(state, best_hyp_indices)
-        elif isinstance(state, mx.nd.NDArray):
-            state = mx.nd.take(state, best_hyp_indices)
+    for i in range(len(states)):
+        if i < 2:
+            state = mx.nd.take(states[i], best_hyp_indices)
         else:
-            ValueError("state list can only be nested list or NDArrays")
+            state = mx.nd.take(states[i], best_hyp_indices, axis=1)
         sorted_states.append(state)
     return sorted_states
 

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -64,7 +64,6 @@ class _SingleModelInference(_Inference):
                     states: List,
                     vocab_slice_ids: Optional[mx.nd.NDArray] = None):
         logits, states, _ = self._model.decode_step(step_input, states, vocab_slice_ids)
-        # TODO: change back to casting first when fp32 safe accumulation is fixed
         if not self._skip_softmax:
             logits = logits.log_softmax(axis=-1)
         scores = -logits

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -166,6 +166,12 @@ CHUNK_SIZE_PER_BATCH_SEGMENT = 500
 BEAM_SEARCH_STOP_FIRST = 'first'
 BEAM_SEARCH_STOP_ALL = 'all'
 
+# State structure constants
+STEP_STATE = 's'
+BIAS_STATE = 'b'
+ENCODER_STATE = 'e'
+DECODER_STATE = 'd'
+
 # Inference Input JSON constants
 JSON_TEXT_KEY = "text"
 JSON_FACTORS_KEY = "factors"

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -173,10 +173,8 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             states = [step, source_mask]
 
             for layer in self.layers:
-                encoder_attention_keys = layer.enc_attention.ff_k(encoder_outputs)
-                encoder_attention_values = layer.enc_attention.ff_v(encoder_outputs)
-                states.append(encoder_attention_keys)
-                states.append(encoder_attention_values)
+                enc_att_kv = layer.enc_attention.ff_kv(encoder_outputs)
+                states.append(enc_att_kv)
         else:
             # NO encoder projection caching
             states = [step, encoder_outputs, source_mask]
@@ -244,7 +242,7 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
 
             if self.inference_only:
                 # pass in cached encoder states
-                encoder_attention_keys_values = states[2:2 + self.config.num_layers * 2]
+                encoder_attention_keys_values = states[2:2 + self.config.num_layers]
                 new_states = [step, states[1]] + encoder_attention_keys_values + self_attention_key_values
             else:
                 encoder_outputs = states[1]
@@ -264,9 +262,8 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             steps, source_mask, *other = states
 
             source_encoded = None  # use constant pre-computed key value projections from the states
-            enc_att_kv = other[:self.config.num_layers * 2]
-            enc_att_kv = [enc_att_kv[i:i + 2] for i in range(0, len(enc_att_kv), 2)]
-            self_att_kv = other[self.config.num_layers * 2:]
+            enc_att_kv = other[:self.config.num_layers]
+            self_att_kv = other[self.config.num_layers:]
         else:
             mask = self.autoregressive_bias(step_input)  # mask: (1, length, length)
 
@@ -274,8 +271,8 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
 
             self_att_kv = other
             
-            enc_att_kv = [(None, None) for _ in range(self.config.num_layers)]
-
+            enc_att_kv = [None for _ in range(self.config.num_layers)]
+        
         # Fold the heads of source_mask (batch_size, num_heads, seq_len) -> (batch_size * num_heads, 1, seq_len)
         source_mask = F.expand_dims(F.reshape(source_mask, shape=(-3, -2)), axis=1)
 
@@ -286,13 +283,13 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             target = F.Dropout(data=target, p=self.config.dropout_prepost)
 
         new_self_att_kv = []  # type: List[Tuple]
-        for layer, _self_att_kv, (enc_att_k, enc_att_v) in zip(self.layers, self_att_kv, enc_att_kv):
+        for layer, _self_att_kv, enc_att_kv in zip(self.layers, self_att_kv, enc_att_kv):
             target, _new_self_att_kv = layer(target,
                                              mask,
                                              source_encoded,
                                              source_mask,
                                              _self_att_kv,
-                                             enc_att_k, enc_att_v)
+                                             enc_att_kv)
             new_self_att_kv.append(_new_self_att_kv)
         target = self.final_process(target, None)
 

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -182,7 +182,7 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             states = [step, encoder_outputs, source_mask]
 
         batch_size = encoder_outputs.shape[0]
-        self_att_key_value_dummies = [mx.nd.zeros((batch_size, 1, 3*self.config.model_size),
+        self_att_key_value_dummies = [mx.nd.zeros((batch_size, 1, 2 * self.config.model_size),
                                                    ctx=encoder_outputs.context,
                                                    dtype=encoder_outputs.dtype)] * self.config.num_layers
         states += self_att_key_value_dummies
@@ -266,13 +266,13 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             source_encoded = None  # use constant pre-computed key value projections from the states
             enc_att_kv = other[:self.config.num_layers * 2]
             enc_att_kv = [enc_att_kv[i:i + 2] for i in range(0, len(enc_att_kv), 2)]
-            self_att_qkv = other[self.config.num_layers * 2:]
+            self_att_kv = other[self.config.num_layers * 2:]
         else:
             mask = self.autoregressive_bias(step_input)  # mask: (1, length, length)
 
             steps, source_encoded, source_mask, *other = states
 
-            self_att_qkv = other
+            self_att_kv = other
             
             enc_att_kv = [(None, None) for _ in range(self.config.num_layers)]
 
@@ -285,18 +285,18 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
         if self.config.dropout_prepost > 0.0:
             target = F.Dropout(data=target, p=self.config.dropout_prepost)
 
-        new_self_att_qkv = []  # type: List[Tuple]
-        for layer, _self_att_qkv, (enc_att_k, enc_att_v) in zip(self.layers, self_att_qkv, enc_att_kv):
-            target, _new_self_att_qkv = layer(target,
-                                              mask,
-                                              source_encoded,
-                                              source_mask,
-                                              _self_att_qkv,
-                                              enc_att_k, enc_att_v)
-            new_self_att_qkv.append(_new_self_att_qkv)
+        new_self_att_kv = []  # type: List[Tuple]
+        for layer, _self_att_kv, (enc_att_k, enc_att_v) in zip(self.layers, self_att_kv, enc_att_kv):
+            target, _new_self_att_kv = layer(target,
+                                             mask,
+                                             source_encoded,
+                                             source_mask,
+                                             _self_att_kv,
+                                             enc_att_k, enc_att_v)
+            new_self_att_kv.append(_new_self_att_kv)
         target = self.final_process(target, None)
 
-        return target, new_self_att_qkv
+        return target, new_self_att_kv
 
     def get_num_hidden(self):
         return self.config.model_size

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -155,8 +155,8 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
     def state_structure(self) -> str:
         """
         Returns the structure of states used for manipulation of the states.
-        Each state is either labeled 's' for step/source_mask (batch-major), 'd' for decoder,
-        or 'e' for encoder.
+        Each state is either labeled 's' for step (batch-major), 'b' for source_mask (batch-major),
+        'd' for decoder (time-major), or 'e' for encoder (time-major).
         """
         structure = ''
         if self.inference_only:

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -278,6 +278,8 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
 
         # target: (batch_size, length, model_size)
         target = self.pos_embedding(step_input, steps)
+        # (length, batch_size, model_size)
+        target = F.transpose(target, axes=(1, 0, 2))
 
         if self.config.dropout_prepost > 0.0:
             target = F.Dropout(data=target, p=self.config.dropout_prepost)
@@ -292,6 +294,7 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
                                              enc_att_kv)
             new_self_att_kv.append(_new_self_att_kv)
         target = self.final_process(target, None)
+        target = F.transpose(target, axes=(1, 0, 2))
 
         return target, new_self_att_kv
 

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -174,13 +174,13 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
 
             for layer in self.layers:
                 enc_att_kv = layer.enc_attention.ff_kv(encoder_outputs)
-                states.append(enc_att_kv)
+                states.append(mx.nd.transpose(enc_att_kv, axes=(1, 0, 2)))
         else:
             # NO encoder projection caching
             states = [step, encoder_outputs, source_mask]
 
         batch_size = encoder_outputs.shape[0]
-        self_att_key_value_dummies = [mx.nd.zeros((batch_size, 1, 2 * self.config.model_size),
+        self_att_key_value_dummies = [mx.nd.zeros((1, batch_size, 2 * self.config.model_size),
                                                    ctx=encoder_outputs.context,
                                                    dtype=encoder_outputs.dtype)] * self.config.num_layers
         states += self_att_key_value_dummies
@@ -285,13 +285,13 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             target = F.Dropout(data=target, p=self.config.dropout_prepost)
 
         new_self_att_kv = []  # type: List[Tuple]
-        for layer, _self_att_kv, enc_att_kv in zip(self.layers, self_att_kv, enc_att_kv):
+        for layer, _self_att_kv, _enc_att_kv in zip(self.layers, self_att_kv, enc_att_kv):
             target, _new_self_att_kv = layer(target,
                                              mask,
                                              source_encoded,
                                              source_mask,
                                              _self_att_kv,
-                                             enc_att_kv)
+                                             _enc_att_kv)
             new_self_att_kv.append(_new_self_att_kv)
         target = self.final_process(target, None)
         target = F.transpose(target, axes=(1, 0, 2))

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -173,7 +173,9 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             states = [step, source_mask]
 
             for layer in self.layers:
+                # (batch_size, source_encoded_max_length, encoder_depth)
                 enc_att_kv = layer.enc_attention.ff_kv(encoder_outputs)
+                # (source_encoded_max_length, batch_size, encoder_depth)
                 states.append(mx.nd.transpose(enc_att_kv, axes=(1, 0, 2)))
         else:
             # NO encoder projection caching

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -182,9 +182,9 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             states = [step, encoder_outputs, source_mask]
 
         batch_size = encoder_outputs.shape[0]
-        self_att_key_value_dummies = [mx.nd.zeros((batch_size, 1, self.config.model_size),
-                                                  ctx=encoder_outputs.context,
-                                                  dtype=encoder_outputs.dtype)] * self.config.num_layers * 2
+        self_att_key_value_dummies = [mx.nd.zeros((batch_size, 1, 3*self.config.model_size),
+                                                   ctx=encoder_outputs.context,
+                                                   dtype=encoder_outputs.dtype)] * self.config.num_layers
         states += self_att_key_value_dummies
 
         return states
@@ -266,16 +266,14 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             source_encoded = None  # use constant pre-computed key value projections from the states
             enc_att_kv = other[:self.config.num_layers * 2]
             enc_att_kv = [enc_att_kv[i:i + 2] for i in range(0, len(enc_att_kv), 2)]
-            self_att_kv = other[self.config.num_layers * 2:]
-            self_att_kv = [self_att_kv[i:i + 2] for i in range(0, len(self_att_kv), 2)]
+            self_att_qkv = other[self.config.num_layers * 2:]
         else:
             mask = self.autoregressive_bias(step_input)  # mask: (1, length, length)
 
             steps, source_encoded, source_mask, *other = states
 
-            self_att_kv = other
-            self_att_kv = [self_att_kv[i:i + 2] for i in range(0, len(self_att_kv), 2)]
-
+            self_att_qkv = other
+            
             enc_att_kv = [(None, None) for _ in range(self.config.num_layers)]
 
         # Fold the heads of source_mask (batch_size, num_heads, seq_len) -> (batch_size * num_heads, 1, seq_len)
@@ -287,18 +285,18 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
         if self.config.dropout_prepost > 0.0:
             target = F.Dropout(data=target, p=self.config.dropout_prepost)
 
-        new_self_att_kv = []  # type: List[Tuple]
-        for layer, (self_att_k, self_att_v), (enc_att_k, enc_att_v) in zip(self.layers, self_att_kv, enc_att_kv):
-            target, new_self_att_k, new_self_att_v = layer(target,
-                                                           mask,
-                                                           source_encoded,
-                                                           source_mask,
-                                                           self_att_k, self_att_v,
-                                                           enc_att_k, enc_att_v)
-            new_self_att_kv += [new_self_att_k, new_self_att_v]
+        new_self_att_qkv = []  # type: List[Tuple]
+        for layer, _self_att_qkv, (enc_att_k, enc_att_v) in zip(self.layers, self_att_qkv, enc_att_kv):
+            target, _new_self_att_qkv = layer(target,
+                                              mask,
+                                              source_encoded,
+                                              source_mask,
+                                              _self_att_qkv,
+                                              enc_att_k, enc_att_v)
+            new_self_att_qkv.append(_new_self_att_qkv)
         target = self.final_process(target, None)
 
-        return target, new_self_att_kv
+        return target, new_self_att_qkv
 
     def get_num_hidden(self):
         return self.config.model_size

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -83,7 +83,7 @@ class Decoder(mx.gluon.Block):
         super().__init__()
 
     @abstractmethod
-    def state_structure(self):
+    def state_structure(self) -> str:
         raise NotImplementedError()
 
     @abstractmethod
@@ -152,7 +152,7 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
                                                                      prefix="final_process_",
                                                                      num_hidden=self.config.model_size)
 
-    def state_structure(self):
+    def state_structure(self) -> str:
         """
         Returns the structure of states used for manipulation of the states.
         Each state is either labeled 's' for step/source_mask (batch-major), 'd' for decoder,
@@ -160,10 +160,10 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
         """
         structure = ''
         if self.inference_only:
-            structure += 'ss' + 'e' * self.config.num_layers
+            structure += C.STEP_STATE + C.BIAS_STATE + C.ENCODER_STATE * self.config.num_layers
         else:
-            structure += 'ses'
-        structure += 'd' * self.config.num_layers
+            structure += C.STEP_STATE + C.ENCODER_STATE + C.BIAS_STATE
+        structure += C.DECODER_STATE * self.config.num_layers
 
         return structure
 

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -324,11 +324,13 @@ class TransformerEncoder(Encoder, mx.gluon.HybridBlock):
 
         # (batch_size * heads, 1, seq_len)
         bias = F.expand_dims(self.valid_length_mask(data, valid_length), axis=1)
+        data = F.transpose(data, axes=(1, 0, 2))
 
         for block in self.layers:
             data = block(data, bias)
 
         data = self.final_process(data, None)
+        data = F.transpose(data, axes=(1, 0, 2))
         return data, valid_length
 
     def get_num_hidden(self) -> int:

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -324,12 +324,14 @@ class TransformerEncoder(Encoder, mx.gluon.HybridBlock):
 
         # (batch_size * heads, 1, seq_len)
         bias = F.expand_dims(self.valid_length_mask(data, valid_length), axis=1)
+        # (seq_len, batch_size, depth)
         data = F.transpose(data, axes=(1, 0, 2))
 
         for block in self.layers:
             data = block(data, bias)
 
         data = self.final_process(data, None)
+        # (batch_size, seq_len, depth)
         data = F.transpose(data, axes=(1, 0, 2))
         return data, valid_length
 

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -32,6 +32,7 @@ from . import utils
 from . import vocab
 from .beam_search import get_beam_search, CandidateScorer
 from .model import SockeyeModel
+from .transformer import TransformerEncoderBlock, TransformerDecoderBlock
 
 logger = logging.getLogger(__name__)
 
@@ -700,6 +701,20 @@ class Translator:
         if strip_unknown_words:
             self.strip_ids.add(self.unk_id)
         self.models = models
+
+        # interleave qkv with heads for fast attention inference
+        for model in self.models:
+            for layer in [l for l in model.encoder.layers] + [l for l in model.decoder.layers]:
+                if isinstance(layer, TransformerEncoderBlock) or isinstance(layer, TransformerDecoderBlock):
+                    proj_weight = layer.self_attention.ff_in.weight
+                    num_heads = layer.self_attention.heads
+                    q_weight, k_weight, v_weight = mx.nd.split(proj_weight.data(), num_outputs=3, axis=0)
+                    q_weight = q_weight.reshape(shape=(num_heads, -1, 0), reverse=True)
+                    k_weight = k_weight.reshape(shape=(num_heads, -1, 0), reverse=True)
+                    v_weight = v_weight.reshape(shape=(num_heads, -1, 0), reverse=True)
+                    tot_weight = mx.nd.concat(q_weight, k_weight, v_weight, dim=-2)
+                    tot_weight = mx.nd.reshape(tot_weight, shape=(-1, 0), reverse=True)
+                    proj_weight.set_data(tot_weight.astype(proj_weight.dtype))
 
         # after models are loaded we ensured that they agree on max_input_length, max_output_length and batch size
         # set a common max_output length for all models.

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -709,11 +709,11 @@ class Translator:
                     proj_weight = layer.self_attention.ff_in.weight
                     num_heads = layer.self_attention.heads
                     q_weight, k_weight, v_weight = mx.nd.split(proj_weight.data(), num_outputs=3, axis=0)
-                    q_weight = q_weight.reshape(shape=(num_heads, -1, 0), reverse=True)
                     k_weight = k_weight.reshape(shape=(num_heads, -1, 0), reverse=True)
                     v_weight = v_weight.reshape(shape=(num_heads, -1, 0), reverse=True)
-                    tot_weight = mx.nd.concat(q_weight, k_weight, v_weight, dim=-2)
-                    tot_weight = mx.nd.reshape(tot_weight, shape=(-1, 0), reverse=True)
+                    kv_weight = mx.nd.concat(k_weight, v_weight, dim=-2)
+                    kv_weight = mx.nd.reshape(kv_weight, shape=(-1, 0), reverse=True)
+                    tot_weight = mx.nd.concat(q_weight, kv_weight, dim=0)
                     proj_weight.set_data(tot_weight.astype(proj_weight.dtype))
 
         # after models are loaded we ensured that they agree on max_input_length, max_output_length and batch size

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -917,7 +917,7 @@ class Translator:
         lengths = [len(inp) for inp in trans_inputs]
         source_length = mx.nd.array(lengths, ctx=self.context, dtype='float32')  # shape: (batch_size,)
         max_length = max(len(inp) for inp in trans_inputs)
-        source = mx.nd.zeros((batch_size, max_length, self.num_source_factors), ctx=self.context, dtype='float32')
+        source_npy = np.zeros((batch_size, max_length, self.num_source_factors), dtype=np.float32)
 
         restrict_lexicon = None  # type: Optional[lexicon.TopKLexicon]
         raw_constraints = [None] * batch_size  # type: List[Optional[constrained.RawConstraintList]]
@@ -927,7 +927,7 @@ class Translator:
         for j, trans_input in enumerate(trans_inputs):
             num_tokens = len(trans_input)  # includes eos
             max_output_lengths.append(self._get_max_output_length(num_tokens))
-            source[j, :num_tokens, 0] = data_io.tokens2ids(trans_input.tokens, self.source_vocabs[0])
+            source_npy[j, :num_tokens, 0] = data_io.tokens2ids(trans_input.tokens, self.source_vocabs[0])
 
             factors = trans_input.factors if trans_input.factors is not None else []
             num_factors = 1 + len(factors)
@@ -937,7 +937,7 @@ class Translator:
             for i, factor in enumerate(factors[:self.num_source_factors - 1], start=1):
                 # fill in as many factors as there are tokens
 
-                source[j, :num_tokens, i] = data_io.tokens2ids(factor, self.source_vocabs[i])[:num_tokens]
+                source_npy[j, :num_tokens, i] = data_io.tokens2ids(factor, self.source_vocabs[i])[:num_tokens]
 
             # Check if vocabulary selection/restriction is enabled:
             # - First, see if the translator input provides a lexicon (used for multiple lexicons)
@@ -969,6 +969,8 @@ class Translator:
                 if any(self.unk_id in phrase for phrase in raw_avoid_list[j]):
                     logger.warning("Sentence %s: %s was found in the list of phrases to avoid; "
                                    "this may indicate improper preprocessing.", trans_input.sentence_id, C.UNK_SYMBOL)
+
+        source = mx.nd.array(source_npy, ctx=self.context)
 
         return source, source_length, restrict_lexicon, raw_constraints, raw_avoid_list, \
                 mx.nd.array(max_output_lengths, ctx=self.context, dtype='int32')

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -915,7 +915,7 @@ class Translator:
         """
         batch_size = len(trans_inputs)
         lengths = [len(inp) for inp in trans_inputs]
-        source_length = mx.nd.array(lengths, ctx=self.context, dtype='float32')  # shape: (batch_size,)
+        source_length = mx.nd.array(lengths, ctx=self.context, dtype=self.dtype)  # shape: (batch_size,)
         max_length = max(len(inp) for inp in trans_inputs)
         source_npy = np.zeros((batch_size, max_length, self.num_source_factors), dtype=np.float32)
 

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -413,7 +413,7 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
                        inputs: mx.sym.Symbol,
                        input_lengths: Optional[mx.sym.Symbol] = None,
                        bias: Optional[mx.sym.Symbol] = None,
-                       previous_qkv: Optional[mx.sym.Symbol] = None):  # mypy: ignore
+                       previous_kv: Optional[mx.sym.Symbol] = None):  # mypy: ignore
         """
         Computes multi-head attention on a set of inputs, serving as queries, keys, and values.
         If sequence lengths are provided, they will be used to mask the attention scores.
@@ -429,33 +429,30 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
         :return: Symbol of shape (batch, max_length, output_depth).
         """
 
-
         proj = self.ff_in(F.transpose(inputs, axes=(1, 0, 2)))
+        queries, kv_1, kv_2 = F.split(proj, num_outputs=3, axis=2)
+        kv = F.concat(kv_1, kv_2, dim=2)
 
-        qkv = proj
-        if previous_qkv is not None:
-            previous_qkv = F.transpose(previous_qkv, axes=(1, 0, 2))
-            proj = F.concat(previous_qkv, proj, dim=0)
-            qkv = F.slice(proj, begin=(1, None, None), end=(None, None, None))
+        updated_kv = kv
+        if previous_kv is not None:
+            previous_kv = F.transpose(previous_kv, axes=(1, 0, 2))
+            updated_kv = F.concat(previous_kv, kv, dim=0)
+            kv = F.slice(updated_kv, begin=(1, None, None), end=(None, None, None))
 
-        score = F.interleaved_matmul_selfatt_qk(qkv, heads=self.heads)
+        score = F.interleaved_matmul_encdec_qk(queries, kv, heads=self.heads)
 
         if bias is not None:
             score = F.broadcast_add(score, bias)
 
         probs = F.softmax(score, axis=-1)
 
-        contexts = F.interleaved_matmul_selfatt_valatt(qkv, probs, heads=self.heads)
+        contexts = F.interleaved_matmul_encdec_valatt(kv, probs, heads=self.heads)
 
-        updated_qkv = F.transpose(proj, axes=(1, 0, 2))
-
-        if previous_qkv is not None:
-            contexts = F.slice(contexts, begin=(-1, None, None), end=(None, None, None))
-
+        updated_kv = F.transpose(updated_kv, axes=(1, 0, 2))
         contexts = F.transpose(contexts, axes=(1, 0, 2))
 
         out = self.ff_out(contexts)
-        return out, updated_qkv
+        return out, updated_kv
 
         """
         # combined: (batch, max_length, depth * 3)

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -429,7 +429,7 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
         :return: Symbol of shape (batch, max_length, output_depth).
         """
 
-        proj = self.ff_in(F.transpose(inputs, axes=(1, 0, 2)))
+        proj = self.ff_in(inputs)
         queries, kv_1, kv_2 = F.split(proj, num_outputs=3, axis=2)
         kv = F.concat(kv_1, kv_2, dim=2)
 
@@ -449,7 +449,6 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
         contexts = F.interleaved_matmul_encdec_valatt(kv, probs, heads=self.heads)
 
         updated_kv = F.transpose(updated_kv, axes=(1, 0, 2))
-        contexts = F.transpose(contexts, axes=(1, 0, 2))
 
         return self.ff_out(contexts), updated_kv
 
@@ -511,7 +510,7 @@ class MultiHeadAttention(MultiHeadAttentionBase):
         :return: Symbol of shape (batch, query_seq_len, output_depth).
         """
 
-        queries = self.ff_q(F.transpose(queries, axes=(1, 0, 2)))
+        queries = self.ff_q(queries)
 
         # TODO: check whether memory has proper shape/structure for self.ff_kv projection
         kv = projected_memory_kv if projected_memory_kv is not None else self.ff_kv(F.transpose(memory, axes=(1, 0, 2)))
@@ -525,7 +524,6 @@ class MultiHeadAttention(MultiHeadAttentionBase):
         probs = F.softmax(score, axis=-1)
 
         contexts = F.interleaved_matmul_encdec_valatt(kv, probs, heads=self.heads)
-        contexts = F.transpose(contexts, axes=(1, 0, 2))
 
         return self.ff_out(contexts)
 

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -413,8 +413,7 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
                        inputs: mx.sym.Symbol,
                        input_lengths: Optional[mx.sym.Symbol] = None,
                        bias: Optional[mx.sym.Symbol] = None,
-                       previous_keys: Optional[mx.sym.Symbol] = None,
-                       previous_values: Optional[mx.sym.Symbol] = None):  # mypy: ignore
+                       previous_qkv: Optional[mx.sym.Symbol] = None):  # mypy: ignore
         """
         Computes multi-head attention on a set of inputs, serving as queries, keys, and values.
         If sequence lengths are provided, they will be used to mask the attention scores.
@@ -428,6 +427,36 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
         :param previous_keys: Optional previous input projections of keys. Shape: (batch, max_length+1, depth_att).
         :param previous_values: Optional previous input projections of values. Shape: (batch, max_length+1, depth_att).
         :return: Symbol of shape (batch, max_length, output_depth).
+        """
+
+
+        proj = self.ff_in(F.transpose(inputs, axes=(1, 0, 2)))
+
+        qkv = proj
+        if previous_qkv is not None:
+            previous_qkv = F.transpose(previous_qkv, axes=(1, 0, 2))
+            proj = F.concat(previous_qkv, proj, dim=0)
+            qkv = F.slice(proj, begin=(1, None, None), end=(None, None, None))
+
+        score = F.interleaved_matmul_selfatt_qk(qkv, heads=self.heads)
+
+        if bias is not None:
+            score = F.broadcast_add(score, bias)
+
+        probs = F.softmax(score, axis=-1)
+
+        contexts = F.interleaved_matmul_selfatt_valatt(qkv, probs, heads=self.heads)
+
+        updated_qkv = F.transpose(proj, axes=(1, 0, 2))
+
+        if previous_qkv is not None:
+            contexts = F.slice(contexts, begin=(-1, None, None), end=(None, None, None))
+
+        contexts = F.transpose(contexts, axes=(1, 0, 2))
+
+        out = self.ff_out(contexts)
+        return out, updated_qkv
+
         """
         # combined: (batch, max_length, depth * 3)
         combined = self.ff_in(inputs)
@@ -447,6 +476,7 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
             values = _remove_first_step(F, updated_values)
 
         return self._attend(F, queries, keys, values, lengths=input_lengths, bias=bias), updated_keys, updated_values
+        """
 
 
 def _remove_first_step(F, data):

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -224,40 +224,6 @@ class LengthRatio(mx.gluon.HybridBlock):
         return F.squeeze(data)
 
 
-def split_heads(F, x: mx.sym.Symbol, depth_per_head: int, heads: int) -> mx.sym.Symbol:
-    """
-    Returns a symbol with head dimension folded into batch and depth divided by the number of heads.
-
-    :param x: Symbol of shape (batch, length, depth).
-    :param depth_per_head: Depth per head.
-    :param heads: Number of heads.
-    :return: Symbol of shape (batch * heads, length, depth_per_heads).
-    """
-    # (batch, length, heads, depth_per_head)
-    x = F.reshape(x, shape=(0, -1, heads, depth_per_head))
-    # (batch, heads, length, depth/heads)
-    x = F.transpose(x, axes=(0, 2, 1, 3))
-    # (batch * heads, length, depth/heads)
-    return F.reshape(x, shape=(-3, -1, depth_per_head))
-
-
-def combine_heads(F, x: mx.sym.Symbol, depth_per_head: int, heads: int) -> mx.sym.Symbol:
-    """
-    Returns a symbol with both batch & length, and head & depth dimensions combined.
-
-    :param x: Symbol of shape (batch * heads, length, depth_per_head).
-    :param depth_per_head: Depth per head.
-    :param heads: Number of heads.
-    :return: Symbol of shape (batch, length, depth).
-    """
-    # (batch, heads, length, depth_per_head)
-    x = F.reshape(x, shape=(-4, -1, heads, 0, depth_per_head))
-    # (batch, length, heads, depth_per_head)
-    x = F.transpose(x, axes=(0, 2, 1, 3))
-    # (batch, length, depth)
-    return F.reshape(x, shape=(-1, 0, depth_per_head * heads))
-
-
 def broadcast_to_heads(F, x: mx.sym.Symbol, num_heads: int, ndim: int, fold_heads: bool = True) -> mx.sym.Symbol:
     """
     Broadcasts batch-major input of shape (batch, d1 ... dn-1) to (batch*heads, d1 ... dn-1).
@@ -423,21 +389,11 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
 
         updated_kv = kv
         if previous_kv is not None:
-            previous_kv = F.transpose(previous_kv, axes=(1, 0, 2))
             updated_kv = F.concat(previous_kv, kv, dim=0)
+            # TODO: remove slicing and initialize with empty array when available in 1.6
             kv = F.slice(updated_kv, begin=(1, None, None), end=(None, None, None))
-        updated_kv = F.transpose(updated_kv, axes=(1, 0, 2))
 
         return self._attend(F, queries, kv, lengths=input_lengths, bias=bias), updated_kv
-
-
-def _remove_first_step(F, data):
-    """
-    :param F: MXNet namespace.
-    :param data: Input data. Shape: (batch, length, num_hidden).
-    :return: Output data. Shape: (batch, length[1:], num_hidden
-    """
-    return F.slice(data, begin=(None, 1, None), end=(None, None, None))
 
 
 class MultiHeadAttention(MultiHeadAttentionBase):
@@ -491,8 +447,7 @@ class MultiHeadAttention(MultiHeadAttentionBase):
         queries = self.ff_q(queries)
 
         # TODO: check whether memory has proper shape/structure for self.ff_kv projection
-        kv = projected_memory_kv if projected_memory_kv is not None else self.ff_kv(F.transpose(memory, axes=(1, 0, 2)))
-        kv = F.transpose(kv, axes=(1, 0, 2))
+        kv = projected_memory_kv if projected_memory_kv is not None else self.ff_kv(memory)
 
         return self._attend(F, queries, kv, bias=bias, lengths=memory_lengths)
 

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -262,7 +262,7 @@ class DotAttentionCell(mx.gluon.HybridBlock):
 
     def hybrid_forward(self, F, queries, key_values, heads, lengths=None, bias=None):
 
-        logits = F.interleaved_matmul_encdec_qk(queries, key_values, heads=heads)
+        logits = F.contrib.interleaved_matmul_encdec_qk(queries, key_values, heads=heads)
 
         # TODO(fhieber): consider softmax with length argument once available.
         # TODO(fhieber: Also see https://github.com/dmlc/gluon-nlp/pull/910
@@ -282,7 +282,7 @@ class DotAttentionCell(mx.gluon.HybridBlock):
         probs = F.softmax(logits, axis=-1)
         probs = F.Dropout(probs, p=self.dropout) if self.dropout > 0.0 else probs
 
-        return F.interleaved_matmul_encdec_valatt(key_values, probs, heads=heads)
+        return F.contrib.interleaved_matmul_encdec_valatt(key_values, probs, heads=heads)
 
 
 class MultiHeadAttentionBase(mx.gluon.HybridBlock):
@@ -418,9 +418,7 @@ class MultiHeadAttention(MultiHeadAttentionBase):
         super().__init__(prefix, depth_att, heads, depth_out, dropout)
 
         with self.name_scope():
-            self.ff_q = mx.gluon.nn.Dense(in_units=depth_out, units=depth_att, flatten=False, use_bias=False, prefix='q2h_')
-            self.ff_k = mx.gluon.nn.Dense(in_units=depth_key_value, units=depth_att, flatten=False, use_bias=False, prefix='k2h_')
-            self.ff_v = mx.gluon.nn.Dense(in_units=depth_key_value, units=depth_att, flatten=False, use_bias=False, prefix='v2h_')
+            self.ff_q = mx.gluon.nn.Dense(units=depth_att, flatten=False, use_bias=False, prefix='q2h_')
             self.ff_kv = mx.gluon.nn.Dense(in_units=depth_key_value, units=2*depth_att, flatten=False, use_bias=False, prefix='kv2h_')
 
     def hybrid_forward(self, F,

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -294,9 +294,9 @@ class DotAttentionCell(mx.gluon.HybridBlock):
         self._dtype = dtype
         super().cast(dtype)
 
-    def hybrid_forward(self, F, queries, keys, values, lengths=None, bias=None):
-        # (n, lq, lk)
-        logits = F.batch_dot(lhs=queries, rhs=keys, transpose_b=True)
+    def hybrid_forward(self, F, queries, key_values, heads, lengths=None, bias=None):
+
+        logits = F.interleaved_matmul_encdec_qk(queries, key_values, heads=heads)
 
         # TODO(fhieber): consider softmax with length argument once available.
         # TODO(fhieber: Also see https://github.com/dmlc/gluon-nlp/pull/910
@@ -310,15 +310,13 @@ class DotAttentionCell(mx.gluon.HybridBlock):
                                     value=-C.LARGE_VALUES[self._dtype])
             # (n, lq, lk)
             logits = F.transpose(data=logits, axes=(1, 2, 0))
-
         if bias is not None:
             logits = F.broadcast_add(logits, bias)
 
         probs = F.softmax(logits, axis=-1)
         probs = F.Dropout(probs, p=self.dropout) if self.dropout > 0.0 else probs
 
-        # (n, lq, lk) x (n, lk, dv) -> (n, lq, dv)
-        return F.batch_dot(lhs=probs, rhs=values)
+        return F.interleaved_matmul_encdec_valatt(key_values, probs, heads=heads)
 
 
 class MultiHeadAttentionBase(mx.gluon.HybridBlock):
@@ -352,8 +350,7 @@ class MultiHeadAttentionBase(mx.gluon.HybridBlock):
     def _attend(self,
                 F,
                 queries: mx.sym.Symbol,
-                keys: mx.sym.Symbol,
-                values: mx.sym.Symbol,
+                key_values: mx.sym.Symbol,
                 lengths: Optional[mx.sym.Symbol] = None,
                 bias: Optional[mx.sym.Symbol] = None) -> mx.sym.Symbol:
         """
@@ -366,22 +363,13 @@ class MultiHeadAttentionBase(mx.gluon.HybridBlock):
         :param bias: Optional 3d bias.
         :return: Context vectors. Shape: (batch_size, query_max_length, output_depth).
         """
-        # scale by sqrt(depth_per_head)
-        queries = queries * (self.depth_per_head ** -0.5)
 
-        # (batch*heads, length, depth/heads)
-        queries = split_heads(F, queries, self.depth_per_head, self.heads)
-        keys = split_heads(F, keys, self.depth_per_head, self.heads)
-        values = split_heads(F, values, self.depth_per_head, self.heads)
         lengths = broadcast_to_heads(F, lengths, self.heads, ndim=1, fold_heads=True) if lengths is not None else lengths
 
-        # (batch*heads, query_max_length, depth_per_head)
-        contexts = self.dot_att(queries, keys, values, lengths, bias)
+        # (query_max_length, batch, depth)
+        contexts = self.dot_att(queries, key_values, self.heads, lengths, bias)
 
-        # (batch, query_max_length, depth)
-        contexts = combine_heads(F, contexts, self.depth_per_head, self.heads)
-
-        # contexts: (batch, query_max_length, output_depth)
+        # (query_max_length, batch, output_depth)
         contexts = self.ff_out(contexts)
 
         return contexts
@@ -438,19 +426,9 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
             previous_kv = F.transpose(previous_kv, axes=(1, 0, 2))
             updated_kv = F.concat(previous_kv, kv, dim=0)
             kv = F.slice(updated_kv, begin=(1, None, None), end=(None, None, None))
-
-        score = F.interleaved_matmul_encdec_qk(queries, kv, heads=self.heads)
-
-        if bias is not None:
-            score = F.broadcast_add(score, bias)
-
-        probs = F.softmax(score, axis=-1)
-
-        contexts = F.interleaved_matmul_encdec_valatt(kv, probs, heads=self.heads)
-
         updated_kv = F.transpose(updated_kv, axes=(1, 0, 2))
 
-        return self.ff_out(contexts), updated_kv
+        return self._attend(F, queries, kv, lengths=input_lengths, bias=bias), updated_kv
 
 
 def _remove_first_step(F, data):
@@ -516,25 +494,7 @@ class MultiHeadAttention(MultiHeadAttentionBase):
         kv = projected_memory_kv if projected_memory_kv is not None else self.ff_kv(F.transpose(memory, axes=(1, 0, 2)))
         kv = F.transpose(kv, axes=(1, 0, 2))
 
-        score = F.interleaved_matmul_encdec_qk(queries, kv, heads=self.heads)
-
-        if bias is not None:
-            score = F.broadcast_add(score, bias)
-
-        probs = F.softmax(score, axis=-1)
-
-        contexts = F.interleaved_matmul_encdec_valatt(kv, probs, heads=self.heads)
-
-        return self.ff_out(contexts)
-
-        """
-        # (batch, query_max_length, depth)
-        queries = self.ff_q(queries)
-        keys = projected_memory_keys if projected_memory_keys is not None else self.ff_k(memory)
-        values = projected_memory_values if projected_memory_values is not None else self.ff_v(memory)
-
-        return self._attend(F, queries, keys, values, bias=bias, lengths=memory_lengths)
-        """
+        return self._attend(F, queries, kv, bias=bias, lengths=memory_lengths)
 
 
 class PlainDotAttention(mx.gluon.HybridBlock):

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -460,10 +460,9 @@ def load_model(model_folder: str,
         cast_dtype = True
         dtype_source = 'current'
 
-    # TODO: change allow_missing back to false when fast attention is implemented for training
     model.load_parameters(filename=params_fname,
                           ctx=context,
-                          allow_missing=True,
+                          allow_missing=False,
                           ignore_extra=False,
                           cast_dtype=cast_dtype,
                           dtype_source=dtype_source)

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -457,9 +457,10 @@ def load_model(model_folder: str,
         cast_dtype = True
         dtype_source = 'current'
 
+    # TODO: change allow_missing back to false when fast attention is implemented for training
     model.load_parameters(filename=params_fname,
                           ctx=context,
-                          allow_missing=False,
+                          allow_missing=True,
                           ignore_extra=False,
                           cast_dtype=cast_dtype,
                           dtype_source=dtype_source)

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -134,6 +134,9 @@ class SockeyeModel(mx.gluon.Block):
         self.dtype = dtype
         super().cast(dtype)
 
+    def state_structure(self):
+        return self.decoder.state_structure()
+
     def encode(self, inputs, valid_length=None):
         """Encode the input sequence.
 

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -178,8 +178,7 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
                        source: mx.sym.Symbol,
                        source_bias: mx.sym.Symbol,
                        self_att_kv: Optional[mx.sym.Symbol] = None,
-                       enc_att_k: Optional[mx.sym.Symbol] = None,
-                       enc_att_v: Optional[mx.sym.Symbol] = None) -> Tuple[mx.sym.Symbol,
+                       enc_att_kv: Optional[mx.sym.Symbol] = None) -> Tuple[mx.sym.Symbol,
                                                                            mx.sym.Symbol,
                                                                            mx.sym.Symbol]:
         # self-attention
@@ -194,8 +193,7 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
                                             source,
                                             None,
                                             source_bias,
-                                            enc_att_k,
-                                            enc_att_v)
+                                            enc_att_kv)
         target = self.post_enc_attention(target_enc_att, target)
 
         # feed-forward

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -182,10 +182,10 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
                                                                            mx.sym.Symbol,
                                                                            mx.sym.Symbol]:
         # self-attention
-        target_self_att, kv = self.self_attention(self.pre_self_attention(target, None),
-                                                  None,
-                                                  target_bias,
-                                                  self_att_kv)
+        target_self_att, keys_values = self.self_attention(self.pre_self_attention(target, None),
+                                                           None,
+                                                           target_bias,
+                                                           self_att_kv)
         target = self.post_self_attention(target_self_att, target)
 
         # encoder attention
@@ -203,7 +203,7 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
         if self.lhuc:
             target = self.lhuc(target)
 
-        return target, kv
+        return target, keys_values
 
 
 class TransformerProcessBlock(mx.gluon.nn.HybridBlock):

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -177,16 +177,16 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
                        target_bias: mx.sym.Symbol,
                        source: mx.sym.Symbol,
                        source_bias: mx.sym.Symbol,
-                       self_att_qkv: Optional[mx.sym.Symbol] = None,
+                       self_att_kv: Optional[mx.sym.Symbol] = None,
                        enc_att_k: Optional[mx.sym.Symbol] = None,
                        enc_att_v: Optional[mx.sym.Symbol] = None) -> Tuple[mx.sym.Symbol,
                                                                            mx.sym.Symbol,
                                                                            mx.sym.Symbol]:
         # self-attention
-        target_self_att, qkv = self.self_attention(self.pre_self_attention(target, None),
-                                                   None,
-                                                   target_bias,
-                                                   self_att_qkv)
+        target_self_att, kv = self.self_attention(self.pre_self_attention(target, None),
+                                                  None,
+                                                  target_bias,
+                                                  self_att_kv)
         target = self.post_self_attention(target_self_att, target)
 
         # encoder attention
@@ -205,7 +205,7 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
         if self.lhuc:
             target = self.lhuc(target)
 
-        return target, qkv
+        return target, kv
 
 
 class TransformerProcessBlock(mx.gluon.nn.HybridBlock):

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -179,7 +179,6 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
                        source_bias: mx.sym.Symbol,
                        self_att_kv: Optional[mx.sym.Symbol] = None,
                        enc_att_kv: Optional[mx.sym.Symbol] = None) -> Tuple[mx.sym.Symbol,
-                                                                           mx.sym.Symbol,
                                                                            mx.sym.Symbol]:
         # self-attention
         target_self_att, keys_values = self.self_attention(self.pre_self_attention(target, None),

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -101,7 +101,7 @@ class TransformerEncoderBlock(mx.gluon.HybridBlock):
 
     def hybrid_forward(self, F, data: mx.sym.Symbol, bias: mx.sym.Symbol) -> mx.sym.Symbol:
         # self-attention
-        data_self_att, _, __ = self.self_attention(self.pre_self_attention(data, None), None, bias, None, None)
+        data_self_att, _ = self.self_attention(self.pre_self_attention(data, None), None, bias, None)
         data = self.post_self_attention(data_self_att, data)
 
         # feed-forward
@@ -177,18 +177,16 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
                        target_bias: mx.sym.Symbol,
                        source: mx.sym.Symbol,
                        source_bias: mx.sym.Symbol,
-                       self_att_k: Optional[mx.sym.Symbol] = None,
-                       self_att_v: Optional[mx.sym.Symbol] = None,
+                       self_att_qkv: Optional[mx.sym.Symbol] = None,
                        enc_att_k: Optional[mx.sym.Symbol] = None,
                        enc_att_v: Optional[mx.sym.Symbol] = None) -> Tuple[mx.sym.Symbol,
                                                                            mx.sym.Symbol,
                                                                            mx.sym.Symbol]:
         # self-attention
-        target_self_att, keys, values = self.self_attention(self.pre_self_attention(target, None),
-                                                            None,
-                                                            target_bias,
-                                                            self_att_k,
-                                                            self_att_v)
+        target_self_att, qkv = self.self_attention(self.pre_self_attention(target, None),
+                                                   None,
+                                                   target_bias,
+                                                   self_att_qkv)
         target = self.post_self_attention(target_self_att, target)
 
         # encoder attention
@@ -207,7 +205,7 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
         if self.lhuc:
             target = self.lhuc(target)
 
-        return target, keys, values
+        return target, qkv
 
 
 class TransformerProcessBlock(mx.gluon.nn.HybridBlock):


### PR DESCRIPTION
Made changes to Sockeye 2 to improve the performance of the Transformer model in machine translation. Current changes only apply to inference; optimizations to training are planned for later but before completion of the pull request.

A list of changes detailed below:
1. Replaced the `batch_dot` ops in multihead attention with ops that do not require folding heads in with batch dimension; one caveat is that batch and sequence_length dimensions are swapped, requiring some adjustments to other parts of the code to account for the change
2. Removed the `take` ops that were applied to the encoder states, as they do not change on different beams; this effectively cuts compute time for these `take`s in half
3. Gathered the input token ids into a numpy array on CPU before sending them all to the GPU at the beginning of beam search, rather than sending each batch element to the GPU one at a time
4. Set the data type of arrays during beam search computation to match the model's data type, rather than explicitly setting it to fp32

#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

