### PR TITLE
Do not store duplicate, shared parameters

### DIFF
--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -275,7 +275,7 @@ class SockeyeModel(mx.gluon.Block):
         Saves model parameters to file.
         :param fname: Path to save parameters to.
         """
-        super().save_parameters(fname)
+        super().save_parameters(fname, deduplicate=True)
         logging.info('Saved params to "%s"', fname)
 
     def load_parameters(self,


### PR DESCRIPTION
Use `deduplicate=True` when saving model parameters. Avoids storing embedding parameters multiple times in the `<model>/params.*` files, when they are shared through `--weight-tying-type`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

