### PR TITLE
Updates to sockeye 2

### DIFF
--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -462,10 +462,11 @@ class BeamSearch(mx.gluon.Block):
             self._sort_by_index = SortByIndex(prefix='sort_by_index_')
             self._update_scores = UpdateScores(prefix='update_scores_')
             self._scorer = scorer
-            self._sort_norm_and_update_finished = SortNormalizeAndUpdateFinished(prefix='sort_norm_and_update_finished_',
-                                                                        pad_id=C.PAD_ID,
-                                                                        eos_id=eos_id,
-                                                                        scorer=scorer)
+            self._sort_norm_and_update_finished = SortNormalizeAndUpdateFinished(
+                prefix='sort_norm_and_update_finished_',
+                pad_id=C.PAD_ID,
+                eos_id=eos_id,
+                scorer=scorer)
 
             self._sample = None  # type: Optional[mx.gluon.HybridBlock]
             self._top = None  # type: Optional[mx.gluon.HybridBlock]
@@ -553,8 +554,6 @@ class BeamSearch(mx.gluon.Block):
         vocab_slice_ids = None  # type: Optional[mx.nd.NDArray]
         if restrict_lexicon:
             source_words = utils.split(source, num_outputs=self.num_source_factors, axis=2, squeeze_axis=True)[0]
-            # TODO: See note in method about migrating to pure MXNet when set operations are supported.
-            #       We currently convert source to NumPy and target ids back to NDArray.
             vocab_slice_ids = restrict_lexicon.get_trg_ids(source_words.astype("int32").asnumpy())
             if any(raw_constraint_list):
                 # Add the constraint IDs to the list of permissibled IDs, and then project them into the reduced space

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -183,8 +183,8 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
 
         batch_size = encoder_outputs.shape[0]
         self_att_key_value_dummies = [mx.nd.zeros((batch_size, 1, self.config.model_size),
-                                                   ctx=encoder_outputs.context,
-                                                   dtype=encoder_outputs.dtype)] * self.config.num_layers * 2
+                                                  ctx=encoder_outputs.context,
+                                                  dtype=encoder_outputs.dtype)] * self.config.num_layers * 2
         states += self_att_key_value_dummies
 
         return states

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -298,7 +298,6 @@ class DotAttentionCell(mx.gluon.HybridBlock):
         # (n, lq, lk)
         logits = F.batch_dot(lhs=queries, rhs=keys, transpose_b=True)
 
-
         # TODO(fhieber): consider softmax with length argument once available.
         # TODO(fhieber: Also see https://github.com/dmlc/gluon-nlp/pull/910
         if lengths is not None:
@@ -467,6 +466,7 @@ class MultiHeadAttention(MultiHeadAttentionBase):
     :param depth_att: Attention depth / number of hidden units.
     :param heads: Number of attention heads.
     :param depth_out: Output depth / number of output units.
