### PR TITLE
Don't cast a model if it's already in that format.

### DIFF
--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -523,7 +523,7 @@ def load_model(model_folder: str,
         allow_missing = True
         cast_dtype = True
         dtype_source = 'saved'
-    elif dtype is None:
+    elif dtype is None or dtype == model_config.dtype:
         logger.info("Model dtype: %s" % model_config.dtype)
         allow_missing = False
         cast_dtype = False


### PR DESCRIPTION
For int8, a model already int8 run with --dtype int8 was casting everything else to int8 and breaking.

For everything else, this avoids an unnecessary cast.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`) (the same ones fail in sockeye_2 for me)
- [n/a] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`) It complains about the same things
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

