### PR TITLE
Updated output options for `sockeye.rerank`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.14]
+
+### Added
+
+- Added `sockeye.rerank` option `--output` to specify output file.
+- Added `sockeye.rerank` option `--output-reference-instead-of-blank` to output reference line instead of best hypothesis when best hypothesis is blank.
+
 ## [2.1.13]
 
 ### Added

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.13'
+__version__ = '2.1.14'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -341,9 +341,14 @@ def add_rerank_args(params):
                                choices=C.RERANK_METRICS,
                                help="Sentence-level metric used to compare each nbest translation to the reference."
                                     "Default: %(default)s.")
+    rerank_params.add_argument("--output", "-o", default=None, help="File to write output to. Default: STDOUT.")
     rerank_params.add_argument("--output-best",
                                action="store_true",
                                help="Output only the best hypothesis from each nbest list.")
+    rerank_params.add_argument("--output-reference-instead-of-blank",
+                               action="store_true",
+                               help="When outputting only the best hypothesis (--output-best) and the best hypothesis "
+                                    "is a blank line, output the reference instead.")
     rerank_params.add_argument("--return-score",
                                action="store_true",
                                help="Returns the reranking scores as scores in output JSON objects.")

--- a/sockeye/rerank.py
+++ b/sockeye/rerank.py
@@ -19,6 +19,7 @@ import argparse
 from functools import partial
 import json
 import logging
+import sys
 from typing import Any, Dict, List
 
 import numpy as np
@@ -26,6 +27,7 @@ import sacrebleu
 
 from . import arguments
 from . import constants as C
+from .data_io import smart_open
 from . import log
 from . import utils
 
@@ -90,6 +92,7 @@ def rerank(args: argparse.Namespace):
     :param args: Namespace object holding CLI arguments.
     """
     reranker = Reranker(args.metric, args.return_score)
+    output_stream = sys.stdout if args.output is None else smart_open(args.output, mode='w')
 
     with utils.smart_open(args.reference) as reference, utils.smart_open(args.hypotheses) as hypotheses:
         for i, (reference_line, hypothesis_line) in enumerate(zip(reference, hypotheses), 1):
@@ -108,12 +111,13 @@ def rerank(args: argparse.Namespace):
                 reranked_hypotheses = reranker.rerank(hypotheses, reference)
 
             if args.output_best:
-                if not num_hypotheses:
-                    print()
-                else:
-                    print(reranked_hypotheses['translations'][0])
+                best_hypothesis = reranked_hypotheses['translations'][0] if num_hypotheses else ''
+                if not best_hypothesis and args.output_reference_instead_of_blank:
+                    logger.warning('Line %d: replacing blank hypothesis with reference.', i)
+                    best_hypothesis = reference
+                print(best_hypothesis, file=output_stream)
             else:
-                print(json.dumps(reranked_hypotheses, sort_keys=True))
+                print(json.dumps(reranked_hypotheses, sort_keys=True), file=output_stream)
 
 
 def main():

--- a/sockeye/rerank.py
+++ b/sockeye/rerank.py
@@ -119,6 +119,9 @@ def rerank(args: argparse.Namespace):
             else:
                 print(json.dumps(reranked_hypotheses, sort_keys=True), file=output_stream)
 
+    if output_stream is not sys.stdout:
+        output_stream.close()
+
 
 def main():
     """


### PR DESCRIPTION
This PR adds 2 simple output options for `sockeye.rerank`:

- `--output`: Specify output file (`sys.stdout` by default)

- `--output-reference-instead-of-blank`: When outputting only the best hypothesis (`--output-best`) and the best hypothesis is blank, output the reference line instead of a blank line and log a warning message.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

