### PR TITLE
Use arange_like in AutoRegressiveBias block to reduce overall number of ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,17 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.2.4]
+
+### Changed
+
+- Use `contrib.arange_like` in AutoRegressiveBias block to reduce number of ops. 
+
 ## [2.2.3]
+
 ### Added
- - Log the absolute number of `<unk>` tokens in source and target data
+
+- Log the absolute number of `<unk>` tokens in source and target data
 
 ## [2.2.2]
 
@@ -21,6 +29,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
  - Fix: Guard against null division for small batch sizes.
 
 ## [2.2.1]
+
 ## Fixed
 
 - Fixes a corner case bug by which the beam decoder can wrongly return a best hypothesis with -infinite score.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.2.3'
+__version__ = '2.2.4'

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -372,7 +372,7 @@ class TransformerValidLengthMask(mx.gluon.HybridBlock):
 
 
 class AutoRegressiveBias(mx.gluon.HybridBlock):
-    def __init__(self, prefix: str = '',) -> None:
+    def __init__(self, prefix: str = '') -> None:
         super().__init__(prefix=prefix)
         self._dtype = 'float32'
 
@@ -381,15 +381,12 @@ class AutoRegressiveBias(mx.gluon.HybridBlock):
         super().cast(dtype)
 
     def hybrid_forward(self, F, x):
-        # (length)
-        x = F.squeeze(F.slice(x, begin=(0, None, 0), end=(1, None, 1)))
-        # (length, 1)
-        # TODO: use F.contrib.arange_like with MXNET 1.6.0
-        length_array = F.cast(F.contrib.index_array(x, axes=(1,)), dtype=self._dtype)
+        # Shape: (length, 1)
+        length_array = F.contrib.arange_like(x, axis=1)
         # matrix with lower triangle and main diagonal set to 0, upper triangle set to 1
         # Shape: (length, length)
-        bias = F.broadcast_greater(F.reshape(length_array, shape=(1, -1)),
-                                   length_array)
+        bias = F.broadcast_greater(F.expand_dims(length_array, axis=0),
+                                   F.expand_dims(length_array, axis=1))
         bias = bias * -C.LARGE_VALUES[self._dtype]
         bias = F.expand_dims(bias, axis=0)
         return F.BlockGrad(bias)

--- a/test/unit/test_transformer.py
+++ b/test/unit/test_transformer.py
@@ -15,19 +15,23 @@ import mxnet as mx
 import numpy as np
 
 import sockeye.transformer
+import sockeye.constants as C
 
 
 def test_auto_regressive_bias_dtype():
     block = sockeye.transformer.AutoRegressiveBias()
     block.initialize()
     length = 10
-    data = mx.nd.ones((2, length, 10), dtype='float32')
+    dtype = 'float32'
+    data = mx.nd.ones((2, length, 10), dtype=dtype)
     bias = block(data)
     assert bias.dtype == np.float32
 
-    block.cast('float16')
-    bias = block(data.astype('float16'))
+    dtype = 'float16'
+    block.cast(dtype)
+    bias = block(data.astype(dtype))
     assert bias.dtype == np.float16
+    assert bias.min().asscalar() == -C.LARGE_VALUES[dtype]
 
 
 def test_auto_regressive_bias_output():


### PR DESCRIPTION
Addition of `arange_like` since MXNet 1.6 allows us to simplify AutoRegressiveBias a little bit.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