+    :param depth_key_value: Dimension of input key and value vectors.
     :param dropout: Dropout probability on attention scores
     """
 
@@ -475,13 +475,14 @@ class MultiHeadAttention(MultiHeadAttentionBase):
                  depth_att: int = 512,
                  heads: int = 8,
                  depth_out: int = 512,
-                 dropout: float = 0.0) -> None:
+                 dropout: float = 0.0,
+                 depth_key_value: int = 0) -> None:
         super().__init__(prefix, depth_att, heads, depth_out, dropout)
 
         with self.name_scope():
-            self.ff_q = mx.gluon.nn.Dense(in_units=depth_att, units=depth_att, flatten=False, use_bias=False, prefix='q2h_')
-            self.ff_k = mx.gluon.nn.Dense(units=depth_att, flatten=False, use_bias=False, prefix='k2h_')
-            self.ff_v = mx.gluon.nn.Dense(units=depth_att, flatten=False, use_bias=False, prefix='v2h_')
+            self.ff_q = mx.gluon.nn.Dense(in_units=depth_out, units=depth_att, flatten=False, use_bias=False, prefix='q2h_')
+            self.ff_k = mx.gluon.nn.Dense(in_units=depth_key_value, units=depth_att, flatten=False, use_bias=False, prefix='k2h_')
+            self.ff_v = mx.gluon.nn.Dense(in_units=depth_key_value, units=depth_att, flatten=False, use_bias=False, prefix='v2h_')
 
     def hybrid_forward(self, F,
                        queries: mx.sym.Symbol,

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -480,8 +480,8 @@ class MultiHeadAttention(MultiHeadAttentionBase):
 
         with self.name_scope():
             self.ff_q = mx.gluon.nn.Dense(in_units=depth_att, units=depth_att, flatten=False, use_bias=False, prefix='q2h_')
-            self.ff_k = mx.gluon.nn.Dense(in_units=depth_att, units=depth_att, flatten=False, use_bias=False, prefix='k2h_')
-            self.ff_v = mx.gluon.nn.Dense(in_units=depth_att, units=depth_att, flatten=False, use_bias=False, prefix='v2h_')
+            self.ff_k = mx.gluon.nn.Dense(units=depth_att, flatten=False, use_bias=False, prefix='k2h_')
+            self.ff_v = mx.gluon.nn.Dense(units=depth_att, flatten=False, use_bias=False, prefix='v2h_')
 
     def hybrid_forward(self, F,
                        queries: mx.sym.Symbol,

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -479,9 +479,9 @@ class MultiHeadAttention(MultiHeadAttentionBase):
         super().__init__(prefix, depth_att, heads, depth_out, dropout)
 
         with self.name_scope():
-            self.ff_q = mx.gluon.nn.Dense(units=depth_att, flatten=False, use_bias=False, prefix='q2h_')
-            self.ff_k = mx.gluon.nn.Dense(units=depth_att, flatten=False, use_bias=False, prefix='k2h_')
-            self.ff_v = mx.gluon.nn.Dense(units=depth_att, flatten=False, use_bias=False, prefix='v2h_')
+            self.ff_q = mx.gluon.nn.Dense(in_units=depth_att, units=depth_att, flatten=False, use_bias=False, prefix='q2h_')
+            self.ff_k = mx.gluon.nn.Dense(in_units=depth_att, units=depth_att, flatten=False, use_bias=False, prefix='k2h_')
+            self.ff_v = mx.gluon.nn.Dense(in_units=depth_att, units=depth_att, flatten=False, use_bias=False, prefix='v2h_')
 
     def hybrid_forward(self, F,
                        queries: mx.sym.Symbol,

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -421,8 +421,7 @@ def load_model(model_folder: str,
     :param dtype: Optional data type to use. If None, will be inferred from stored model.
     :param hybridize: Whether to hybridize the loaded models. Default: true.
     :param inference_only: Use the model only for inference, enabling optimizations.
-    :return: List of models, source vocabulary, target vocabulary, source factor vocabularies.
-    :return:
+    :return: List of models, source vocabularies, target vocabulary.
     """
     source_vocabs = vocab.load_source_vocabs(model_folder)
     target_vocab = vocab.load_target_vocab(model_folder)
@@ -449,7 +448,7 @@ def load_model(model_folder: str,
         cast_dtype = False
         dtype_source = 'saved'
     else:
-        logger.info("Model dtype: overriden to %s" % dtype)
+        logger.info("Model dtype: overridden to %s" % dtype)
         model.cast(dtype)
         cast_dtype = True
         dtype_source = 'current'

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -362,7 +362,8 @@ class SockeyeModel(mx.gluon.Block):
             output_weight = target_embed_weight
         else:
             output_weight = self.params.get(output_embed_name,
-                                            shape=(self.config.config_embed_target.vocab_size, 0),
+                                            shape=(self.config.config_embed_target.vocab_size,
+                                                   self.config.config_decoder.model_size),
                                             allow_deferred_init=True)
 
         return source_embed_weight, target_embed_weight, output_weight

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -437,8 +437,7 @@ def create_encoder_config(args: argparse.Namespace,
 
 
 def create_decoder_config(args: argparse.Namespace, encoder_num_hidden: int,
-                          max_seq_len_source: int, max_seq_len_target: int,
-                          num_embed_target: int) -> decoder.DecoderConfig:
+                          max_seq_len_source: int, max_seq_len_target: int) -> decoder.DecoderConfig:
     """
     Create the config for the decoder.
 
@@ -446,7 +445,6 @@ def create_decoder_config(args: argparse.Namespace, encoder_num_hidden: int,
     :param encoder_num_hidden: Number of hidden units of the Encoder.
     :param max_seq_len_source: Maximum source sequence length.
     :param max_seq_len_target: Maximum target sequence length.
-    :param num_embed_target: The size of the source embedding.
     :return: The config for the decoder.
     """
     _, decoder_num_layers = args.num_layers
@@ -467,7 +465,8 @@ def create_decoder_config(args: argparse.Namespace, encoder_num_hidden: int,
         postprocess_sequence=decoder_transformer_postprocess,
         max_seq_len_source=max_seq_len_source,
         max_seq_len_target=max_seq_len_target,
-        lhuc=args.lhuc is not None and (C.LHUC_DECODER in args.lhuc or C.LHUC_ALL in args.lhuc))
+        lhuc=args.lhuc is not None and (C.LHUC_DECODER in args.lhuc or C.LHUC_ALL in args.lhuc),
+        depth_key_value=encoder_num_hidden)
 
     return config_decoder
 
