### PR TITLE
Vocabulary selection w/ mxnet arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 - Ability to set environment variables from training/translate CLIs before MXNet is imported. For example, users can 
   configure MXNet as such: `--env "OMP_NUM_THREADS=1;MXNET_ENGINE_TYPE=NaiveEngine"`
 
+### Changed
+- Vocabulary selection is now fully implemented in mxnet operations, no more temporary conversion to numpy arrays.
+
 ## [2.1.0]
 
 ### Changed

--- a/sockeye/lexicon.py
+++ b/sockeye/lexicon.py
@@ -181,11 +181,12 @@ class TopKLexicon:
                                "contains at most %d entries per source.", k, loaded_k)
         else:
             top_k = loaded_k
-        self.lex = mx.nd.zeros((len(self.vocab_source), top_k), dtype=_lex.dtype, ctx=self.ctx)
+        self.lex = mx.nd.zeros((len(self.vocab_source), top_k), dtype=_lex.dtype, ctx=mx.cpu())
         for src_id, trg_ids in enumerate(_lex):
             self.lex[src_id, :] = mx.nd.sort(trg_ids[:top_k])
+        self.lex = self.lex.as_in_context(self.ctx)
         load_time = time.time() - load_time_start
-        logger.info("Loaded top-%d lexicon from \"%s\" in %.4fs.", top_k, path, load_time)
+        logger.info("Loaded top-%d lexicon from \"%s\" to \"%s\" in %.4fs.", top_k, path, self.ctx, load_time)
 
     def get_trg_ids(self, src_ids: mx.nd.NDArray) -> mx.nd.NDArray:
         """

--- a/sockeye/lexicon.py
+++ b/sockeye/lexicon.py
@@ -181,7 +181,7 @@ class TopKLexicon:
                                "contains at most %d entries per source.", k, loaded_k)
         else:
             top_k = loaded_k
-        self.lex = mx.nd.zeros((len(self.vocab_source), top_k), dtype=_lex.dtype, ctx=mx.cpu())
+        self.lex = mx.nd.zeros((len(self.vocab_source), top_k), dtype='int32', ctx=mx.cpu())
         for src_id, trg_ids in enumerate(_lex):
             self.lex[src_id, :] = mx.nd.sort(trg_ids[:top_k])
         self.lex = self.lex.as_in_context(self.ctx)

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -91,7 +91,7 @@ def run_translate(args: argparse.Namespace):
             logger.info(str(args.restrict_lexicon))
             if len(args.restrict_lexicon) == 1:
                 # Single lexicon used for all inputs
-                restrict_lexicon = TopKLexicon(source_vocabs[0], target_vocab)
+                restrict_lexicon = TopKLexicon(source_vocabs[0], target_vocab, ctx=context)
                 # Handle a single arg of key:path or path (parsed as path:path)
                 restrict_lexicon.load(args.restrict_lexicon[0][1], k=args.restrict_lexicon_topk)
             else:
@@ -100,7 +100,7 @@ def run_translate(args: argparse.Namespace):
                 # Multiple lexicons with specified names
                 restrict_lexicon = dict()
                 for key, path in args.restrict_lexicon:
-                    lexicon = TopKLexicon(source_vocabs[0], target_vocab)
+                    lexicon = TopKLexicon(source_vocabs[0], target_vocab, ctx=context)
                     lexicon.load(path, k=args.restrict_lexicon_topk)
                     restrict_lexicon[key] = lexicon
 


### PR DESCRIPTION
Requires MXNet 1.6.

Makes use of new set operations in MXNet 1.6.
Requires passing context to TopKLexicon class.


#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

