### PR TITLE
Upgrade to MXNet 1.5.1 ; fix manifest

### DIFF
--- a/.github/workflows/mxnet_nightly.yml
+++ b/.github/workflows/mxnet_nightly.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         python-version: [3.6, 3.7]
         platform: [ubuntu-latest, macos-latest]
-        mxnet-version: [mxnet-mkl, mxnet]
       
     # The type of runner that the job will run on
     runs-on: ${{ matrix.platform }}
@@ -34,14 +33,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     # Runs a set of commands using the runners shell:
-    - name: Install dependencies ${{ matrix.mxnet-version }}
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install "pyyaml>=5.1" "numpy>1.16.0,<2.0.0" "typing" "portalocker" "sacrebleu==1.4.3"
+        pip install "pyyaml>=5.1" "numpy>1.16.0,<2.0.0" "portalocker" "sacrebleu==1.4.3"
         pip install -r requirements/requirements.dev.txt
-        pip install --pre "${{ matrix.mxnet-version }}<2" -f https://dist.mxnet.io/python
-    # Runs a single command using the runners shell
+        pip install --pre "mxnet<2" -f https://dist.mxnet.io/python
+    - name: Print mxnet build
+      run: pip list | grep mxnet
     - name: Unit tests
-      run: python3 setup.py test
+      run: pytest 
     - name: System tests
-      run: python -m pytest --maxfail=1 test/system
+      run: pytest --maxfail=1 test/system

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,6 +21,7 @@ recursive-include docs *.html
 recursive-include docs *.png
 recursive-include docs *.md
 recursive-include docs *.py
+recursive-include docs *.sh
 recursive-include docs *.yml
 recursive-include docs *.ico
 recursive-include docs *.css

--- a/requirements/requirements.gpu-cu100.txt
+++ b/requirements/requirements.gpu-cu100.txt
@@ -1,5 +1,5 @@
 pyyaml>=5.1
-mxnet-cu100mkl==1.5.0
+mxnet-cu100mkl==1.5.1
 numpy>=1.14
 typing
 portalocker

--- a/requirements/requirements.gpu-cu101.txt
+++ b/requirements/requirements.gpu-cu101.txt
@@ -1,5 +1,5 @@
 pyyaml>=5.1
-mxnet-cu101mkl==1.5.0
+mxnet-cu101mkl==1.5.1
 numpy>=1.14
 typing
 portalocker

--- a/requirements/requirements.gpu-cu80.txt
+++ b/requirements/requirements.gpu-cu80.txt
@@ -1,5 +1,5 @@
 pyyaml>=5.1
-mxnet-cu80mkl==1.5.0
+mxnet-cu80mkl==1.5.1
 numpy>=1.14
 typing
 portalocker

--- a/requirements/requirements.gpu-cu90.txt
+++ b/requirements/requirements.gpu-cu90.txt
@@ -1,5 +1,5 @@
 pyyaml>=5.1
-mxnet-cu90mkl==1.5.0
+mxnet-cu90mkl==1.5.1
 numpy>=1.14
 typing
 portalocker

--- a/requirements/requirements.gpu-cu92.txt
+++ b/requirements/requirements.gpu-cu92.txt
@@ -1,5 +1,5 @@
 pyyaml>=5.1
-mxnet-cu92mkl==1.5.0
+mxnet-cu92mkl==1.5.1
 numpy>=1.14
 typing
 portalocker

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 pyyaml>=5.1
-mxnet-mkl==1.5.0
+mxnet-mkl==1.5.1
 numpy>=1.14
 typing
 portalocker


### PR DESCRIPTION
Fix missing file in manifest (multilingual tutorial), update to MXNet 1.5.1 (1.5.0 seems to no longer exist for all architectures).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

