### PR TITLE
Re-introduce softmax with length in DotAttention (see #772)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ### Changed
 
 - Updated to [MXNet 1.7.0](https://github.com/apache/incubator-mxnet/tree/1.7.0).
+- Re-introduced use of softmax with length parameter in DotAttentionCell (see PR #772).
 
 ## [2.1.22]
 

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -308,9 +308,6 @@ class TransformerEncoder(Encoder, mx.gluon.HybridBlock):
                                                              prefix=C.SOURCE_POSITIONAL_EMBEDDING_PREFIX,
                                                              scale_up_input=True,
                                                              scale_down_positions=False)
-            self.valid_length_mask = transformer.TransformerValidLengthMask(num_heads=self.config.attention_heads,
-                                                                            fold_heads=True,
-                                                                            name="bias")
 
             self.layers = mx.gluon.nn.HybridSequential()
             for i in range(config.num_layers):
@@ -328,11 +325,11 @@ class TransformerEncoder(Encoder, mx.gluon.HybridBlock):
         if self.config.dropout_prepost > 0.0:
             data = F.Dropout(data=data, p=self.config.dropout_prepost)
 
-        # (batch_size * heads, 1, seq_len)
-        bias = F.expand_dims(self.valid_length_mask(data, valid_length), axis=1)
+        # (batch_size * heads,)
+        att_valid_length = F.repeat(valid_length, repeats=self.config.attention_heads, axis=0)
 
         for block in self.layers:
-            data = block(data, bias)
+            data = block(data, att_valid_length)
 
         data = self.final_process(data, None)
         return data, valid_length

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -305,11 +305,9 @@ class DotAttentionCell(mx.gluon.HybridBlock):
         logits = F.batch_dot(lhs=queries, rhs=keys, transpose_b=True)
 
         if bias is not None:
-            assert lengths is None, "Cannot provide both bias and lengths"
             logits = F.broadcast_add(logits, bias)
 
         if lengths is not None:
-            assert bias is None, "Cannot provide both bias and lengths"
             lengths = F.broadcast_like(F.expand_dims(lengths, axis=1), logits, lhs_axes=(1,), rhs_axes=(1,))
             probs = F.softmax(logits, axis=-1, length=F.cast(lengths, dtype='int32'), use_length=True)
         else:

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -105,9 +105,9 @@ class TransformerEncoderBlock(mx.gluon.HybridBlock):
             if config.use_lhuc:
                 self.lhuc = layers.LHUC(config.model_size)
 
-    def hybrid_forward(self, F, data: mx.sym.Symbol, bias: mx.sym.Symbol) -> mx.sym.Symbol:
+    def hybrid_forward(self, F, data: mx.sym.Symbol, lengths: mx.sym.Symbol) -> mx.sym.Symbol:
         # self-attention
-        data_self_att, _, __ = self.self_attention(self.pre_self_attention(data, None), [None, None], None, bias)
+        data_self_att, _, __ = self.self_attention(self.pre_self_attention(data, None), [None, None], lengths, None)
         data = self.post_self_attention(data_self_att, data)
 
         # feed-forward
@@ -215,7 +215,7 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
                        target: mx.sym.Symbol,
                        target_bias: mx.sym.Symbol,
                        source: mx.sym.Symbol,
-                       source_bias: mx.sym.Symbol,
+                       source_att_lengths: mx.sym.Symbol,
                        autoregr_states: mx.sym.Symbol,
                        enc_att_k: Optional[mx.sym.Symbol] = None,
                        enc_att_v: Optional[mx.sym.Symbol] = None) -> Tuple[mx.sym.Symbol,
@@ -230,8 +230,8 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
         # encoder attention
         target_enc_att = self.enc_attention(self.pre_enc_attention(target, None),
                                             source,
+                                            source_att_lengths,
                                             None,
-                                            source_bias,
                                             enc_att_k,
                                             enc_att_v)
 
@@ -326,51 +326,6 @@ class TransformerFeedForward(mx.gluon.HybridBlock):
             h = F.Dropout(h, p=self.dropout)
         y = self.ff2(h)
         return y
-
-
-class TransformerValidLengthMask(mx.gluon.HybridBlock):
-    """
-    Returns bias/mask for variable sequence lengths.
-
-    :param num_heads: Number of attention heads.
-    :param fold_heads: Whether to fold heads dimension into batch dimension.
-    :param name: Name of symbol.
-    :return: Bias symbol. Shape: (batch, seq_len)
-    """
-    def __init__(self, num_heads: Optional[int] = None, fold_heads: bool = True, name: str = '') -> None:
-        super().__init__(prefix=name)
-        self.num_heads = num_heads
-        self.fold_heads = fold_heads
-        self._dtype = 'float32'
-
-    def cast(self, dtype):
-        self._dtype = dtype
-        super().cast(dtype)
-
-    def hybrid_forward(self, F, data, lengths):
-        """
-        Returns bias/mask for variable sequence lengths.
-
-        :param F: symbolic or ndarray.
-        :param data: Input data to mask. Shape: (batch, seq_len, _).
-        :param lengths: Sequence lengths. Shape: (batch,).
-        :return:
-        """
-        # (batch, 1)
-        mask = F.reshape(F.zeros_like(lengths.astype(self._dtype)), shape=(-1, 1))
-        # (batch, seq_len)
-        mask = F.broadcast_like(mask, data, lhs_axes=(1,), rhs_axes=(1,))
-        # (batch_size, max_length)
-        mask = F.SequenceMask(data=mask,
-                              use_sequence_length=True,
-                              sequence_length=lengths,
-                              axis=1,
-                              value=-C.LARGE_VALUES[self._dtype])
-        if self.num_heads is not None:
-            # (batch_size, heads, max_length) if fold_heads == False else (batch_size * heads, max_length)
-            mask = layers.broadcast_to_heads(F, mask, self.num_heads, ndim=2, fold_heads=self.fold_heads)
-
-        return F.BlockGrad(mask)
 
 
 class AutoRegressiveBias(mx.gluon.HybridBlock):


### PR DESCRIPTION
Re-introduces #772 which was reverted after discovering an incompatibility with `broadcast_like` in MXNet 1.6. This is fixed in MXNet 1.7, therefore, this PR is based on the `mx17` branch.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