@@ -541,8 +540,7 @@ def create_model_config(args: argparse.Namespace,
 
     config_encoder, encoder_num_hidden = create_encoder_config(args, max_seq_len_source, max_seq_len_target,
                                                                num_embed_source)
-    config_decoder = create_decoder_config(args, encoder_num_hidden, max_seq_len_source, max_seq_len_target,
-                                           num_embed_target)
+    config_decoder = create_decoder_config(args, encoder_num_hidden, max_seq_len_source, max_seq_len_target)
 
     source_factor_configs = None
     if len(source_vocab_sizes) > 1:

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -36,7 +36,8 @@ class TransformerConfig(config.Config):
                  postprocess_sequence: str,
                  max_seq_len_source: int,
                  max_seq_len_target: int,
-                 lhuc: bool = False) -> None:  # type: ignore
+                 lhuc: bool = False,
+                 depth_key_value: int = 0) -> None:  # type: ignore
         super().__init__()
         self.model_size = model_size
         self.attention_heads = attention_heads
@@ -52,6 +53,7 @@ class TransformerConfig(config.Config):
         self.max_seq_len_source = max_seq_len_source
         self.max_seq_len_target = max_seq_len_target
         self.use_lhuc = lhuc
+        self.depth_key_value = depth_key_value
 
 
 class TransformerEncoderBlock(mx.gluon.HybridBlock):
@@ -145,6 +147,7 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
                                                            heads=config.attention_heads,
                                                            depth_out=config.model_size,
                                                            dropout=config.dropout_attention,
+                                                           depth_key_value=config.depth_key_value,
                                                            prefix="att_enc_")
             self.post_enc_attention = TransformerProcessBlock(sequence=config.postprocess_sequence,
                                                               dropout=config.dropout_prepost,

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -716,34 +716,6 @@ def cleanup_params_files(output_folder: str, max_to_keep: int, checkpoint: int, 
                     logger.warning('File has already been removed: %s', param_fname_n)
 
 
-def cast_conditionally(F, data: mx.sym.Symbol, dtype: str) -> mx.sym.Symbol:
-    """
-    Workaround until no-op cast will be fixed in MXNet codebase.
-    Creates cast symbol only if dtype is different from default one, i.e. float32.
-
-    :param data: Input symbol.
-    :param dtype: Target dtype.
-    :return: Cast symbol or just data symbol.
-    """
-    if dtype != C.DTYPE_FP32:
-        return F.cast(data=data, dtype=dtype)
-    return data
-
-
-def uncast_conditionally(F, data: mx.sym.Symbol, dtype: str) -> mx.sym.Symbol:
-    """
-    Workaround until no-op cast will be fixed in MXNet codebase.
-    Creates cast to float32 symbol only if dtype is different from default one, i.e. float32.
-
-    :param data: Input symbol.
-    :param dtype: Input symbol dtype.
-    :return: Cast symbol or just data symbol.
-    """
-    if dtype != C.DTYPE_FP32:
-        return F.cast(data=data, dtype=C.DTYPE_FP32)
-    return data
-
-
 def split(data: mx.nd.NDArray,
           num_outputs: int,
           axis: int = 1,

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -773,9 +773,9 @@ def log_parameters(params: mx.gluon.ParameterDict):
             total_learned += size
             learned_parameter_names.append(repr)
     total_parameters = total_learned + total_fixed
-    logger.info("Total number of parameters: %d | learned: %d (%.2f%%) | fixed: %d (%.2f%%)",
+    logger.info("# of parameters: %d | trainable: %d (%.2f%%) | fixed: %d (%.2f%%)",
                 total_parameters,
                 total_learned, total_learned / total_parameters * 100,
                 total_fixed, total_fixed / total_parameters * 100)
     logger.info("Trainable parameters: \n%s", pprint.pformat(learned_parameter_names))
-    logger.info("Fixed model parameters:\n%s", pprint.pformat(fixed_parameter_names))
+    logger.info("Fixed parameters:\n%s", pprint.pformat(fixed_parameter_names))


### PR DESCRIPTION
- Log full number of parameters of specified model in sockeye.train. This is achieved by removing all shape inference from the model definition by adding a 'depth_key_value' attribute to `TransformerConfig`. Change should be backwards compatible.
- Some small cosmetic updates

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

