### PR TITLE
Sockeye 2 Inference Optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.3]
+
+### Changed
+
+- Performance optimizations to beam search inference
+  - Remove unneeded take ops on encoder states
+  - Gathering input data before sending to GPU, rather than sending each batch element individually
+  - All of beam search can be done in fp16, if specified by the model
+  - Other small miscellaneous optimizations
+- Model states are now a flat list in ensemble inference, structure of states provided by `state_structure()`
+
 ## [2.1.2]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.2'
+__version__ = '2.1.3'

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -711,7 +711,7 @@ class BeamSearch(mx.gluon.Block):
         # (9) Sort the hypotheses within each sentence (normalization for finished hyps may have unsorted them).
         folded_accumulated_scores = scores_accumulated.reshape((batch_size,
                                                                 self.beam_size * scores_accumulated.shape[-1]))
-        indices = mx.nd.cast(mx.nd.argsort(folded_accumulated_scores, axis=1), dtype='int32').reshape((-1,))
+        indices = mx.nd.cast(mx.nd.argsort(folded_accumulated_scores.astype('float32'), axis=1), dtype='int32').reshape((-1,))
         best_hyp_indices, _ = mx.nd.unravel_index(indices, scores_accumulated.shape) + offset
         scores_accumulated = scores_accumulated.take(best_hyp_indices)
         best_hyp_indices_list.append(best_hyp_indices)

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -101,7 +101,7 @@ class _EnsembleInference(_Inference):
         return structure
 
     def encode_and_initialize(self, inputs: mx.nd.NDArray, valid_length: Optional[mx.nd.NDArray] = None):
-        model_states = []  # type: List[List[mx.nd.NDArray]]
+        model_states = []  # type: List[mx.nd.NDArray]
         predicted_output_lengths = []  # type: List[mx.nd.NDArray]
         for model in self._models:
             states, predicted_output_length = model.encode_and_initialize(inputs, valid_length, self._const_lr)
@@ -115,7 +115,8 @@ class _EnsembleInference(_Inference):
                     step_input: mx.nd.NDArray,
                     states: List,
                     vocab_slice_ids: Optional[mx.nd.NDArray] = None):
-        outputs, new_states = [], []
+        outputs = []  # type: List[mx.nd.NDArray]
+        new_states = []  # type: List[mx.nd.NDArray]
         state_index = 0
         for model, model_state_structure in zip(self._models, self.state_structure()):
             model_states = states[state_index:state_index+len(model_state_structure)]

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -67,7 +67,7 @@ class _SingleModelInference(_Inference):
         # TODO: change back to casting first when fp32 safe accumulation is fixed
         if not self._skip_softmax:
             logits = logits.log_softmax(axis=-1)
-        scores = -logits.astype('float32', copy=False)
+        scores = -logits
         return scores, states
 
 
@@ -104,7 +104,6 @@ class _EnsembleInference(_Inference):
         outputs, new_states = [], []
         for model, model_states in zip(self._models, states):
             logits, model_states, _ = model.decode_step(step_input, model_states, vocab_slice_ids)
-            logits = logits.astype('float32', copy=False)
             probs = logits.softmax(axis=-1)
             outputs.append(probs)
             new_states.append(model_states)
