### PR TITLE
Update to MXNet 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,13 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ### Changed
 
 - Updated to [MXNet 1.6.0](https://github.com/apache/incubator-mxnet/tree/1.6.0)
+
+### Added
+
+- Added support for CUDA 10.2
+
 ### Removed
+
 - Removed support for CUDA<9.1 / CUDNN<7.5
 
 ## [2.1.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.2]
+
+### Changed
+
+- Updated to [MXNet 1.6.0](https://github.com/apache/incubator-mxnet/tree/1.6.0)
+### Removed
+- Removed support for CUDA<9.1 / CUDNN<7.5
+
 ## [2.1.1]
 
 ### Added

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,7 +28,7 @@ Depending on your version of CUDA, you can do this by running the following:
 > pip install sockeye --no-deps -r requirements.gpu-cu${CUDA_VERSION}.txt
 > rm requirements.gpu-cu${CUDA_VERSION}.txt
 ```
-where `${CUDA_VERSION}` can be `80` (8.0), `90` (9.0), `92` (9.2), or `100` (10.0).
+where `${CUDA_VERSION}` can be `92` (9.2), `100` (10.0),or `101` (10.1).
 
 ### → via source...
 
@@ -47,7 +47,7 @@ running the following:
 > pip install -r requirements/requirements.gpu-cu${CUDA_VERSION}.txt
 > pip install .
 ```
-where `${CUDA_VERSION}` can be `80` (8.0), `90` (9.0), `92` (9.2), or `100` (10.0).
+where `${CUDA_VERSION}` can be `92` (9.2), `100` (10.0),or `101` (10.1).
 
 Developers will be better served by pointing `$PYTHONPATH` to the root of the git-cloned source.
 
@@ -70,7 +70,7 @@ On an instance with a GPU, the following commands will work
 > pip install sockeye --no-deps -r requirements.gpu-cu${CUDA_VERSION}.txt
 rm requirements.gpu-cu${CUDA_VERSION}.txt
 ```
-where `${CUDA_VERSION}` can be `80` (8.0), `90` (9.0), `92` (9.2), or `100` (10.0).
+where `${CUDA_VERSION}` can be `92` (9.2), `100` (10.0),or `101` (10.1).
 
 ### Optional dependencies
 In order to write training statistics to a Tensorboard event file for visualization, you can optionally install mxboard

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,7 +28,7 @@ Depending on your version of CUDA, you can do this by running the following:
 > pip install sockeye --no-deps -r requirements.gpu-cu${CUDA_VERSION}.txt
 > rm requirements.gpu-cu${CUDA_VERSION}.txt
 ```
-where `${CUDA_VERSION}` can be `92` (9.2), `100` (10.0),or `101` (10.1).
+where `${CUDA_VERSION}` can be `92` (9.2), `100` (10.0), `101` (10.1), or `102` (10.2).
 
 ### → via source...
 
@@ -47,7 +47,7 @@ running the following:
 > pip install -r requirements/requirements.gpu-cu${CUDA_VERSION}.txt
 > pip install .
 ```
-where `${CUDA_VERSION}` can be `92` (9.2), `100` (10.0),or `101` (10.1).
+where `${CUDA_VERSION}` can be `92` (9.2), `100` (10.0), `101` (10.1), or `102` (10.2).
 
 Developers will be better served by pointing `$PYTHONPATH` to the root of the git-cloned source.
 
@@ -70,7 +70,7 @@ On an instance with a GPU, the following commands will work
 > pip install sockeye --no-deps -r requirements.gpu-cu${CUDA_VERSION}.txt
 rm requirements.gpu-cu${CUDA_VERSION}.txt
 ```
-where `${CUDA_VERSION}` can be `92` (9.2), `100` (10.0),or `101` (10.1).
+where `${CUDA_VERSION}` can be `92` (9.2), `100` (10.0), `101` (10.1), or `102` (10.2).
 
 ### Optional dependencies
 In order to write training statistics to a Tensorboard event file for visualization, you can optionally install mxboard

--- a/requirements/requirements.gpu-cu100.txt
+++ b/requirements/requirements.gpu-cu100.txt
@@ -1,6 +1,6 @@
 pyyaml>=5.1
-mxnet-cu100mkl==1.5.0
-numpy
+mxnet-cu100mkl==1.6.0
+numpy>1.16.0,<2.0.0
 typing
 portalocker
 sacrebleu==1.4.3

--- a/requirements/requirements.gpu-cu101.txt
+++ b/requirements/requirements.gpu-cu101.txt
@@ -1,6 +1,6 @@
 pyyaml>=5.1
-mxnet-cu80mkl==1.5.0
-numpy
+mxnet-cu101mkl==1.6.0
+numpy>1.16.0,<2.0.0
 typing
 portalocker
 sacrebleu==1.4.3

--- a/requirements/requirements.gpu-cu102.txt
+++ b/requirements/requirements.gpu-cu102.txt
@@ -1,0 +1,6 @@
+pyyaml>=5.1
+mxnet-cu102mkl==1.6.0
+numpy>1.16.0,<2.0.0
+typing
+portalocker
+sacrebleu==1.4.3

--- a/requirements/requirements.gpu-cu90.txt
+++ b/requirements/requirements.gpu-cu90.txt
@@ -1,6 +1,0 @@
-pyyaml>=5.1
-mxnet-cu90mkl==1.5.0
-numpy
-typing
-portalocker
-sacrebleu==1.4.3

--- a/requirements/requirements.gpu-cu92.txt
+++ b/requirements/requirements.gpu-cu92.txt
@@ -1,6 +1,6 @@
 pyyaml>=5.1
-mxnet-cu92mkl==1.5.0
-numpy
+mxnet-cu92mkl==1.6.0
+numpy>1.16.0,<2.0.0
 typing
 portalocker
 sacrebleu==1.4.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml>=5.1
-mxnet-mkl==1.5.0
-numpy
+mxnet-mkl==1.6.0
+numpy>1.16.0,<2.0.0
 typing
 portalocker
 sacrebleu==1.4.3

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.1'
+__version__ = '2.1.2'


### PR DESCRIPTION
This is still work in progress as MXNet 1.6 is not yet available.

- Removed old CUDA support, MXNet 1.6 requires CUDA 9.1, cudnn 7.5.
- Fixed numpy version.



#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

