### PR TITLE
Re-introduce '--softmax-temperature'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.1.22]
+
+### Added
+
+- Re-introduced `--softmax-temperature` flag for `sockeye.score` and `sockeye.translate`.
+
 ## [2.1.21]
 
 ### Added

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.1.21'
+__version__ = '2.1.22'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1083,6 +1083,11 @@ def add_score_cli_args(params):
                         choices=C.SCORING_TYPE_CHOICES,
                         default=C.SCORING_TYPE_DEFAULT,
                         help='Score type to output. Default: %(default)s')
+    params.add_argument('--softmax-temperature',
+                        type=float,
+                        default=None,
+                        help='Controls peakiness of model predictions. Values < 1.0 produce '
+                             'peaked predictions, values > 1.0 produce smoothed distributions.')
 
     params.add_argument('--dtype', default=None, choices=[None, C.DTYPE_FP32, C.DTYPE_FP16, C.DTYPE_INT8],
                         help="Data type. Default: %(default)s infers from saved model.")
@@ -1162,7 +1167,14 @@ def add_inference_args(params):
     decode_params.add_argument('--mc-dropout',
                                default=False,
                                action='store_true',
-                               help='Turn on dropout during inference (Monte Carlo dropout). This will make translations non-deterministic and might slow down translation speed.')
+                               help='Turn on dropout during inference (Monte Carlo dropout). '
+                                    'This will make translations non-deterministic and might slow '
+                                    'down translation speed.')
+    decode_params.add_argument('--softmax-temperature',
+                               type=float,
+                               default=None,
+                               help='Controls peakiness of model predictions. Values < 1.0 produce '
+                                    'peaked predictions, values > 1.0 produce smoothed distributions.')
     decode_params.add_argument('--sample',
                                type=int_greater_or_equal(0),
                                default=None,

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -682,7 +682,8 @@ class Translator:
                  hybridize: bool = True,
                  max_output_length_num_stds: int = C.DEFAULT_NUM_STD_MAX_OUTPUT_LENGTH,
                  max_input_length: Optional[int] = None,
-                 max_output_length: Optional[int] = None) -> None:
+                 max_output_length: Optional[int] = None,
+                 softmax_temperature: Optional[float] = None) -> None:
         self.context = context
         self.dtype = C.DTYPE_FP32 if models[0].dtype == C.DTYPE_INT8 else models[0].dtype
         self._scorer = scorer
@@ -727,14 +728,15 @@ class Translator:
             scorer=self._scorer,
             constant_length_ratio=constant_length_ratio,
             avoid_list=avoid_list,
-            hybridize=hybridize)
+            hybridize=hybridize,
+            softmax_temperature=softmax_temperature)
 
         self._concat_translations = partial(_concat_nbest_translations if self.nbest_size > 1 else _concat_translations,
                                             stop_ids=self.stop_ids,
                                             scorer=self._scorer)  # type: Callable
 
         logger.info("Translator (%d model(s) beam_size=%d beam_search_stop=%s max_input_length=%s "
-                    "nbest_size=%s ensemble_mode=%s max_batch_size=%d avoiding=%d dtype=%s)",
+                    "nbest_size=%s ensemble_mode=%s max_batch_size=%d avoiding=%d dtype=%s softmax_temperature=%s)",
                     len(self.models),
                     self.beam_size,
                     self.beam_search_stop,
@@ -743,7 +745,8 @@ class Translator:
                     "None" if len(self.models) == 1 else ensemble_mode,
                     self.max_batch_size,
                     0 if self._beam_search.global_avoid_trie is None else len(self._beam_search.global_avoid_trie),
-                    self.dtype)
+                    self.dtype,
+                    softmax_temperature)
 
     @property
     def max_input_length(self) -> int:

--- a/sockeye/score.py
+++ b/sockeye/score.py
@@ -95,7 +95,8 @@ def score(args: argparse.Namespace):
                                                                   length_penalty_beta=args.length_penalty_beta,
                                                                   brevity_penalty_weight=args.brevity_penalty_weight),
                                            score_type=args.score_type,
-                                           constant_length_ratio=constant_length_ratio)
+                                           constant_length_ratio=constant_length_ratio,
+                                           softmax_temperature=args.softmax_temperature)
         if hybridize:
             batch_scorer.hybridize(static_alloc=True)
 

--- a/sockeye/scoring.py
+++ b/sockeye/scoring.py
@@ -39,11 +39,13 @@ class BatchScorer(mx.gluon.HybridBlock):
                  scorer: CandidateScorer,
                  score_type: str = C.SCORING_TYPE_DEFAULT,
                  constant_length_ratio: Optional[float] = None,
-                 prefix='BatchScorer_') -> None:
+                 prefix='BatchScorer_',
+                 softmax_temperature: Optional[float] = None) -> None:
         super().__init__(prefix=prefix)
         self.score_type = score_type
         self.scorer = scorer
         self.constant_length_ratio = constant_length_ratio
+        self.softmax_temperature = softmax_temperature
 
     def hybrid_forward(self, F, logits, labels, length_ratio, source_length, target_length):
         """
@@ -56,7 +58,7 @@ class BatchScorer(mx.gluon.HybridBlock):
         :param target_length: Target lengths. Shape: (batch,).
         :return: Sequence scores. Shape: (batch,).
         """
-        logprobs = F.log_softmax(logits, axis=-1)
+        logprobs = F.log_softmax(logits, axis=-1, temperature=self.softmax_temperature)
 
         # Select the label probability, then take their logs.
         # probs and scores: (batch_size, target_seq_len)

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -146,7 +146,8 @@ def run_translate(args: argparse.Namespace):
                                           max_output_length_num_stds=args.max_output_length_num_stds,
                                           max_input_length=args.max_input_length,
                                           max_output_length=args.max_output_length,
-                                          hybridize=hybridize)
+                                          hybridize=hybridize,
+                                          softmax_temperature=args.softmax_temperature)
         read_and_translate(translator=translator,
                            output_handler=output_handler,
                            chunk_size=args.chunk_size,

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -154,6 +154,7 @@ def test_model_parameters(test_params, expected_params):
                       strip_unknown_words=False,
                       dtype=None,
                       mc_dropout=False,
+                      softmax_temperature=None,
                       sample=None,
                       seed=None)),
 ])


### PR DESCRIPTION
Adds back ability to control softmax temperature in inference & scoring (as was available in Sockeye 1).


#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

