### PR TITLE
generate_graphs.py incorrect dependency.

### DIFF
--- a/sockeye_contrib/vistools/requirements.txt
+++ b/sockeye_contrib/vistools/requirements.txt
@@ -1,1 +1,1 @@
-networkx
+networkx==2.0


### PR DESCRIPTION
I followed the `sockeye/sockeye_contrib/vistools/README.md` to try generating beam search graphs but stumbled on the following error after installing the latest `networkx` as instructed by `requirements.txt`.

```
python /project/WMT20/opt/sockeye/sockeye_contrib/vistools/generate_graphs.py -d beams.json -o generated_graphs
Traceback (most recent call last):
  File "/project/WMT20/opt/sockeye/sockeye_contrib/vistools/generate_graphs.py", line 158, in <module>
    main()
  File "/project/WMT20/opt/sockeye/sockeye_contrib/vistools/generate_graphs.py", line 154, in main
    generate(args.data, args.output_dir, include_pad=args.include_pad)
  File "/project/WMT20/opt/sockeye/sockeye_contrib/vistools/generate_graphs.py", line 129, in generate
    include_pad=include_pad)
  File "/project/WMT20/opt/sockeye/sockeye_contrib/vistools/generate_graphs.py", line 106, in create_graph
    scores[level], normalized_scores[level], include_pad)
  File "/project/WMT20/opt/sockeye/sockeye_contrib/vistools/generate_graphs.py", line 92, in _add_graph_level
    graph.node[new_node]["name"] = names[i]
AttributeError: 'DiGraph' object has no attribute 'node'
```

Based on the date on that `README.md`, I simply reverted `networkx` to a version close to that date and chose `networkx==2.0`.  I haven't tried any other versions as this one worked.


#### Pull Request Checklist ##
- [X ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

