### PR TITLE
Cross-entropy loss without SoftmaxOutput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.10]
+
+### Changed
+
+- Changed to a cross-entropy loss implementation that avoids the use of SoftmaxOutput.
+
 ## [2.1.9]
 
 ### Added

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.9'
+__version__ = '2.1.10'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -663,7 +663,6 @@ def add_model_parameters(params):
                                    'For example: n:drn '
                                    'Default: %(default)s.')
 
-    # LHUC
     model_params.add_argument('--lhuc',
                               nargs="+",
                               default=None,
@@ -738,7 +737,6 @@ def add_batch_args(params, default_batch_size=4096):
                              'multiple of this integer. Default: %(default)s.')
 
 
-
 def add_hybridization_arg(params):
     params.add_argument('--no-hybridization',
                         action='store_true',
@@ -752,8 +750,8 @@ def add_training_args(params):
     add_batch_args(train_params)
 
     train_params.add_argument('--loss',
-                              default=C.CROSS_ENTROPY,
-                              choices=[C.CROSS_ENTROPY],
+                              default=C.CROSS_ENTROPY_WITOUT_SOFTMAX_OUTPUT,
+                              choices=[C.CROSS_ENTROPY, C.CROSS_ENTROPY_WITOUT_SOFTMAX_OUTPUT],
                               help='Loss to optimize. Default: %(default)s.')
     train_params.add_argument('--label-smoothing',
                               default=0.1,

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -324,6 +324,7 @@ EVALUATE_METRICS = [BLEU, CHRF, ROUGE1, ROUGE2, ROUGEL]
 
 # loss
 CROSS_ENTROPY = 'cross-entropy'
+CROSS_ENTROPY_WITOUT_SOFTMAX_OUTPUT = 'cross-entropy-without-softmax-output'
 LENRATIO_REGRESSION = 'length-ratio-regression'
 
 LINK_NORMAL = 'normal'

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -163,7 +163,7 @@ def test_inference_args(test_params, expected_params):
     ('', dict(batch_size=4096,
               batch_type='word',
               round_batch_sizes_to_multiple_of=1,
-              loss=C.CROSS_ENTROPY,
+              loss='cross-entropy-without-softmax-output',
               label_smoothing=0.1,
               length_task=None,
               length_task_layers=1,

--- a/test/unit/test_loss.py
+++ b/test/unit/test_loss.py
@@ -16,7 +16,6 @@ import math
 import mxnet as mx
 import numpy as np
 import pytest
-
 import sockeye.constants as C
 import sockeye.loss
 import sockeye.model
@@ -102,6 +101,84 @@ def test_cross_entropy_loss():
     assert labels.grad.sum().asscalar() == 0
 
 
+def test_cross_entropy_loss_without_softmax_output():
+    b = sockeye.loss.CrossEntropyLossWithoutSoftmaxOutput(ignore_label=C.PAD_ID, label_smoothing=0.0, num_labels=4)
+    b.initialize()
+    assert b.ignore_label == C.PAD_ID
+    assert b.name == C.CROSS_ENTROPY
+    assert b.weight == 1.0
+    assert b._dtype == C.DTYPE_FP32
+    assert b.output_name == C.LOGITS_NAME
+    assert b.label_name == C.TARGET_LABEL_NAME
+    assert b._alpha == 0.0
+
+    logits = mx.nd.array([[1, 1, 1, 1],
+                          [4, 2, 2, 2],
+                          [1, 1, 1, 1],
+                          [1, 1, 1, 1]])
+    logits.attach_grad()
+    labels = mx.nd.array([1, 0, 2, 3])
+    labels.attach_grad()
+
+    with mx.autograd.record():
+        loss_value, loss_samples = b({C.LOGITS_NAME: logits, 'other_stuff': None},
+                                     {C.TARGET_LABEL_NAME: labels, 'other_stuff': None})
+    loss_value.backward()
+    assert loss_samples.asscalar() == 1  # this loss returns always 1
+
+    expected_logits_grad = [[0.08333334, -0.25,        0.08333334,  0.08333334],
+                            [0.,          0.,          0.,          0.],
+                            [0.08333334,  0.08333334, -0.25,        0.08333334],
+                            [0.08333334,  0.08333334,  0.08333334, -0.25]]
+    num_valid = (C.PAD_ID != labels).sum().asscalar()
+    expected_loss_value = -(math.log(1/4) * 3) / num_valid  # 3 valid rows, all uniform, divided by num_valid
+
+    assert np.isclose(loss_value.asscalar(), expected_loss_value)
+    assert np.allclose(logits.grad.asnumpy(), expected_logits_grad)
+    assert labels.grad.sum().asscalar() == 0
+
+
+@pytest.mark.parametrize("label_smoothing", [0.0, 0.1])
+def test_cross_entropy_loss_implementations(label_smoothing):
+    np.random.seed(1)
+    _logits = np.random.uniform(0, 10, (1, 5, 6))
+    logits_ce = mx.nd.array(_logits)
+    logits_ce_without_softmax_output = mx.nd.array(_logits)
+    logits_ce.attach_grad()
+    logits_ce_without_softmax_output.attach_grad()
+
+    labels = mx.nd.array([[3, 2, 1, 5, 0]])
+
+    loss_ce = sockeye.loss.CrossEntropyLoss(ignore_label=0, label_smoothing=label_smoothing)
+    loss_ce_without_softmax_output = sockeye.loss.CrossEntropyLossWithoutSoftmaxOutput(
+        ignore_label=0, label_smoothing=label_smoothing, num_labels=labels.sum().asscalar() + 1)
+    loss_ce.initialize()
+    loss_ce_without_softmax_output.initialize()
+
+    metric_ce = loss_ce.create_metric()
+    metric_ce_without_softmax_output = loss_ce_without_softmax_output.create_metric()
+
+    with mx.autograd.record():
+        ce, n = loss_ce({C.LOGITS_NAME: logits_ce},
+                        {C.TARGET_LABEL_NAME: labels})
+    ce.backward()
+    metric_ce.update(ce.asnumpy(), n.asscalar())
+
+    with mx.autograd.record():
+        ce_without_softmax_output, n = loss_ce_without_softmax_output({C.LOGITS_NAME: logits_ce_without_softmax_output},
+                                                                      {C.TARGET_LABEL_NAME: labels})
+    ce_without_softmax_output.backward()
+    metric_ce_without_softmax_output.update(ce_without_softmax_output.asnumpy(), n.asscalar())
+
+    if label_smoothing == 0.0:
+        # we expect equality for logit gradients, metric value (ppl), but not forward output.
+        assert np.allclose(logits_ce.grad.asnumpy(), logits_ce_without_softmax_output.grad.asnumpy())
+        assert np.isclose(metric_ce.get(), metric_ce_without_softmax_output.get())
+    else:
+        # we expect no equality due to bug in SoftmaxOutput
+        assert logits_ce.grad.shape == logits_ce_without_softmax_output.grad.shape
+
+
 def test_perplexity_metric():
     ppl = sockeye.loss.PerplexityMetric()
     assert ppl.name == C.PERPLEXITY
@@ -110,6 +187,3 @@ def test_perplexity_metric():
         ppl.update(ce, 1)
     expected_ppl = math.exp(sum(ces) / len(ces))
     assert np.isclose(ppl.get(), expected_ppl)
-
-
-# TODO(fhieber): test to compare SoftmaxOutput and alternative cross entropy loss implementation


### PR DESCRIPTION
Use cross entropy loss implementation that avoids SoftmaxOutput by default.

Added tests to verify equivalence to SoftmaxOutput as much as possible (for the case without label smoothing). For label-smoothed cross-entropy, there actually seems to be an issue with SoftmaxOutputs gradients: I was not able to reproduce them with an independent implementation.

Speed-wise, the SoftmaxOutput-less cross-entropy loss is about 5-10% slower at equal memory cost.

However, given the issues with SoftmaxOutput smoothed gradients, I am inclined to change the default to a verifiable correct implementation.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

