### PR TITLE
Diverse Beam Search 

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1132,7 +1132,16 @@ def add_inference_args(params):
                                type=int_greater_or_equal(1),
                                default=5,
                                help='Size of the beam. Default: %(default)s.')
-
+    decode_params.add_argument('--num-diverse-groups',
+                               type=int_greater_or_equal(1),
+                               default=1,
+                               help='Number of groups for diverse beam search. Default: %(default)s.')
+    decode_params.add_argument('--diversity-penalty',
+                               type=float,
+                               default=0.5,
+                               help='Penalty strength for diverse beam search (only takes effect when --num-diverse-groups > 1). '
+                                    'With a higher value, undiverse hypotheses will be penalized more strongly. '
+                                    'Default: %(default)s.')
     decode_params.add_argument('--beam-search-stop',
                                choices=[C.BEAM_SEARCH_STOP_ALL, C.BEAM_SEARCH_STOP_FIRST],
                                default=C.BEAM_SEARCH_STOP_ALL,

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -710,7 +710,7 @@ class BeamSearch(mx.gluon.Block):
                     # Penalize the chosen words in all following groups
                     add_diversity_penalty = mx.nd.sum(mx.nd.one_hot(group_best_word_indices, depth=vocab_size), axis=1)
                     # Don't penalize EOS and padding
-                    add_diversity_penalty[:, [C.EOS_ID, C.PAD_ID]] = 0
+                    add_diversity_penalty[:, [C.EOS_ID, C.PAD_ID]] = 0  # pylint: disable=unsupported-assignment-operation
                     diversity_penalty += mx.nd.expand_dims(add_diversity_penalty, axis=1) * self.diversity_penalty_strength
 
                 # Back to original shape: (batch_size * beam_size)

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -673,6 +673,8 @@ class Translator:
                  target_vocab: vocab.Vocab,
                  beam_size: int = 5,
                  nbest_size: int = 1,
+                 num_diverse_groups: int = 1,
+                 diversity_penalty: float = 0.5,
                  restrict_lexicon: Optional[Union[lexicon.TopKLexicon, Dict[str, lexicon.TopKLexicon]]] = None,
                  avoid_list: Optional[str] = None,
                  strip_unknown_words: bool = False,
@@ -715,9 +717,16 @@ class Translator:
             utils.check_condition(self.beam_search_stop == C.BEAM_SEARCH_STOP_ALL,
                                   "nbest_size > 1 requires beam_search_stop to be set to 'all'")
 
+        self.num_diverse_groups = num_diverse_groups
+        self.diversity_penalty = diversity_penalty
+        utils.check_condition(self.beam_size % self.num_diverse_groups == 0,
+                              "beam_size must be a multiple of num_diverse_groups")
+
         self._beam_search = get_beam_search(
             models=self.models,
             beam_size=self.beam_size,
+            num_diverse_groups=self.num_diverse_groups,
+            diversity_penalty=self.diversity_penalty,
             context=self.context,
             vocab_target=target_vocab,
             output_scores=output_scores,

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -133,6 +133,8 @@ def run_translate(args: argparse.Namespace):
                                           beam_size=args.beam_size,
                                           beam_search_stop=args.beam_search_stop,
                                           nbest_size=args.nbest_size,
+                                          num_diverse_groups=args.num_diverse_groups,
+                                          diversity_penalty=args.diversity_penalty,
                                           models=models,
                                           source_vocabs=source_vocabs,
                                           target_vocab=target_vocab,

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -134,6 +134,8 @@ def test_model_parameters(test_params, expected_params):
                       models=['model'],
                       beam_size=5,
                       nbest_size=1,
+                      num_diverse_groups=1,
+                      diversity_penalty=0.5,
                       batch_size=1,
                       chunk_size=None,
                       ensemble_mode='linear',

--- a/test/unit/test_beam_search.py
+++ b/test/unit/test_beam_search.py
@@ -403,7 +403,7 @@ def test_diverse_beam_search():
         assert len(np.unique(best_word_indices[:, t])) == beam_size
 
     # Disable diversity penalty
-    bs.diversity_penalty_strength = 0
+    bs._top.penalty_strength = 0
     bs_out = bs(source, source_length, restrict_lexicon, raw_constraints, raw_avoid_list, max_output_lengths)
     best_hyp_indices, best_word_indices, scores, lengths, estimated_ref_lengths, constraints = bs_out
 


### PR DESCRIPTION
Diverse Beam Search with Hamming diversity as described by [Vijayakumar et al. (2016)](https://arxiv.org/abs/1610.02424). `TopK` is applied to each one of the `num_diverse_groups` beam groups separately. When a word is selected in one group, that word's score is penalized in all subsequent groups. Regular beam search is still the default (with `--num-diverse-groups 1`) and should still have the same result.

Note: I didn't quite understand why `batch_size` and `beam_size` are combined into a single dimension, but I thought it was easiest to reshape them for treating each diverse group separately. I'm new to MXNet, so I might be missing something.


#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