@@ -276,11 +275,13 @@ class SortNormalizeAndUpdateFinished(mx.gluon.HybridBlock):
     """
 
     def __init__(self,
+                 dtype: str,
                  pad_id: int,
                  eos_id: int,
                  scorer: CandidateScorer,
                  **kwargs) -> None:
         super().__init__(**kwargs)
+        self.dtype = dtype
         self.pad_id = pad_id
         self.eos_id = eos_id
         self._scorer = scorer
@@ -298,7 +299,7 @@ class SortNormalizeAndUpdateFinished(mx.gluon.HybridBlock):
         newly_finished = F.broadcast_logical_xor(all_finished, finished)
         scores_accumulated = F.where(newly_finished,
                                      self._scorer(scores_accumulated,
-                                                  F.cast(F.expand_dims(lengths, axis=1), 'float32'),
+                                                  F.cast(F.expand_dims(lengths, axis=1), self.dtype),
                                                   reference_lengths),
                                      scores_accumulated)
 
@@ -435,6 +436,7 @@ class BeamSearch(mx.gluon.Block):
 
     def __init__(self,
                  beam_size: int,
+                 dtype: str,
                  bos_id: int,
                  eos_id: int,
                  context: Union[mx.Context, List[mx.Context]],
@@ -447,6 +449,7 @@ class BeamSearch(mx.gluon.Block):
                  sample: Optional[int] = None) -> None:
         super().__init__(prefix='beam_search_')
         self.beam_size = beam_size
+        self.dtype = dtype
         self.bos_id = bos_id
         self.eos_id = eos_id
         self.output_vocab_size = output_vocab_size
@@ -462,6 +465,7 @@ class BeamSearch(mx.gluon.Block):
             self._scorer = scorer
             self._sort_norm_and_update_finished = SortNormalizeAndUpdateFinished(
                 prefix='sort_norm_and_update_finished_',
+                dtype=self.dtype,
                 pad_id=C.PAD_ID,
                 eos_id=eos_id,
                 scorer=scorer)
@@ -526,12 +530,12 @@ class BeamSearch(mx.gluon.Block):
 
         # locations of each batch item when first dimension is (batch * beam)
         batch_indices = mx.nd.arange(0, batch_size * self.beam_size, self.beam_size, dtype='int32', ctx=self.context)
-        first_step_mask = mx.nd.full((batch_size * self.beam_size, 1), val=np.inf, ctx=self.context, dtype='float32')
+        first_step_mask = mx.nd.full((batch_size * self.beam_size, 1), val=np.inf, ctx=self.context, dtype=self.dtype)
         first_step_mask[batch_indices] = 1.0
         pad_dist = mx.nd.full((batch_size * self.beam_size, self.output_vocab_size - 1), val=np.inf,
-                              ctx=self.context, dtype='float32')
+                              ctx=self.context, dtype=self.dtype)
         eos_dist = mx.nd.full((batch_size * self.beam_size, self.output_vocab_size), val=np.inf,
-                              ctx=self.context, dtype='float32')
+                              ctx=self.context, dtype=self.dtype)
         eos_dist[:, C.EOS_ID] = 0
 
         # Best word and hypotheses indices across beam search steps from topk operation.
@@ -545,7 +549,7 @@ class BeamSearch(mx.gluon.Block):
         max_output_lengths = mx.nd.repeat(max_output_lengths, self.beam_size)
 
         # scores_accumulated: chosen smallest scores in scores (ascending).
-        scores_accumulated = mx.nd.zeros((batch_size * self.beam_size, 1), ctx=self.context, dtype='float32')
+        scores_accumulated = mx.nd.zeros((batch_size * self.beam_size, 1), ctx=self.context, dtype=self.dtype)
 
         # If using a top-k lexicon, select param rows for logit computation that correspond to the
         # target vocab for this sentence.
@@ -730,6 +734,7 @@ def get_beam_search(models: List[SockeyeModel],
     global_avoid_trie = None if avoid_list is None else constrained.get_avoid_trie(avoid_list, vocab_target)
     bs = BeamSearch(
         beam_size=beam_size,
+        dtype=models[0].dtype,
         bos_id=C.BOS_ID,
         eos_id=C.EOS_ID,
         context=context,

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -31,6 +31,10 @@ logger = logging.getLogger(__name__)
 class _Inference(ABC):
 
     @abstractmethod
+    def state_structure(self):
+        raise NotImplementedError()
+
+    @abstractmethod
     def encode_and_initialize(self,
                               inputs: mx.nd.NDArray,
                               valid_length: Optional[mx.nd.NDArray] = None):

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -64,8 +64,10 @@ class _SingleModelInference(_Inference):
                     states: List,
                     vocab_slice_ids: Optional[mx.nd.NDArray] = None):
         logits, states, _ = self._model.decode_step(step_input, states, vocab_slice_ids)
-        logits = logits.astype('float32', copy=False)
-        scores = -logits if self._skip_softmax else -logits.log_softmax(axis=-1)
+        # TODO: change back to casting first when fp32 safe accumulation is fixed
+        if not self._skip_softmax:
+            logits = logits.log_softmax(axis=-1)
+        scores = -logits.astype('float32', copy=False)
         return scores, states
 
 

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -64,7 +64,6 @@ class _SingleModelInference(_Inference):
                     states: List,
                     vocab_slice_ids: Optional[mx.nd.NDArray] = None):
         logits, states, _ = self._model.decode_step(step_input, states, vocab_slice_ids)
-        # TODO: change back to casting first when fp32 safe accumulation is fixed
         if not self._skip_softmax:
             logits = logits.log_softmax(axis=-1)
         scores = -logits

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -166,6 +166,12 @@ CHUNK_SIZE_PER_BATCH_SEGMENT = 500
 BEAM_SEARCH_STOP_FIRST = 'first'
 BEAM_SEARCH_STOP_ALL = 'all'
 
+# State structure constants
+STEP_STATE = 's'
+BIAS_STATE = 'b'
+ENCODER_STATE = 'e'
+DECODER_STATE = 'd'
+
 # Inference Input JSON constants
 JSON_TEXT_KEY = "text"
 JSON_FACTORS_KEY = "factors"

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -888,7 +888,7 @@ class Translator:
         """
         batch_size = len(trans_inputs)
         lengths = [len(inp) for inp in trans_inputs]
