### PR TITLE
Allow setting custom env variables for train & translate clis before mxnet import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ## [2.1.1]
 
 ### Added
-- Ability to set environment variables from training/translate CLIs before MXNet is important. For example, users can 
+- Ability to set environment variables from training/translate CLIs before MXNet is imported. For example, users can 
   configure MXNet as such: `--env "OMP_NUM_THREADS=1;MXNET_ENGINE_TYPE=NaiveEngine"`
 
 ## [2.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.1]
+
+### Added
+- Ability to set environment variables from training/translate CLIs before MXNet is important. For example, users can 
+  configure MXNet as such: `--env "OMP_NUM_THREADS=1;MXNET_ENGINE_TYPE=NaiveEngine"`
+
 ## [2.1.0]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -527,6 +527,9 @@ def add_device_args(params):
                                help='Set the OMP_NUM_THREADS environment variable (CPU threads). Recommended: set to '
                                     'number of GPUs for training, number of physical CPU cores for inference. Default: '
                                     '%(default)s.')
+    device_params.add_argument('--env',
+                               help='List of environment variables to be set before importing MXNet. Separated by ",", '
+                                    'e.g. --env=OMP_NUM_THREADS=4,MXNET_GPU_WORKER_NTHREADS=3 etc.')
     device_params.add_argument('--disable-device-locking',
                                action='store_true',
                                help='Just use the specified device ids without locking.')

--- a/sockeye/pre_mxnet.py
+++ b/sockeye/pre_mxnet.py
@@ -19,6 +19,7 @@ import sys
 
 OMP_NUM_THREADS = 'OMP_NUM_THREADS'
 OMP_NUM_THREADS_ARG = '--omp-num-threads'
+ENV_ARG = '--env'
 
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,15 @@ def handle_omp_num_threads():
                 val = sys.argv[i + 1]
             logger.warning('Setting %s=%s', OMP_NUM_THREADS, val)
             os.environ[OMP_NUM_THREADS] = val
+        elif arg.startswith(ENV_ARG):
+            if arg.startswith(ENV_ARG + '='):
+                argval = arg.split("=", 1)[1]
+            else:
+                argval = sys.argv[i + 1]
+            for var_val in argval.split(','):
+                var, val = var_val.split('=', 1)
+                logger.warning('Setting %s=%s', var, val)
+                os.environ[var] = val
 
 
 def init():

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -78,9 +78,19 @@ def test_logging_args(test_params, expected_params):
 
 
 @pytest.mark.parametrize("test_params, expected_params", [
-    ('', dict(device_ids=[-1], use_cpu=False, omp_num_threads=None, disable_device_locking=False, lock_dir='/tmp')),
+    ('', dict(device_ids=[-1],
+              use_cpu=False,
+              omp_num_threads=None,
+              env=None,
+              disable_device_locking=False,
+              lock_dir='/tmp')),
     ('--device-ids 1 2 3 --use-cpu --disable-device-locking --lock-dir test_dir',
-     dict(device_ids=[1, 2, 3], use_cpu=True, omp_num_threads=None, disable_device_locking=True, lock_dir='test_dir'))
+     dict(device_ids=[1, 2, 3],
+          use_cpu=True,
+          omp_num_threads=None,
+          env=None,
+          disable_device_locking=True,
+          lock_dir='test_dir'))
 ])
 def test_device_args(test_params, expected_params):
     _test_args(test_params, expected_params, arguments.add_device_args)


### PR DESCRIPTION
Add ability to set any environment variables for CLIs before mxnet import.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

