### PR TITLE
Update TrainState metrics before saving TrainState to fix inconsistency with training resumption. Fixes #859

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.20]
+
+### Fixed
+
+- Fixed a bug where the training state object was saved to disk before training metrics were added to it, leading to an inconsistency between the training state object and the metrics file (see #859).
+
 ## [2.1.19]
 
 ### Fixed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.19'
+__version__ = '2.1.20'

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -161,12 +161,6 @@ class TrainState:
             setattr(self, k, v)
         self.gradients = {}
 
-    def __repr__(self):
-        return "TrainState: epoch=%d, checkpoint=%d batches=%d updates=%d best_metric=%.2f, " \
-               "best_checkpoint=%d time_elapsed=%d" % (
-            self.epoch, self.checkpoint, self.batches, self.updates, self.best_metric,
-            self.best_checkpoint, self.time_elapsed)
-
 
 class GluonEarlyStoppingTrainer:
 
@@ -670,7 +664,10 @@ class GluonEarlyStoppingTrainer:
                  self.trainer._amp_loss_scaler._next_loss_scale,
                  self.trainer._amp_loss_scaler._unskipped) = pickle.load(fp)
 
-        logger.info(self.state)
+        logger.info("Training State: epoch=%d, checkpoint=%d batches=%d updates=%d best_metric=%.2f, " \
+                    "best_checkpoint=%d time_elapsed=%d" % (
+                        self.state.epoch, self.state.checkpoint, self.state.batches, self.state.updates,
+                        self.state.best_metric, self.state.best_checkpoint, self.state.time_elapsed))
 
     def _cleanup(self, keep_training_state=False):
         """


### PR DESCRIPTION
Fixes an issue where the training state would be pickled to disk before the metrics were added to it. For training resumption, this led to an inconsistency between the loaded TrainState object and the metrics file, as reported in #859 .

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

