### PR TITLE
Small typo in --checkpoint-improvement-threshold's CLI documentation.

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -858,7 +858,7 @@ def add_training_args(params):
     train_params.add_argument('--checkpoint-improvement-threshold',
                               type=float,
                               default=0.,
-                              help='Improvement in <optimized-metric> over specified number of checkpoints must exceed'
+                              help='Improvement in <optimized-metric> over specified number of checkpoints must exceed '
                                    'this value to be considered actual improvement. Default: %(default)s.')
 
     train_params.add_argument('--min-num-epochs',


### PR DESCRIPTION
There is a minor typo in sockeye.train's CLI where `--checkpoint-improvement-threshold` is missing a space.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

