### PR TITLE
Do not use MKL on CPU builds

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 pyyaml>=5.1
-mxnet-mkl==1.6.0
+mxnet==1.6.0
 numpy>1.16.0,<2.0.0
 typing
 portalocker


### PR DESCRIPTION
Fixes OSX builds where `mxnet-mkl==1.6.0` is not available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

