### PR TITLE
Sparse gradient arrays for embeddings

### DIFF
--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -239,7 +239,7 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             # (batch, num_hidden)
             target = mx.nd.reshape(target, shape=(-1, self.get_num_hidden()))
 
-            # We also increment time step state (2nd state in the list) and add new caches
+            # We also increment time step state (1st state in the list) and add new caches
             step = states[0] + 1
 
             if self.inference_only:

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -345,7 +345,7 @@ class SockeyeModel(mx.gluon.Block):
         target_embed_name = C.TARGET_EMBEDDING_PREFIX + "weight" if not share_embed else C.SHARED_EMBEDDING_PREFIX + "weight"
         output_embed_name = "target_output_weight" if not tie_weights else target_embed_name
 
-        source_grad_stype = 'row_sparse' if self.config.config_embed_source.allow_sparse_grad and not share_embed else 'default'
+        source_grad_stype = 'row_sparse' if self.config.config_embed_source.allow_sparse_grad and not tie_weights else 'default'
         source_embed_weight = self.params.get(source_embed_name,
                                               shape=(self.config.config_embed_source.vocab_size,
                                                      self.config.config_embed_source.num_embed),

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -348,7 +348,8 @@ class SockeyeModel(mx.gluon.Block):
         source_embed_weight = self.params.get(source_embed_name,
                                               shape=(self.config.config_embed_source.vocab_size,
                                                      self.config.config_embed_source.num_embed),
-                                              allow_deferred_init=True)
+                                              allow_deferred_init=True,
+                                              grad_stype='default' if share_embed else 'row_sparse')
 
         if share_embed:
             target_embed_weight = source_embed_weight
@@ -356,7 +357,8 @@ class SockeyeModel(mx.gluon.Block):
             target_embed_weight = self.params.get(target_embed_name,
                                                   shape=(self.config.config_embed_target.vocab_size,
                                                          self.config.config_embed_target.num_embed),
-                                                  allow_deferred_init=True)
+                                                  allow_deferred_init=True,
+                                                  grad_stype='default' if tie_weights else 'row_sparse')
 
         if tie_weights:
             output_weight = target_embed_weight

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -345,20 +345,22 @@ class SockeyeModel(mx.gluon.Block):
         target_embed_name = C.TARGET_EMBEDDING_PREFIX + "weight" if not share_embed else C.SHARED_EMBEDDING_PREFIX + "weight"
         output_embed_name = "target_output_weight" if not tie_weights else target_embed_name
 
+        source_grad_stype = 'row_sparse' if self.config.config_embed_source.allow_sparse_grad and not share_embed else 'default'
         source_embed_weight = self.params.get(source_embed_name,
                                               shape=(self.config.config_embed_source.vocab_size,
                                                      self.config.config_embed_source.num_embed),
                                               allow_deferred_init=True,
-                                              grad_stype='default' if share_embed else 'row_sparse')
+                                              grad_stype=source_grad_stype)
 
         if share_embed:
             target_embed_weight = source_embed_weight
         else:
+            target_grad_stype = 'row_sparse' if self.config.config_embed_target.allow_sparse_grad and not tie_weights else 'default'
             target_embed_weight = self.params.get(target_embed_name,
                                                   shape=(self.config.config_embed_target.vocab_size,
                                                          self.config.config_embed_target.num_embed),
                                                   allow_deferred_init=True,
-                                                  grad_stype='default' if tie_weights else 'row_sparse')
+                                                  grad_stype=target_grad_stype)
 
         if tie_weights:
             output_weight = target_embed_weight

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -566,14 +566,18 @@ def create_model_config(args: argparse.Namespace,
                                                                       args.source_factors_combine,
                                                                       args.source_factors_share_embedding)]
 
+    allow_sparse_grad = args.update_interval == 1  # sparse embedding gradients do not work with grad_req='add'
+
     config_embed_source = encoder.EmbeddingConfig(vocab_size=source_vocab_size,
                                                   num_embed=num_embed_source,
                                                   dropout=embed_dropout_source,
-                                                  factor_configs=source_factor_configs)
+                                                  factor_configs=source_factor_configs,
+                                                  allow_sparse_grad=allow_sparse_grad)
 
     config_embed_target = encoder.EmbeddingConfig(vocab_size=target_vocab_size,
                                                   num_embed=num_embed_target,
-                                                  dropout=embed_dropout_target)
+                                                  dropout=embed_dropout_target,
+                                                  allow_sparse_grad=allow_sparse_grad)
 
     config_length_task = None
     if args.length_task is not None:

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -956,7 +956,6 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
             # we set them immediately after calling init.
             gluon_trainer._amp_loss_scaler._scale_seq_len = args.amp_scale_interval
 
-
         losses = create_losses(args)
 
         hybridize = not args.no_hybridization


### PR DESCRIPTION
Use sparse gradient arrays for embeddings when weight tying is not used.
This speeds up training by ~7% but only works for configurations without weight tying, and no gradient accumulation (`sparse_grad=True` does not work with `grad_req='add'` in MXNET currently).

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

