### PR TITLE
Add mxnet cuda 10.1 requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [1.18.115]
+### Added
+- Added requirements for MXnet compatible with cuda 10.1.
+
 ## [1.18.114]
 ### Fixed
 - Fix bug in prepare_train_data arguments.

--- a/requirements/requirements.gpu-cu101.txt
+++ b/requirements/requirements.gpu-cu101.txt
@@ -1,0 +1,6 @@
+pyyaml>=5.1
+mxnet-cu101mkl==1.5.0
+numpy>=1.14
+typing
+portalocker
+sacrebleu==1.3.6

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '1.18.114'
+__version__ = '1.18.115'


### PR DESCRIPTION
Just a very minor change, adding requirements for mxnet cuda 10.1 - something that breaks some of my automation scripts.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

