### PR TITLE
-Infinity score bug in beam decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.2.1]
+## Fixed
+
+- Fixes a corner case bug by which the beam decoder can wrongly return a best hypothesis with -infinite score.
+
 ## [2.2.0]
 
 ### Changed
@@ -1105,5 +1110,3 @@ sockeye.evaluate now accepts `bleu` and `chrf` as values for `--metrics`
 ### Changed
  - `--attention-*` CLI params renamed to `--rnn-attention-*`.
  - `--transformer-no-positional-encodings` generalized to `--transformer-positional-embedding-type`.
-
-

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -565,7 +565,7 @@ class BeamSearch(mx.gluon.Block):
         # locations of each batch item when first dimension is (batch * beam)
         batch_indices = mx.nd.arange(0, batch_size * self.beam_size, self.beam_size, dtype='int32', ctx=self.context)
         first_step_mask = mx.nd.full((batch_size * self.beam_size, 1), val=np.inf, ctx=self.context, dtype=self.dtype)
-        first_step_mask[batch_indices] = 1.0
+        first_step_mask[batch_indices] = 0.0
         pad_dist = mx.nd.full((batch_size * self.beam_size, self.output_vocab_size - 1), val=np.inf,
                               ctx=self.context, dtype=self.dtype)
         eos_dist = mx.nd.full((batch_size * self.beam_size, self.output_vocab_size), val=np.inf,
@@ -673,7 +673,7 @@ class BeamSearch(mx.gluon.Block):
                 # On the first timestep, all hypotheses have identical histories, so force topk() to choose extensions
                 # of the first row only by setting all other rows to inf
                 if t == 1:
-                    scores *= first_step_mask
+                    scores += first_step_mask
 
                 best_hyp_indices, best_word_indices, scores_accumulated = self._top(scores, offset)
 


### PR DESCRIPTION
When beam-size > 1, a tiny negative score (~-10E-12) in the scores matrix
multiplied with first_step_mask introduces -inf, which ranks first in topk.

Summing the mask is more robust and should fix this corner case issue.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