-        source_length = mx.nd.array(lengths, ctx=self.context, dtype='float32')  # shape: (batch_size,)
+        source_length = mx.nd.array(lengths, ctx=self.context, dtype=self.dtype)  # shape: (batch_size,)
         max_length = max(len(inp) for inp in trans_inputs)
         source_npy = np.zeros((batch_size, max_length, self.num_source_factors), dtype=np.float32)
 

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -890,7 +890,7 @@ class Translator:
         lengths = [len(inp) for inp in trans_inputs]
         source_length = mx.nd.array(lengths, ctx=self.context, dtype='float32')  # shape: (batch_size,)
         max_length = max(len(inp) for inp in trans_inputs)
-        source = mx.nd.zeros((batch_size, max_length, self.num_source_factors), ctx=self.context, dtype='float32')
+        source_npy = np.zeros((batch_size, max_length, self.num_source_factors), dtype=np.float32)
 
         restrict_lexicon = None  # type: Optional[lexicon.TopKLexicon]
         raw_constraints = [None] * batch_size  # type: List[Optional[constrained.RawConstraintList]]
@@ -900,7 +900,7 @@ class Translator:
         for j, trans_input in enumerate(trans_inputs):
             num_tokens = len(trans_input)  # includes eos
             max_output_lengths.append(self._get_max_output_length(num_tokens))
-            source[j, :num_tokens, 0] = data_io.tokens2ids(trans_input.tokens, self.source_vocabs[0])
+            source_npy[j, :num_tokens, 0] = data_io.tokens2ids(trans_input.tokens, self.source_vocabs[0])
 
             factors = trans_input.factors if trans_input.factors is not None else []
             num_factors = 1 + len(factors)
@@ -910,7 +910,7 @@ class Translator:
             for i, factor in enumerate(factors[:self.num_source_factors - 1], start=1):
                 # fill in as many factors as there are tokens
 
-                source[j, :num_tokens, i] = data_io.tokens2ids(factor, self.source_vocabs[i])[:num_tokens]
+                source_npy[j, :num_tokens, i] = data_io.tokens2ids(factor, self.source_vocabs[i])[:num_tokens]
 
             # Check if vocabulary selection/restriction is enabled:
             # - First, see if the translator input provides a lexicon (used for multiple lexicons)
@@ -942,6 +942,8 @@ class Translator:
                 if any(self.unk_id in phrase for phrase in raw_avoid_list[j]):
                     logger.warning("Sentence %s: %s was found in the list of phrases to avoid; "
                                    "this may indicate improper preprocessing.", trans_input.sentence_id, C.UNK_SYMBOL)
