### PR TITLE
Parallelize token frequency calculation

### DIFF
--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -27,7 +27,8 @@ import random
 import sys
 import time
 from contextlib import contextmanager, ExitStack
-from functools import reduce
+from functools import partial, reduce
+from itertools import islice
 from typing import Any, List, Iterator, Iterable, Set, Tuple, Dict, Optional, Union, IO, TypeVar, cast
 
 import mxnet as mx
@@ -195,6 +196,17 @@ def chunks(some_list: List, n: int) -> Iterable[List]:
     """Yield successive n-sized chunks from l."""
     for i in range(0, len(some_list), n):
         yield some_list[i:i + n]
+
+
+def take(n: int, iterable: Iterable[Any]) -> Iterable[Any]:
+    """Return first `n` items of the iterable as a list"""
+    return list(islice(iterable, n))
+
+
+def partition_all(n: int, iterable: Iterable[Any]) -> Iterable[List[Any]]:
+    """Return chunks of size `n` from `iterable`. The last chunk may be smaller
+    than `n` if a full chunk cannot be made."""
+    return iter(partial(take, n, iter(iterable)), [])
 
 
 def get_tokens(line: str) -> Iterator[str]:


### PR DESCRIPTION
Make token frequency calculation parallel.

Currently relies on a couple of functions from [more-itertools](https://more-itertools.readthedocs.io/en/stable/index.html). We could also take a dependency on the package instead if that's desirable. It's even [endorsed](https://docs.python.org/3/library/itertools.html#itertools-recipes) by the official Python docs.

#### Pull Request Checklist ##
- [X] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [X] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [X] Passed code style checking (`./style-check.sh`)
- [X] You have considered writing a test
- [X] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [X] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

