### PR TITLE
Fix: Guard against null division for small batch sizes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.2.2]
+
+### Fixed
+ - Fix: Guard against null division for small batch sizes.
+
 ## [2.2.1]
 ## Fixed
 

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.2.1'
+__version__ = '2.2.2'

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -212,7 +212,7 @@ def define_bucket_batch_sizes(buckets: List[Tuple[int, int]],
             # Max number of sequences without exceeding batch size
             batch_size_seq = batch_size // padded_seq_len
             # Round down to closest multiple
-            batch_size_seq = (batch_size_seq // min_batch_step) * min_batch_step
+            batch_size_seq = max(1, batch_size_seq // min_batch_step) * min_batch_step
         elif batch_type == C.BATCH_TYPE_SENTENCE:
             batch_size_seq = batch_size
         else:

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -214,7 +214,7 @@ def define_bucket_batch_sizes(buckets: List[Tuple[int, int]],
             check_condition(batch_size_seq // min_batch_step > 0,
                             'Please increase the batch size to avoid the batch size being rounded down to 0.')
             # Round down to closest multiple
-            batch_size_seq = batch_size_seq // min_batch_step * min_batch_step
+            batch_size_seq = (batch_size_seq // min_batch_step) * min_batch_step
         elif batch_type == C.BATCH_TYPE_SENTENCE:
             batch_size_seq = batch_size
         else:

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -211,8 +211,10 @@ def define_bucket_batch_sizes(buckets: List[Tuple[int, int]],
                             % (padded_seq_len, batch_size))
             # Max number of sequences without exceeding batch size
             batch_size_seq = batch_size // padded_seq_len
+            check_condition(batch_size_seq // min_batch_step > 0,
+                            'Please increase the batch size to avoid the batch size being rounded down to 0.')
             # Round down to closest multiple
-            batch_size_seq = max(1, batch_size_seq // min_batch_step) * min_batch_step
+            batch_size_seq = batch_size_seq // min_batch_step * min_batch_step
         elif batch_type == C.BATCH_TYPE_SENTENCE:
             batch_size_seq = batch_size
         else:

--- a/test/unit/test_data_io.py
+++ b/test/unit/test_data_io.py
@@ -264,16 +264,18 @@ def test_word_based_define_bucket_batch_sizes(batch_num_devices, length_ratio, b
     assert last_bbs_num_words >= max_num_words
 
 
-@pytest.mark.parametrize("batch_num_devices,length_ratio,batch_sentences_multiple_of,expected_batch_sizes", [
+@pytest.mark.parametrize("batch_num_devices,length_ratio,batch_sentences_multiple_of,batch_size,expected_batch_sizes", [
         # Reference batch sizes manually inspected for sanity.
-        (1, 0.5, 1, [200, 100, 66, 50, 40, 33, 28, 25, 22, 20]),
-        (2, 0.5, 1, [200, 100, 66, 50, 40, 32, 28, 24, 22, 20]),
-        (8, 0.5, 1, [200, 96, 64, 48, 40, 32, 24, 24, 16, 16]),
-        (1, 1.5, 1, [100, 50, 33, 25, 20, 20, 20, 20]),
-        (1, 1.5, 8, [96, 48, 32, 24, 16, 16, 16, 16])])
-def test_max_word_based_define_bucket_batch_sizes(batch_num_devices, length_ratio, batch_sentences_multiple_of, expected_batch_sizes):
+        (1, 0.5, 1, 1000, [200, 100, 66, 50, 40, 33, 28, 25, 22, 20]),
+        (2, 0.5, 1, 1000, [200, 100, 66, 50, 40, 32, 28, 24, 22, 20]),
+        (8, 0.5, 1, 1000, [200, 96, 64, 48, 40, 32, 24, 24, 16, 16]),
+        (1, 1.5, 1, 1000, [100, 50, 33, 25, 20, 20, 20, 20]),
+        (1, 1.5, 8, 1000, [96, 48, 32, 24, 16, 16, 16, 16]),
+        (1, 1.5, 8, 100,  [8, 8, 8, 8, 8, 8, 8, 8]),
+])
+def test_max_word_based_define_bucket_batch_sizes(batch_num_devices, length_ratio, batch_sentences_multiple_of,
+                                                  batch_size, expected_batch_sizes):
     batch_type = C.BATCH_TYPE_MAX_WORD
-    batch_size = 1000
     max_seq_len = 50
     buckets = data_io.define_parallel_buckets(max_seq_len, max_seq_len, 10, True, length_ratio)
     bucket_batch_sizes = data_io.define_bucket_batch_sizes(buckets=buckets,

--- a/test/unit/test_data_io.py
+++ b/test/unit/test_data_io.py
@@ -264,18 +264,16 @@ def test_word_based_define_bucket_batch_sizes(batch_num_devices, length_ratio, b
     assert last_bbs_num_words >= max_num_words
 
 
-@pytest.mark.parametrize("batch_num_devices,length_ratio,batch_sentences_multiple_of,batch_size,expected_batch_sizes", [
+@pytest.mark.parametrize("batch_num_devices,length_ratio,batch_sentences_multiple_of,expected_batch_sizes", [
         # Reference batch sizes manually inspected for sanity.
-        (1, 0.5, 1, 1000, [200, 100, 66, 50, 40, 33, 28, 25, 22, 20]),
-        (2, 0.5, 1, 1000, [200, 100, 66, 50, 40, 32, 28, 24, 22, 20]),
-        (8, 0.5, 1, 1000, [200, 96, 64, 48, 40, 32, 24, 24, 16, 16]),
-        (1, 1.5, 1, 1000, [100, 50, 33, 25, 20, 20, 20, 20]),
-        (1, 1.5, 8, 1000, [96, 48, 32, 24, 16, 16, 16, 16]),
-        (1, 1.5, 8, 100,  [8, 8, 8, 8, 8, 8, 8, 8]),
-])
-def test_max_word_based_define_bucket_batch_sizes(batch_num_devices, length_ratio, batch_sentences_multiple_of,
-                                                  batch_size, expected_batch_sizes):
+        (1, 0.5, 1, [200, 100, 66, 50, 40, 33, 28, 25, 22, 20]),
+        (2, 0.5, 1, [200, 100, 66, 50, 40, 32, 28, 24, 22, 20]),
+        (8, 0.5, 1, [200, 96, 64, 48, 40, 32, 24, 24, 16, 16]),
+        (1, 1.5, 1, [100, 50, 33, 25, 20, 20, 20, 20]),
+        (1, 1.5, 8, [96, 48, 32, 24, 16, 16, 16, 16])])
+def test_max_word_based_define_bucket_batch_sizes(batch_num_devices, length_ratio, batch_sentences_multiple_of, expected_batch_sizes):
     batch_type = C.BATCH_TYPE_MAX_WORD
+    batch_size = 1000
     max_seq_len = 50
     buckets = data_io.define_parallel_buckets(max_seq_len, max_seq_len, 10, True, length_ratio)
     bucket_batch_sizes = data_io.define_bucket_batch_sizes(buckets=buckets,


### PR DESCRIPTION
For small batch sizes we could end up with batch sizes of 0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

