### PR TITLE
Process the shards using multiple processes in prepare_train_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.7]
+
+### Changed
+
+- Optimize prepare_data by saving the shards in parallel. The prepare_data script accepts a new parameter max-processes to control the level of parallelization.
+
 ## [2.1.6]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 
 ### Changed
 
-- Optimize prepare_data by saving the shards in parallel. The prepare_data script accepts a new parameter max-processes to control the level of parallelization.
+- Optimize prepare_data by saving the shards in parallel. The prepare_data script accepts a new parameter `--max-processes` to control the level of parallelism with which shards are written to disk.
 
 ## [2.1.6]
 

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.6'
+__version__ = '2.1.7'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -506,6 +506,7 @@ def add_prepare_data_cli_args(params):
                         help='Folder where the prepared and possibly sharded data is written to.')
     params.add_argument('--max-processes',
                         type=int_greater_or_equal(1),
+                        default=1,
                         help='Process the shards in parallel using max-processes processes.')
 
     add_logging_args(params)

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -504,6 +504,9 @@ def add_prepare_data_cli_args(params):
     params.add_argument('--output', '-o',
                         required=True,
                         help='Folder where the prepared and possibly sharded data is written to.')
+    params.add_argument('--max-processes',
+                        type=int_greater_or_equal(1),
+                        help='Process the shards in parallel using max-processes processes.')
 
     add_logging_args(params)
 

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -28,6 +28,8 @@ from typing import Any, cast, Dict, Iterator, Iterable, List, Optional, Sequence
 import mxnet as mx
 import numpy as np
 
+import multiprocessing
+
 from . import config
 from . import constants as C
 from . import horovod_mpi