+
+        source = mx.nd.array(source_npy, ctx=self.context)
 
         return source, source_length, restrict_lexicon, raw_constraints, raw_avoid_list, \
                 mx.nd.array(max_output_lengths, ctx=self.context, dtype='int32')

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -432,7 +432,7 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
         :param input_lengths: Optional lengths of inputs to mask attention scores. Shape: (batch, 1).
         :param bias: Optional 3d bias tensor to mask attention scores.
         :param previous_keys: Optional previous input projections of keys. Shape: (batch, max_length+1, depth_att).
-        :param previous_keys: Optional previous input projections of values. Shape: (batch, max_length+1, depth_att).
+        :param previous_values: Optional previous input projections of values. Shape: (batch, max_length+1, depth_att).
         :return: Symbol of shape (batch, max_length, output_depth).
         """
         # combined: (batch, max_length, depth * 3)

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -411,6 +411,7 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
                  dropout: float = 0.0) -> None:
         super().__init__(prefix, depth_att, heads, depth_out, dropout)
 
+        self.depth_att = depth_att
         with self.name_scope():
             self.ff_in = mx.gluon.nn.Dense(in_units=depth_att, units=depth_att * 3, flatten=False, use_bias=False, prefix='i2h_')
 
@@ -427,12 +428,11 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
         May also use a cache of previously computed inputs.
         Returns a symbol of shape (batch, max_length, output_depth).
 
-        :param inputs: Input Data. Shape: (batch, max_length, input_depth).
+        :param inputs: Input Data. Shape: (max_length, batch, input_depth).
         :param input_lengths: Optional lengths of inputs to mask attention scores. Shape: (batch, 1).
         :param bias: Optional 3d bias tensor to mask attention scores.
-        :param previous_keys: Optional previous input projections of keys. Shape: (batch, max_length+1, depth_att).
-        :param previous_values: Optional previous input projections of values. Shape: (batch, max_length+1, depth_att).
-        :return: Symbol of shape (batch, max_length, output_depth).
+        :param previous_keys_values: Optional previous input projections of keys and values. Shape: (max_length+1, batch, depth_att * 2).
+        :return: Symbol of shape (max_length, batch, output_depth).
         """
         # combined: (batch, max_length, depth * 3)
         combined = self.ff_in(inputs)

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -428,11 +428,12 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase):
         May also use a cache of previously computed inputs.
         Returns a symbol of shape (batch, max_length, output_depth).
 
-        :param inputs: Input Data. Shape: (max_length, batch, input_depth).
+        :param inputs: Input Data. Shape: (batch, max_length, input_depth).
         :param input_lengths: Optional lengths of inputs to mask attention scores. Shape: (batch, 1).
         :param bias: Optional 3d bias tensor to mask attention scores.
-        :param previous_keys_values: Optional previous input projections of keys and values. Shape: (max_length+1, batch, depth_att * 2).
-        :return: Symbol of shape (max_length, batch, output_depth).
+        :param previous_keys: Optional previous input projections of keys. Shape: (batch, max_length+1, depth_att).
+        :param previous_keys: Optional previous input projections of values. Shape: (batch, max_length+1, depth_att).
+        :return: Symbol of shape (batch, max_length, output_depth).
         """
         # combined: (batch, max_length, depth * 3)
         combined = self.ff_in(inputs)

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -134,6 +134,9 @@ class SockeyeModel(mx.gluon.Block):
         self.dtype = dtype
         super().cast(dtype)
 
+    def state_structure(self):
+        return self.decoder.state_structure()
+
     def encode(self, inputs, valid_length=None):
         """Encode the input sequence.
 


### PR DESCRIPTION
Made changes to Sockeye 2 to improve the performance of the Transformer model in machine translation for inference.

A list of changes detailed below:
1. Removed the take ops that were applied to the encoder states, as they do not change on different beams; this effectively cuts compute time for these takes in half
2. Gathered the input token ids into a numpy array on CPU before sending them all to the GPU at the beginning of beam search, rather than sending each batch element to the GPU one at a time
3. Set the data type of arrays during beam search computation to match the model's data type, rather than explicitly setting it to fp32

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

