### PR TITLE
Training arg for --ignore-extra-params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.9]
+
+### Added
+
+- Added training argument `--ignore-extra-params` to ignore extra parameters when loading models.  The primary use case is continuing training with a model that has already been annotated with scaling factors (`sockeye.quantize`).
+
 ## [2.1.8]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.8'
+__version__ = '2.1.9'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -595,6 +595,11 @@ def add_model_parameters(params):
                               default=False,
                               help="Allow missing parameters when initializing model parameters from file. "
                                    "Default: %(default)s.")
+    model_params.add_argument('--ignore-extra-params',
+                              action="store_true",
+                              default=False,
+                              help="Allow extra parameters when initializing model parameters from file. "
+                                   "Default: %(default)s.")
 
     model_params.add_argument('--encoder',
                               choices=C.ENCODERS,

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -910,6 +910,7 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
             training_model.load_parameters(filename=args.params,
                                            ctx=context,
                                            allow_missing=args.allow_missing_params or model_config.lhuc,
+                                           ignore_extra=args.ignore_extra_params,
                                            cast_dtype=True,
                                            dtype_source='current')
         params = training_model.collect_params()

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -99,6 +99,7 @@ def test_device_args(test_params, expected_params):
 @pytest.mark.parametrize("test_params, expected_params", [
     ('', dict(params=None,
               allow_missing_params=False,
+              ignore_extra_params=False,
               num_layers=(6, 6),
               num_embed=(None, None),
               source_factors_num_embed=[],


### PR DESCRIPTION
This adds the training argument `--ignore-extra-params`, that passes `ignore_extra=True` when loading model params.  This is particularly useful when initializing a model with parameters from a pre-trained model that has been annotated with scaling factors.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

