### PR TITLE
Dockerfile for CPU-optimized Sockeye image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to the project are documented in this file.
 
 Version numbers are of the form `1.0.0`.
@@ -9,6 +10,14 @@ e.g. due to changing the architecture or simply modifying model parameter names.
 Note that Sockeye has checks in place to not translate with an old model that was trained with an incompatible version.
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
+
+## [2.1.4]
+
+### Added
+
+- Added Dockerfiles that build an experimental CPU-optimized Sockeye image:
+  - Uses the latest versions of [kpuatamazon/incubator-mxnet](https://github.com/kpuatamazon/incubator-mxnet) (supports [intgemm](https://github.com/kpu/intgemm) and makes full use of Intel MKL) and [kpuatamazon/sockeye](https://github.com/kpuatamazon/sockeye) (supports int8 quantization for inference).
+  - See [sockeye_contrib/docker](sockeye_contrib/docker).
 
 ## [2.1.3]
 
@@ -38,7 +47,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ## [2.1.1]
 
 ### Added
-- Ability to set environment variables from training/translate CLIs before MXNet is imported. For example, users can 
+- Ability to set environment variables from training/translate CLIs before MXNet is imported. For example, users can
   configure MXNet as such: `--env "OMP_NUM_THREADS=1;MXNET_ENGINE_TYPE=NaiveEngine"`
 
 ## [2.1.0]

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.3'
+__version__ = '2.1.4'

--- a/sockeye_contrib/docker/Dockerfile.cpu
+++ b/sockeye_contrib/docker/Dockerfile.cpu
@@ -1,0 +1,81 @@
+FROM ubuntu:18.04
+
+ENV PYTHON_VERSION=3.6
+
+# Set default shell to /bin/bash
+SHELL ["/bin/bash", "-cu"]
+
+#
+# Install Intel MKL
+#
+
+RUN apt-get update && apt-get install -y gnupg wget
+
+RUN cd /tmp && \
+    wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB && \
+    apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB && \
+    rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
+
+RUN echo "deb https://apt.repos.intel.com/mkl all main" > /etc/apt/sources.list.d/intel-mkl.list
+
+RUN apt-get update && apt-get install -y intel-mkl-2019.4-070
+
+#
+# Install MXNet
+#
+
+# Workaround for making sure DNNL uses MKL
+ENV CXXFLAGS="-O3 -march=native -DUSE_MKL -I/opt/intel/mkl/include"
+ENV CFLAGS="-O3 -march=native -DUSE_MKL -I/opt/intel/mkl/include"
+ENV LD_PRELOAD=/opt/intel/mkl/lib/intel64/libmkl_rt.so
+
+# MXNet dependencies
+RUN mkdir /work && \
+    touch /work/requirements && \
+    cd /opt && \
+    wget https://raw.githubusercontent.com/apache/incubator-mxnet/master/ci/docker/install/ubuntu_core.sh && \
+    wget https://raw.githubusercontent.com/apache/incubator-mxnet/master/ci/docker/install/ubuntu_python.sh && \
+    sh ubuntu_core.sh && \
+    sh ubuntu_python.sh && \
+    rm -rf /work
+
+RUN pip3 install --no-cache-dir wheel 'pyyaml>=5.1'
+
+RUN apt-get update && apt-get install -y \
+    build-essential git ninja-build ccache google-perftools gcc-8 g++-8 awscli python3-venv libssl-dev
+
+# MXNet branch with intgemm support
+RUN cd /opt && \
+    git clone https://github.com/kpuatamazon/incubator-mxnet.git mxnet && \
+    cd mxnet && \
+    git checkout intgemm && \
+    git submodule init && \
+    git submodule update --recursive
+
+# Build MXNet
+RUN cd /opt/mxnet && \
+    rm -rf build && \
+    mkdir -p build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DUSE_MKL_IF_AVAILABLE=ON -DUSE_MKLDNN=ON -DUSE_CUDA=OFF -G Ninja -DUSE_INTGEMM=ON -DCMAKE_CXX_COMPILER=g++-8 -DCMAKE_C_COMPILER=gcc-8 .. && \
+    ninja -j$(nproc)
+
+# Install MXNet Python
+RUN cd /opt/mxnet/python && pip3 install -e .
+
+#
+# Install Sockeye
+#
+
+RUN cd /opt && \
+    git clone https://github.com/kpuatamazon/sockeye && \
+    cd sockeye && \
+    git checkout heafield-quantize
+
+# Sockeye dependencies
+RUN pip3 install --no-cache-dir numpy typing portalocker sacrebleu==1.3.6
+
+RUN cd /opt/sockeye && pip3 install . --no-deps
+
+# Guarantee Intel NumPy
+RUN pip3 install intel-numpy

--- a/sockeye_contrib/docker/README.md
+++ b/sockeye_contrib/docker/README.md
@@ -63,3 +63,23 @@ docker run --rm -i --network=host -v /mnt/share/ssh:/home/ec2-user/.ssh -v /mnt/
         --use-cpu \
         --horovod
 ```
+
+## Experimental CPU-Optimized Image
+
+To build a Docker image with the latest CPU-optimized version of Sockeye, run the following script:
+
+```bash
+python3 sockeye_contrib/docker/build_cpu_optimized.py
+```
+
+This produces an image called `sockeye-cpu:latest` that uses the latest versions of the following:
+
+- [kpuatamazon/incubator-mxnet](https://github.com/kpuatamazon/incubator-mxnet): The MXNet fork that supports [intgemm](https://github.com/kpu/intgemm) and makes full use of Intel MKL (versus just DNNL).
+- [kpuatamazon/sockeye](https://github.com/kpuatamazon/sockeye): The Sockeye fork that supports int8 quantization for inference.
+
+This image can then be used with existing Sockeye models, which can be quantized to int8 at load time.
+In the following example, `LEXICON` is a top-k lexicon (see the [fast_align documentation](sockeye_contrib/fast_align) and `sockeye.lexicon create`; k=200 works well in practice) and `NCPUS` is the number of physical CPU cores on the host running Sockeye.
+
+```bash
+docker run --rm -i -v $PWD:/work -w /work sockeye-cpu:latest python3 -m sockeye.translate --use-cpu --omp-num-threads NCPUS --dtype int8 --input test.src --restrict-lexicon LEXICON --models model --output test.out
+```

--- a/sockeye_contrib/docker/build_cpu_optimized.py
+++ b/sockeye_contrib/docker/build_cpu_optimized.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+
+
+SOCKEYE_DIR = os.path.dirname(os.path.dirname((os.path.dirname(os.path.abspath(__file__)))))
+DOCKERFILE = os.path.join(SOCKEYE_DIR, 'sockeye_contrib', 'docker', 'Dockerfile.cpu')
+
+DOCKER = 'docker'
+
+REPOSITORY = 'sockeye-cpu'
+
+
+def check_command(cmd):
+    try:
+        retcode = subprocess.call([cmd, '--version'])
+    except FileNotFoundError:
+        retcode = None
+    if retcode != 0:
+        msg = 'Please install {}'.format(cmd)
+        raise subprocess.SubprocessError(msg)
+
+
+def run_command(cmd_args, get_output=False):
+    print('Running: {}'.format(' '.join(cmd_args)), file=sys.stderr)
+    if get_output:
+        return subprocess.check_output(cmd_args, cwd=SOCKEYE_DIR).decode('utf-8').strip()
+    return subprocess.call(cmd_args, cwd=SOCKEYE_DIR)
+
+
+def main():
+    if not os.path.exists(DOCKERFILE):
+        msg = 'Cannot find {}. Please make sure {} is a properly cloned repository.'.format(DOCKERFILE, SOCKEYE_DIR)
+        raise FileNotFoundError(msg)
+
+    check_command(DOCKER)
+
+    print('Running commands in {}'.format(SOCKEYE_DIR), file=sys.stderr)
+
+    tag = 'latest'
+
+    run_command([DOCKER, 'build', '-t', '{}:{}'.format(REPOSITORY, tag), '-f', DOCKERFILE, '.'])
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit adds a Dockerfile and build script for an experimental CPU-optimized Sockeye image.  The resulting image includes the following:
- Intel MKL 2019.4 downloaded from the apt repository.
- [kpuatamazon/incubator-mxnet](https://github.com/kpuatamazon/incubator-mxnet): The MXNet fork that supports [intgemm](https://github.com/kpu/intgemm) and makes full use of Intel MKL (versus just DNNL).
- [kpuatamazon/sockeye](https://github.com/kpuatamazon/sockeye): The Sockeye fork that supports int8 quantization for inference.

The updated docker/README.md includes instructions for using this image.

This requires no code changes to the sockeye_2 branch (version is only incremented for tracking changes).

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

