### PR TITLE
Made mxnet random seeding device-independent.

### DIFF
--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -757,8 +757,6 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
             # Do not keep redundant copies of the checkpoint history
             args.keep_last_params = 1
 
-    utils.seed_rngs(args.seed)
-
     check_arg_compatibility(args)
     output_folder = os.path.abspath(args.output)
     resume_training = check_resume(args, output_folder)
@@ -788,6 +786,8 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
                                                                  "divisible by the number of devices. Choose a batch "
                                                                  "size that is a multiple of %d." % len(context))
         logger.info("Training Device(s): %s", ", ".join(str(c) for c in context))
+
+        utils.seed_rngs(args.seed, ctx=context)
 
         train_iter, eval_iter, config_data, source_vocabs, target_vocab = create_data_iters_and_vocabs(
             args=args,

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -101,15 +101,27 @@ def log_basic_info(args) -> None:
     logger.info("Arguments: %s", args)
 
 
-def seed_rngs(seed: int) -> None:
+def seed_rngs(seed: int, ctx: Optional[Union[mx.Context, List[mx.Context]]] = None) -> None:
     """
-    Seed the random number generators (Python, Numpy and MXNet)
+    Seed the random number generators (Python, Numpy and MXNet).
 
     :param seed: The random seed.
+    :param ctx: Random number generators in MXNet are device specific.
+           If None, MXNet will set the state of each generator of each device using seed and device id. This will lead
+           to different results on different devices. If ctx is provided, this function will seed
+           device-specific generators with a fixed offset. E.g. for 2 devices and seed=13, seed for gpu(0) will be 13,
+           14 for gpu(1). See https://beta.mxnet.io/api/gluon-related/_autogen/mxnet.random.seed.html.
     """
+    logger.info("Random seed: %d", seed)
     np.random.seed(seed)
     random.seed(seed)
-    mx.random.seed(seed)
+    if ctx is None:
+        mx.random.seed(seed, ctx='all')
+    else:
+        if isinstance(ctx, mx.Context):
+            ctx = [ctx]
+        for i, c in enumerate(ctx):
+            mx.random.seed(seed + i, ctx=c)
 
 
 def check_condition(condition: bool, error_message: str):


### PR DESCRIPTION
Made mxnet random seeding device-independent. Generators are still different across devices, but now independent of the device ID, i.e. training on GPUs 0 and 1 with random seed 13 will lead to the same results as training on GPUs 1 and 2 with random seed 13.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

