### PR TITLE
Option to suppress console output for secondary workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.13]
+
+### Added
+
+- Training option `--quiet-secondary-workers` that suppresses console output for secondary workers when training with Horovod/MPI.
+
 ## [2.1.12]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ### Added
 
 - Training option `--quiet-secondary-workers` that suppresses console output for secondary workers when training with Horovod/MPI.
+- Set version of isort to `<5.0.0` in requirements.dev.txt to avoid incompatibility between newer versions of isort and pylint.
 
 ## [2.1.12]
 

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -5,6 +5,7 @@ check-manifest
 matplotlib
 mypy==0.610
 pylint==2.3.0
+isort<5.0.0
 setuptools>=38.6.0
 twine>=1.11.0
 wheel>=0.31.0

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.12'
+__version__ = '2.1.13'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -375,6 +375,10 @@ def add_logging_args(params):
                                 default=False,
                                 action="store_true",
                                 help='Suppress console logging.')
+    logging_params.add_argument('--quiet-secondary-workers', '-qsw',
+                                default=False,
+                                action="store_true",
+                                help='Suppress console logging for secondary workers when training with Horovod/MPI.')
     logging_params.add_argument('--no-logfile',
                                 default=False,
                                 action="store_true",

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -820,6 +820,9 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
             args.output = os.path.join(args.output, C.HOROVOD_SECONDARY_WORKERS_DIRNAME, str(horovod_mpi.hvd.rank()))
             # Do not keep redundant copies of the checkpoint history
             args.keep_last_params = 1
+            # If requested, suppress console output for secondary workers
+            if args.quiet_secondary_workers:
+                args.quiet = True
 
     check_arg_compatibility(args)
     output_folder = os.path.abspath(args.output)

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -70,6 +70,7 @@ def test_io_args(test_params, expected_params):
 
 @pytest.mark.parametrize("test_params, expected_params", [
     ('', dict(quiet=False,
+              quiet_secondary_workers=False,
               loglevel='INFO',
               no_logfile=False)),
 ])
@@ -272,6 +273,7 @@ def test_tutorial_averaging_args(test_params, expected_params, expected_params_p
           seed=13,
           output='train_data',
           quiet=False,
+          quiet_secondary_workers=False,
           loglevel='INFO',
           no_logfile=False,
           max_processes=1
@@ -303,6 +305,7 @@ def test_tutorial_prepare_data_cli_args(test_params, expected_params):
           seed=13,
           output='prepared_data',
           quiet=False,
+          quiet_secondary_workers=False,
           loglevel='INFO',
           no_logfile=False,
           max_processes=1


### PR DESCRIPTION
This PR adds an option to suppress console output for secondary workers when using Horovod/MPI (`--horovod`).

By default, using N processes results in N times as many logging lines.  The `--quiet-secondary-workers` training option activates `--quiet` for secondary workers so only the primary worker's logging lines are written to the console.

**Unrelated change**: Newer versions of isort cause pylint to fail with `AttributeError: module 'isort' has no attribute 'SortImports'`.  This has caused our automatic tests to start failing, first noticed with this PR's tests.  Setting the version of isort to `<5.0.0` in requirements.dev.txt resolves this.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