@@ -535,6 +537,22 @@ def get_num_shards(num_samples: int, samples_per_shard: int, min_num_shards: int
     return max(int(math.ceil(num_samples / samples_per_shard)), min_num_shards)
 
 
+def process_shard(shard_idx, data_loader, shard_sources, shard_target, 
+                  shard_stats, output_prefix, keep_tmp_shard_files):
+    sources_sentences = [SequenceReader(s) for s in shard_sources]
+    target_sentences = SequenceReader(shard_target)
+    dataset = data_loader.load(sources_sentences, target_sentences, shard_stats.num_sents_per_bucket)
+    shard_fname = os.path.join(output_prefix, C.SHARD_NAME % shard_idx)
+    shard_stats.log()
+    logger.info("Writing '%s'", shard_fname)
+    dataset.save(shard_fname)
+
+    if not keep_tmp_shard_files:
+        for f in shard_sources:
+            os.remove(f)
+        os.remove(shard_target)
+
+
 def prepare_data(source_fnames: List[str],
                  target_fname: str,
                  source_vocabs: List[vocab.Vocab],
@@ -550,7 +568,8 @@ def prepare_data(source_fnames: List[str],
                  min_num_shards: int,
                  output_prefix: str,
                  bucket_scaling: bool = True,
-                 keep_tmp_shard_files: bool = False):
+                 keep_tmp_shard_files: bool = False,
+                 max_processes: int = None):
     logger.info("Preparing data.")
     # write vocabularies to data folder
     vocab.save_source_vocabs(source_vocabs, output_prefix)
@@ -591,19 +610,29 @@ def prepare_data(source_fnames: List[str],
                                            pad_id=C.PAD_ID)
 
     # 3. convert each shard to serialized ndarrays
-    for shard_idx, (shard_sources, shard_target, shard_stats) in enumerate(shards):
-        sources_sentences = [SequenceReader(s) for s in shard_sources]
-        target_sentences = SequenceReader(shard_target)
-        dataset = data_loader.load(sources_sentences, target_sentences, shard_stats.num_sents_per_bucket)
-        shard_fname = os.path.join(output_prefix, C.SHARD_NAME % shard_idx)
-        shard_stats.log()
-        logger.info("Writing '%s'", shard_fname)
-        dataset.save(shard_fname)
+    if not max_processes:
+        logger.info("Processing shards sequentily.")
+        # Process shards sequantially woithout using multiprocessing
+        for shard_idx, (shard_sources, shard_target, shard_stats) in enumerate(shards):
+            process_shard(shard_idx, data_loader, shard_sources, shard_target, 
+                                                        shard_stats, output_prefix, keep_tmp_shard_files)
+    else:
+        logger.info(f"Processing shards using {max_processes} processes.")
+        # Process shards in parallel using max_processes process
+        results = []
+        pool = multiprocessing.pool.Pool(processes=max_processes)
+        for shard_idx, (shard_sources, shard_target, shard_stats) in enumerate(shards):
+            result = pool.apply_async(process_shard, args=(shard_idx, data_loader, shard_sources, shard_target, 
+                                                        shard_stats, output_prefix, keep_tmp_shard_files))
+            results.append(result)
+        pool.close()
+        pool.join()
 
-        if not keep_tmp_shard_files:
-            for f in shard_sources:
-                os.remove(f)
-            os.remove(shard_target)
+        for result in results:
+            if not result.successful():
+                logger.error("Process ended in error.")
+                raise RuntimeError("Shard processing fail")
+
 
     data_info = DataInfo(sources=[os.path.abspath(fname) for fname in source_fnames],
                          target=os.path.abspath(target_fname),

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -541,8 +541,9 @@ def save_shard(shard_idx: int, data_loader: RawParallelDatasetLoader,
                shard_sources: List[str], shard_target: str, 
                shard_stats: 'DataStatistics', output_prefix: str, keep_tmp_shard_files: bool):
     """
-    Load a shard source/target data files into an NDArrays and then save it to desk.
-    Optionally it can delete the source/target files
+    Load shard source and target data files into NDArrays and save to disk.
+    Optionally it can delete the source/target files.
+
     :param shard_idx: The index of the shard.
     :param data_loader: A loader for loading parallel data from sources and target.
     :param shard_sources: A list of sources file names.
@@ -581,7 +582,7 @@ def prepare_data(source_fnames: List[str],
                  output_prefix: str,
                  bucket_scaling: bool = True,
                  keep_tmp_shard_files: bool = False,
-                 max_processes: int = None):
+                 max_processes: int = 1):
     logger.info("Preparing data.")
     # write vocabularies to data folder
     vocab.save_source_vocabs(source_vocabs, output_prefix)
@@ -622,7 +623,7 @@ def prepare_data(source_fnames: List[str],
                                            pad_id=C.PAD_ID)
 
     # 3. convert each shard to serialized ndarrays
-    if not max_processes:
+    if max_processes == 1:
         logger.info("Processing shards sequentially.")
         # Process shards sequantially woithout using multiprocessing
         for shard_idx, (shard_sources, shard_target, shard_stats) in enumerate(shards):

--- a/sockeye/prepare_data.py
+++ b/sockeye/prepare_data.py
@@ -91,7 +91,8 @@ def prepare_data(args: argparse.Namespace):
                          samples_per_shard=samples_per_shard,
                          min_num_shards=minimum_num_shards,
                          output_prefix=output_folder,
-                         bucket_scaling=bucket_scaling)
+                         bucket_scaling=bucket_scaling,
+                         max_processes=args.max_processes)
 
 
 if __name__ == "__main__":

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -62,7 +62,7 @@ def test_simple_dict():
           source_vocab=None, target_vocab=None, source_factor_vocabs=[], shared_vocab=False, num_words=(0, 0),
           word_min_count=(1, 1), pad_vocab_to_multiple_of=None,
           no_bucketing=False, bucket_width=10, no_bucket_scaling=False, max_seq_len=(99, 99),
-          monitor_pattern=None, monitor_stat_func='mx_default')),
+          monitor_pattern=None, monitor_stat_func='mx_default'))
 ])
 def test_io_args(test_params, expected_params):
     _test_args(test_params, expected_params, arguments.add_training_io_args)

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -62,7 +62,7 @@ def test_simple_dict():
           source_vocab=None, target_vocab=None, source_factor_vocabs=[], shared_vocab=False, num_words=(0, 0),
           word_min_count=(1, 1), pad_vocab_to_multiple_of=None,
           no_bucketing=False, bucket_width=10, no_bucket_scaling=False, max_seq_len=(99, 99),
-          monitor_pattern=None, monitor_stat_func='mx_default'))
+          monitor_pattern=None, monitor_stat_func='mx_default')),
 ])
 def test_io_args(test_params, expected_params):
     _test_args(test_params, expected_params, arguments.add_training_io_args)
@@ -270,7 +270,8 @@ def test_tutorial_averaging_args(test_params, expected_params, expected_params_p
           output='train_data',
           quiet=False,
           loglevel='INFO',
-          no_logfile=False
+          no_logfile=False,
+          max_processes=None
           ))
 ])
 def test_tutorial_prepare_data_cli_args(test_params, expected_params):
@@ -299,7 +300,8 @@ def test_tutorial_prepare_data_cli_args(test_params, expected_params):
           output='prepared_data',
           quiet=False,
           loglevel='INFO',
-          no_logfile=False
+          no_logfile=False,
+          max_processes=None
           ))
 ])
 def test_prepare_data_cli_args(test_params, expected_params):

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -271,7 +271,7 @@ def test_tutorial_averaging_args(test_params, expected_params, expected_params_p
           quiet=False,
           loglevel='INFO',
           no_logfile=False,
-          max_processes=None
+          max_processes=1
           ))
 ])
 def test_tutorial_prepare_data_cli_args(test_params, expected_params):
@@ -301,7 +301,7 @@ def test_tutorial_prepare_data_cli_args(test_params, expected_params):
           quiet=False,
           loglevel='INFO',
           no_logfile=False,
-          max_processes=None
+          max_processes=1
           ))
 ])
 def test_prepare_data_cli_args(test_params, expected_params):

--- a/test/unit/test_vocab.py
+++ b/test/unit/test_vocab.py
@@ -14,6 +14,8 @@
 import pytest
 from unittest import mock
 
+
+
 import sockeye.constants as C
 from sockeye.vocab import build_vocab, get_ordered_tokens_from_vocab, is_valid_vocab, _get_sorted_source_vocab_fnames
 

--- a/test/unit/test_vocab.py
+++ b/test/unit/test_vocab.py
@@ -14,8 +14,6 @@
 import pytest
 from unittest import mock
 
-
-
 import sockeye.constants as C
 from sockeye.vocab import build_vocab, get_ordered_tokens_from_vocab, is_valid_vocab, _get_sorted_source_vocab_fnames
 


### PR DESCRIPTION
Process the shards using multiple processes in prepare_train_data.

I tested the change by running the following commands and checking the outputs

```
python -m sockeye.prepare_data --source source --target target --output prepared_data --max-processes 10 --min-num-shards 20

python -m sockeye.prepare_data --source source --target target --output prepared_data
```

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

