### PR TITLE
Guard against empty bucket slices when loading shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,20 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 
 ### Fixed
 
-- When loading a shard in Horovod mode, there is now a check that each bucket contains enough sentences to cover each worker's slice. If not, the bucket's sentences are replicated to guarantee coverage.
+- When loading a shard in Horovod mode, there is now a check that each non-empty bucket contains enough sentences to cover each worker's slice. If not, the bucket's sentences are replicated to guarantee coverage.
 
 ## [2.1.17]
 
 ### Added
 
-- Added `layers.SSRU`, which implements a Simpler Simple Recurrent Unit as described in 
+- Added `layers.SSRU`, which implements a Simpler Simple Recurrent Unit as described in
 Kim et al, "From Research to Production and Back: Ludicrously Fast Neural Machine Translation" WNGT 2019.
 
 - Added `ssru_transformer` option to `--decoder`, which enables the usage of SSRUs as a replacement for the decoder-side self-attention layers.
 
 ### Changed
 
-- Reduced the number of arguments for `MultiHeadSelfAttention.hybrid_forward()`. 
+- Reduced the number of arguments for `MultiHeadSelfAttention.hybrid_forward()`.
  `previous_keys` and `previous_values` should now be input together as `previous_states`, a list containing two symbols.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.18]
+
+### Fixed
+
+- When loading a shard in Horovod mode, there is now a check that each bucket contains enough sentences to cover each worker's slice. If not, the bucket's sentences are replicated to guarantee coverage.
+
 ## [2.1.17]
 
 ### Added

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.17'
+__version__ = '2.1.18'

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -1455,8 +1455,8 @@ class ParallelDataSet:
                     if num_copies > 1:
                         logger.info('Replicating bucket of %d sentence(s) %d times to cover %d splits.',
                                     num_sentences, num_copies, total_splits)
-                        source[k] = mx.nd.concat(*[source[k] for _ in range(num_copies)], dim=0)
-                        target[k] = mx.nd.concat(*[target[k] for _ in range(num_copies)], dim=0)
+                        source[k] = mx.nd.repeat(source[k], repeats=num_copies, axis=0)
+                        target[k] = mx.nd.repeat(target[k], repeats=num_copies, axis=0)
             # Load this worker's slice of each bucket.  If the bucket is empty,
             # there is no need to slice and attempting to do so will raise an
             # error.

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -1432,6 +1432,7 @@ class ParallelDataSet:
         """
         Loads a dataset from a binary .npy file.  When running Horovod, the data
         is sliced and each worker loads a different slice based on its rank.
+        Specifically, each of N workers loads 1/N of each bucket.
         """
         data = mx.nd.load(fname)
         n = len(data) // 2
@@ -1442,6 +1443,19 @@ class ParallelDataSet:
             total_splits = horovod_mpi.hvd.size()
             i = split_index / total_splits
             j = (split_index + 1) / total_splits
+            # For each bucket, check if there are more splits (workers) than
+            # sentences.  If so, replicate that bucket's sentences N times where
+            # N is the minimum number required so that each split has at least
+            # one sentence.
+            for k in range(len(source)):
+                num_sentences = len(source[k])
+                if num_sentences > 0:
+                    num_copies = math.ceil(total_splits / num_sentences)
+                    if num_copies > 1:
+                        logger.info('Replicating bucket of %d sentences %d times to cover %d splits.',
+                                    num_sentences, num_copies, total_splits)
+                        source[k] = mx.nd.concat(*[source[k] for _ in range(num_copies)], dim=0)
+                        target[k] = mx.nd.concat(*[target[k] for _ in range(num_copies)], dim=0)
             # Load this worker's slice of each bucket.  If the bucket is empty,
             # there is no need to slice and attempting to do so will raise an
             # error.

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -1452,7 +1452,7 @@ class ParallelDataSet:
                 if num_sentences > 0:
                     num_copies = math.ceil(total_splits / num_sentences)
                     if num_copies > 1:
-                        logger.info('Replicating bucket of %d sentences %d times to cover %d splits.',
+                        logger.info('Replicating bucket of %d sentence(s) %d times to cover %d splits.',
                                     num_sentences, num_copies, total_splits)
                         source[k] = mx.nd.concat(*[source[k] for _ in range(num_copies)], dim=0)
                         target[k] = mx.nd.concat(*[target[k] for _ in range(num_copies)], dim=0)

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -1446,7 +1446,8 @@ class ParallelDataSet:
             # For each bucket, check if there are more splits (workers) than
             # sentences.  If so, replicate that bucket's sentences N times where
             # N is the minimum number required so that each split has at least
-            # one sentence.
+            # one sentence.  This is not required for empty buckets since all
+            # splits will contain zero sentences.
             for k in range(len(source)):
                 num_sentences = len(source[k])
                 if num_sentences > 0:


### PR DESCRIPTION
When loading a shard in Horovod mode, each of the N workers loads 1/N of each bucket (one "split").  This PR adds the following safeguard: if a bucket is non-empty but contains fewer than N sentences, replicate those sentences the minimum number of times to meet or exceed N.  This guarantees that each bucket will be consistently empty or non-empty across workers.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

