### PR TITLE
Refactor build_vocab to allow merging multiple independent token counters

### DIFF
--- a/test/unit/test_vocab.py
+++ b/test/unit/test_vocab.py
@@ -13,9 +13,25 @@
 
 import pytest
 from unittest import mock
+from collections import Counter
 
 import sockeye.constants as C
-from sockeye.vocab import build_vocab, get_ordered_tokens_from_vocab, is_valid_vocab, _get_sorted_source_vocab_fnames
+from sockeye.vocab import (build_vocab, get_ordered_tokens_from_vocab, is_valid_vocab, \
+    _get_sorted_source_vocab_fnames, build_raw_vocab, merge_raw_vocabs)
+
+
+def test_build_raw_vocab():
+    data = ["a b c", "c d e"]
+    raw_vocab = build_raw_vocab(data)
+    assert raw_vocab == Counter({"a": 1, "b": 1, "c": 2, "d": 1, "e": 1})
+
+
+def test_merge_raw_vocabs():
+    v1 = build_raw_vocab(["a b c", "c d e"])
+    v2 = build_raw_vocab(["a b c", "c d g"])
+    raw_vocab = merge_raw_vocabs(v1, v2)
+    assert raw_vocab == Counter({"a": 2, "b": 2, "c": 4, "d": 2, "e": 1, "g": 1})
+
 
 test_vocab = [
         # Example 1


### PR DESCRIPTION
Refactor token counting and pruning/padding/mapping into two separate methods. Also adds a merge_raw_vocab function that merges multiple raw token counters.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

