### PR TITLE
Option for setting parameters in model

### DIFF
--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -317,6 +317,17 @@ class SockeyeModel(mx.gluon.Block):
                                 cast_dtype=cast_dtype, dtype_source=dtype_source)
         logger.info('Loaded params from "%s" to "%s"', filename, mx.cpu() if ctx is None else ctx)
 
+    def set_parameters(self, new_params: dict):
+        """
+        Update model params with new values from a dictionary.
+
+        :param new_params: Dictionary containing the new parameters.
+        """
+        model_params = self.collect_params()
+        for k in new_params:
+            if k in model_params:
+                model_params[k].set_data(new_params[k].data())
+
     @staticmethod
     def save_version(folder: str):
         """
@@ -415,7 +426,9 @@ def load_model(model_folder: str,
                dtype: Optional[str] = None,
                checkpoint: Optional[int] = None,
                hybridize: bool = True,
-               inference_only: bool = False) -> Tuple[SockeyeModel, List[vocab.Vocab], vocab.Vocab]:
+               inference_only: bool = False,
+               allow_missing: bool = False,
+               set_grad_req_null: bool = True) -> Tuple[SockeyeModel, List[vocab.Vocab], vocab.Vocab]:
     """
     Load a model from model_folder.
 
@@ -425,6 +438,8 @@ def load_model(model_folder: str,
     :param dtype: Optional data type to use. If None, will be inferred from stored model.
     :param hybridize: Whether to hybridize the loaded models. Default: true.
     :param inference_only: Use the model only for inference, enabling optimizations.
+    :param allow_missing: Allow missing parameters in the loaded model.
+    :param set_grad_req_null: Set grad_req to null for model parameters.
     :return: List of models, source vocabularies, target vocabulary.
     """
     source_vocabs = vocab.load_source_vocabs(model_folder)
@@ -459,12 +474,13 @@ def load_model(model_folder: str,
 
     model.load_parameters(filename=params_fname,
                           ctx=context,
-                          allow_missing=False,
+                          allow_missing=allow_missing,
                           ignore_extra=False,
                           cast_dtype=cast_dtype,
                           dtype_source=dtype_source)
-    for param in model.collect_params().values():
-        param.grad_req = 'null'
+    if set_grad_req_null:
+        for param in model.collect_params().values():
+            param.grad_req = 'null'
 
     if hybridize:
         model.hybridize(static_alloc=True)
@@ -481,7 +497,9 @@ def load_models(context: Union[List[mx.context.Context], mx.context.Context],
                 checkpoints: Optional[List[int]] = None,
                 dtype: Optional[str] = C.DTYPE_FP32,
                 hybridize: bool = True,
-                inference_only: bool = False) -> Tuple[List[SockeyeModel], List[vocab.Vocab], vocab.Vocab]:
+                inference_only: bool = False,
+                allow_missing: bool = False,
+                set_grad_req_null: bool = True) -> Tuple[List[SockeyeModel], List[vocab.Vocab], vocab.Vocab]:
     """
     Loads a list of models for inference.
 
@@ -491,6 +509,8 @@ def load_models(context: Union[List[mx.context.Context], mx.context.Context],
     :param dtype: Optional data type to use. If None, will be inferred from stored model.
     :param hybridize: Whether to hybridize the loaded models. Default: true.
     :param inference_only: Use the model only for inference, enabling optimizations.
+    :param allow_missing: Allow missing parameters in the loaded models.
+    :param set_grad_req_null: Set grad_req to null for model parameters.
     :return: List of models, source vocabulary, target vocabulary, source factor vocabularies.
     """
     logger.info("Loading %d model(s) from %s ...", len(model_folders), model_folders)
@@ -510,7 +530,9 @@ def load_models(context: Union[List[mx.context.Context], mx.context.Context],
                                               dtype=dtype,
                                               checkpoint=checkpoint,
                                               hybridize=hybridize,
-                                              inference_only=inference_only)
+                                              inference_only=inference_only,
+                                              allow_missing=allow_missing,
+                                              set_grad_req_null=set_grad_req_null)
         models.append(model)
         source_vocabs.append(src_vcbs)
         target_vocabs.append(trg_vcb)

--- a/test/unit/test_params.py
+++ b/test/unit/test_params.py
@@ -16,6 +16,11 @@ import glob
 import os.path
 import tempfile
 
+import mxnet as mx
+import pytest
+
+import sockeye.encoder
+import sockeye.model
 import sockeye.training
 import sockeye.constants as C
 import sockeye.utils
@@ -33,6 +38,7 @@ def test_cleanup_param_files():
         # 17 must survive because it is the best one
         assert set(glob.glob(os.path.join(tmp_dir, C.PARAMS_PREFIX + "*"))) == expectedSurviving
 
+
 def test_cleanup_param_files_keep_first():
     with tempfile.TemporaryDirectory() as tmp_dir:
         for n in itertools.chain(range(0, 20, 2), range(21, 41)):
@@ -45,3 +51,91 @@ def test_cleanup_param_files_keep_first():
         # 16 must survive because it is the best one
         # 0 should also survive because we set keep_first to True
         assert set(glob.glob(os.path.join(tmp_dir, C.PARAMS_PREFIX + "*"))) == expectedSurviving
+
+
+def mock_model():
+    config_embed = sockeye.encoder.EmbeddingConfig(vocab_size=20, num_embed=4, dropout=0.0)
+    config_encoder = sockeye.encoder.EncoderConfig(model_size=4, attention_heads=1, feed_forward_num_hidden=4,
+                                                   act_type='relu', num_layers=1, dropout_attention=0.0,
+                                                   dropout_act=0.0, dropout_prepost=0.0,
+                                                   positional_embedding_type='fixed', preprocess_sequence='none',
+                                                   postprocess_sequence='none', max_seq_len_source=30,
+                                                   max_seq_len_target=30)
+    config = sockeye.model.ModelConfig(config_data=None, vocab_source_size=20, vocab_target_size=20,
+                                       config_embed_source=config_embed, config_embed_target=config_embed,
+                                       config_encoder=config_encoder, config_decoder=config_encoder)
+    model = sockeye.model.SockeyeModel(config=config)
+    return model
+
+
+def test_set_parameters():
+    model = mock_model()
+    model.initialize(init='xavier', ctx=mx.cpu(0))
+    p = mx.gluon.Parameter('source_target_embed_weight', shape=(20, 4))
+    p.initialize(init='xavier', ctx=mx.cpu(0))
+    model.set_parameters({'source_target_embed_weight': p})
+    assert mx.test_utils.same(model.params['source_target_embed_weight'].data(), p.data())
+
+
+def test_set_parameters_allow_missing():
+    model = mock_model()
+    model.initialize(init='xavier', ctx=mx.cpu(0))
+    model.set_parameters({}, allow_missing=True)
+    assert 'source_target_embed_weight' in model.params
+    with pytest.raises(AssertionError) as e:
+        model.set_parameters({}, allow_missing=False)
+    assert str(e.value) == "Parameter 'source_target_embed_weight' is missing in new_params dictionary. " \
+                           "Set allow_missing=True to ignore missing parameters."
+
+
+def test_set_parameters_ignore_extra():
+    model = mock_model()
+    model.initialize(init='xavier', ctx=mx.cpu(0))
+    p = mx.gluon.Parameter('source_target_embed_weight', shape=(20, 4))
+    p.initialize(init='xavier', ctx=mx.cpu(0))
+    q = mx.gluon.Parameter('q', shape=(1, 1))
+    q.initialize(init='xavier', ctx=mx.cpu(0))
+    params = {'source_target_embed_weight': p, 'q': q}
+    model.set_parameters(params, ignore_extra=True)
+    assert 'source_target_embed_weight' in model.params
+    assert 'q' not in model.params
+    with pytest.raises(ValueError) as e:
+        model.set_parameters(params, ignore_extra=False)
+    assert str(e.value) == "Parameter 'q' in new_params dictionary is not preset in ParameterDict. " \
+                           "Set ignore_extra=True to ignore."
+
+
+def test_set_parameters_context():
+    model = mock_model()
+    model.initialize(init='xavier', ctx=[mx.cpu(0), mx.cpu(1)])
+    p = mx.gluon.Parameter('source_target_embed_weight', shape=(20, 4))
+    p.initialize(init='xavier', ctx=mx.cpu(2))
+    model.set_parameters({'source_target_embed_weight': p})
+    for i in range(2):
+        assert mx.test_utils.same(model.params['source_target_embed_weight'].data(mx.cpu(i)), p.data(mx.cpu(2)))
+
+
+def test_set_parameters_shape():
+    model = mock_model()
+    model.initialize(init='xavier', ctx=mx.cpu(0))
+    p = mx.gluon.Parameter('source_target_embed_weight', shape=(10, 10))
+    p.initialize(init='xavier', ctx=mx.cpu(0))
+    with pytest.raises(AssertionError) as e:
+        model.set_parameters({'source_target_embed_weight': p})
+    assert str(e.value) == "Parameter 'source_target_embed_weight' has shape '(20, 4)' in the model but shape " \
+                           "'(10, 10)' in the new_params dictionary."
+
+
+def test_set_parameters_uninitialized():
+    model = mock_model()
+    model.initialize(init='xavier', ctx=mx.cpu(0))
+    p = mx.gluon.Parameter('source_target_embed_weight', shape=(20, 4))
+    with pytest.raises(AssertionError) as e:
+        model.set_parameters({'source_target_embed_weight': p})
+    assert str(e.value) == "Parameter 'source_target_embed_weight' is not initialized in new_params dictionary."
+    p.initialize(init='xavier', ctx=mx.cpu(0))
+    model = mock_model()
+    with pytest.raises(AssertionError) as e:
+        model.set_parameters({'source_target_embed_weight': p})
+    assert str(e.value) == "Parameter 'source_target_embed_weight' must be initialized before it can be reset using " \
+                           "set_parameters."


### PR DESCRIPTION
Added some additional options to models/model loading, including a function to set model parameters from a dictionary

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

