### PR TITLE
Fix batch sizing error introduced in c00da52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ### Fixed
 
 - Fixed batch sizing error introduced in version 2.1.12 (c00da52) that caused batch sizes to be multiplied by the number of devices. Batch sizing now works as documented (same as pre-2.1.12 versions).
+- Fixed `max-word` batching to properly size batches to a multiple of both `--batch-sentences-multiple-of` and the number of devices.
 
 ## [2.1.15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.16]
+
+### Fixed
+
+- Fixed batch sizing error introduced in version 2.1.12 (c00da52) that caused batch sizes to be multiplied by the number of devices. Batch sizing now works as documented (same as pre-2.1.12 versions).
+
 ## [2.1.15]
 
 ### Added

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.15'
+__version__ = '2.1.16'

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -212,13 +212,11 @@ def define_bucket_batch_sizes(buckets: List[Tuple[int, int]],
             # Max number of sequences without exceeding batch size
             batch_size_seq = batch_size // padded_seq_len
             # Round down to closest multiple
-            batch_size_seq = (batch_size_seq // batch_sentences_multiple_of) * batch_sentences_multiple_of
+            batch_size_seq = (batch_size_seq // min_batch_step) * min_batch_step
         elif batch_type == C.BATCH_TYPE_SENTENCE:
             batch_size_seq = batch_size
         else:
             raise ValueError('Unknown batch type: %s' % batch_type)
-        # Batch size is per device
-        batch_size_seq *= batch_num_devices
         # Number of words here is an average of non-padding tokens
         batch_size_word = batch_size_seq * average_seq_len
 

--- a/test/unit/test_data_io.py
+++ b/test/unit/test_data_io.py
@@ -228,17 +228,18 @@ def test_sample_based_define_bucket_batch_sizes():
         assert bbs.average_target_words_per_batch == bbs.bucket[1] * batch_size
 
 
-@pytest.mark.parametrize("length_ratio,batch_sentences_multiple_of,expected_batch_sizes", [
+@pytest.mark.parametrize("batch_num_devices,length_ratio,batch_sentences_multiple_of,expected_batch_sizes", [
         # Reference batch sizes manually inspected for sanity.  Note that for
         # very unbalanced lengths, the last batch can be very large.  This is
         # due to the requirement for any size batch (total elements) to fit into
         # the same allocated space for MXNet's memory sharing.
-        (0.5, 1, [200.0, 100.0, 67.0, 50.0, 40.0, 33.0, 29.0, 25.0, 22.0, 41.0]),
-        (1.5, 1, [100.0, 50.0, 33.0, 25.0, 20.0, 20.0, 20.0, 20.0]),
-        (1.5, 8, [96.0, 48.0, 32.0, 24.0, 16.0, 16.0, 16.0, 24.0])])
-def test_word_based_define_bucket_batch_sizes(length_ratio, batch_sentences_multiple_of, expected_batch_sizes):
+        (1, 0.5, 1, [200.0, 100.0, 67.0, 50.0, 40.0, 33.0, 29.0, 25.0, 22.0, 41.0]),
+        (2, 0.5, 1, [200.0, 100.0, 66.0, 50.0, 40.0, 34.0, 28.0, 24.0, 22.0, 40.0]),
+        (8, 0.5, 1, [200.0, 96.0, 64.0, 48.0, 40.0, 32.0, 32.0, 24.0, 24.0, 40.0]),
+        (1, 1.5, 1, [100.0, 50.0, 33.0, 25.0, 20.0, 20.0, 20.0, 20.0]),
+        (1, 1.5, 8, [96.0, 48.0, 32.0, 24.0, 16.0, 16.0, 16.0, 24.0])])
+def test_word_based_define_bucket_batch_sizes(batch_num_devices, length_ratio, batch_sentences_multiple_of, expected_batch_sizes):
     batch_type = C.BATCH_TYPE_WORD
-    batch_num_devices = 1
     batch_size = 1000
     max_seq_len = 50
     buckets = data_io.define_parallel_buckets(max_seq_len, max_seq_len, 10, True, length_ratio)
@@ -263,14 +264,15 @@ def test_word_based_define_bucket_batch_sizes(length_ratio, batch_sentences_mult
     assert last_bbs_num_words >= max_num_words
 
 
-@pytest.mark.parametrize("length_ratio,batch_sentences_multiple_of,expected_batch_sizes", [
+@pytest.mark.parametrize("batch_num_devices,length_ratio,batch_sentences_multiple_of,expected_batch_sizes", [
         # Reference batch sizes manually inspected for sanity.
-        (0.5, 1, [200, 100, 66, 50, 40, 33, 28, 25, 22, 20]),
-        (1.5, 1, [100, 50, 33, 25, 20, 20, 20, 20]),
-        (1.5, 8, [96, 48, 32, 24, 16, 16, 16, 16])])
-def test_max_word_based_define_bucket_batch_sizes(length_ratio, batch_sentences_multiple_of, expected_batch_sizes):
+        (1, 0.5, 1, [200, 100, 66, 50, 40, 33, 28, 25, 22, 20]),
+        (2, 0.5, 1, [200, 100, 66, 50, 40, 32, 28, 24, 22, 20]),
+        (8, 0.5, 1, [200, 96, 64, 48, 40, 32, 24, 24, 16, 16]),
+        (1, 1.5, 1, [100, 50, 33, 25, 20, 20, 20, 20]),
+        (1, 1.5, 8, [96, 48, 32, 24, 16, 16, 16, 16])])
+def test_max_word_based_define_bucket_batch_sizes(batch_num_devices, length_ratio, batch_sentences_multiple_of, expected_batch_sizes):
     batch_type = C.BATCH_TYPE_MAX_WORD
-    batch_num_devices = 1
     batch_size = 1000
     max_seq_len = 50
     buckets = data_io.define_parallel_buckets(max_seq_len, max_seq_len, 10, True, length_ratio)


### PR DESCRIPTION
This PR corrects the batching error introduced in c00da52 that caused batch sizes to be multiplied by the number of devices, typically resulting in crashes due to exhausting GPU memory.  The PR also corrects a related issue with `max-word` batching.

Batch sizing now works as documented and user-specified batch sizes are always per-process.  For example:
- Training with 1 process using 4 GPUs and `--batch-size 8192`: batch size per GPU is 8192/4=2048, effective batch size is 1*8192=8192.
- Training with 4 processes using 1 GPU each (Horovod/MPI) and `--batch-size 2048`: batch size per GPU is 2048/1=2048, effective batch size is 4*2048=8192.

New unit tests cover multi-device batching for `word` and `max-word` batching.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

