### PR TITLE
Update N-best reranking module (input format, BLEU smoothing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.11]
+
+### Changed
+
+- Updated `sockeye.rerank` module to use "add-k" smoothing for sentence-level BLEU.
+
+### Fixed
+
+- Updated `sockeye.rerank` module to use current N-best format.
+
 ## [2.1.10]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.10'
+__version__ = '2.1.11'

--- a/test/unit/test_reranking.py
+++ b/test/unit/test_reranking.py
@@ -21,8 +21,8 @@ import sockeye.rerank as rerank
     (["No Liber@@ ation for Ty@@ mo@@ sh@@ en@@ ko by Parliament",
       "No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament"],
      "Parliament Does Not Support Amendment Fre@@ eing Ty@@ mo@@ sh@@ en@@ ko",
-     ['No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament',
-      'No Liber@@ ation for Ty@@ mo@@ sh@@ en@@ ko by Parliament'], "bleu"),
+     ['No Liber@@ ation for Ty@@ mo@@ sh@@ en@@ ko by Parliament',
+      'No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament'], "bleu"),
     # test chrf as metric
     (["No Liber@@ ation for Ty@@ mo@@ sh@@ en@@ ko by Parliament",
       "No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament"],
@@ -38,7 +38,9 @@ import sockeye.rerank as rerank
 ])
 def test_rerank_hypotheses(hypotheses, reference, expected_output, metric):
     reranker = rerank.Reranker(metric=metric, return_score=False)
-    hypotheses = {'translations': hypotheses}
+    hypotheses = {'sentence_id': 0,
+                  'translation': '',
+                  'translations': hypotheses}
     reranked_hypotheses = reranker.rerank(hypotheses, reference)
     assert reranked_hypotheses['translations'] == expected_output
 
@@ -47,11 +49,13 @@ def test_rerank_hypotheses(hypotheses, reference, expected_output, metric):
     (["Completely different",
       "No Liber@@ ating Ty@@ mo@@ sh@@ en@@ ko by Parliament"],
      "Parliament Does Not Support Amendment Fre@@ eing Ty@@ mo@@ sh@@ en@@ ko",
-     [60.26404810093175, 0.0])
+     [61.69564583930634, 0.0])
 ])
 def test_rerank_return_score(hypotheses, reference, expected_scores):
     reranker = rerank.Reranker(metric="bleu", return_score=True)
-    hypotheses = {'translations': hypotheses}
+    hypotheses = {'sentence_id': 0,
+                  'translation': '',
+                  'translations': hypotheses}
     reranked_hypotheses = reranker.rerank(hypotheses, reference)
     assert 'scores' in reranked_hypotheses
     actual_scores = reranked_hypotheses['scores']


### PR DESCRIPTION
This PR makes 2 updates to the `sockeye.rerank` module:

- Support the current N-best format by passing through (not sorting) non-list data (`sentence_id`, `translation`, `score`).

- Use "add-k" smoothing for sentence-level BLEU, which is the top-performing method available in SacreBLEU (see [Chen and Cherry, 2014](https://www.aclweb.org/anthology/W14-3346.pdf)).  Updated unit tests are verified by manually running SacreBLEU to confirm scores/rankings.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

