### PR TITLE
Fix amp issues with using length argument for softmax in attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,25 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.2.4]
+
+### Changed
+
+- Use softmax with length in DotAttentionCell.
+
 ## [2.2.3]
+
 ### Added
  - Log the absolute number of `<unk>` tokens in source and target data
 
 ## [2.2.2]
 
 ### Fixed
- - Fix: Guard against null division for small batch sizes.
+
+- Fix: Guard against null division for small batch sizes.
 
 ## [2.2.1]
+
 ## Fixed
 
 - Fixes a corner case bug by which the beam decoder can wrongly return a best hypothesis with -infinite score.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.2.3'
+__version__ = '2.2.4'

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -143,9 +143,7 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
                                                              scale_up_input=True,
                                                              scale_down_positions=False)
             self.autoregressive_bias = transformer.AutoRegressiveBias(prefix="autoregressive_bias_")
-            self.valid_length_mask = transformer.TransformerValidLengthMask(num_heads=self.config.attention_heads,
-                                                                            fold_heads=False,
-                                                                            name="bias")
+
             self.layers = mx.gluon.nn.HybridSequential()
             for i in range(config.num_layers):
                 self.layers.add(transformer.TransformerDecoderBlock(config, prefix="%d_" % i, dtype=dtype,
@@ -187,21 +185,22 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
         :param encoder_valid_length: Valid lengths of encoder outputs. Shape: (batch,).
         :return: Initial states.
         """
-        source_mask = self.valid_length_mask(encoder_outputs, encoder_valid_length)
+        # (batch, heads)
+        att_valid_length = encoder_valid_length.reshape((-1, 1)).repeat(repeats=self.config.attention_heads, axis=1)
 
         # (batch_size, 1)
         step = mx.nd.expand_dims(mx.nd.zeros_like(encoder_valid_length), axis=1)
 
         if self.inference_only:
             # Encoder projection caching, therefore we don't pass the encoder_outputs
-            states = [step, source_mask]
+            states = [step, att_valid_length]
 
             for layer in self.layers:
                 enc_att_kv = layer.enc_attention.ff_kv(encoder_outputs)
                 states.append(mx.nd.transpose(enc_att_kv, axes=(1, 0, 2)))
         else:
             # NO encoder projection caching
-            states = [step, mx.nd.transpose(encoder_outputs, axes=(1, 0, 2)), source_mask]
+            states = [step, mx.nd.transpose(encoder_outputs, axes=(1, 0, 2)), att_valid_length]
 
         batch_size = encoder_outputs.shape[0]
         dummy_autoregr_states = [mx.nd.zeros(layer.get_states_shape(batch_size),
@@ -273,8 +272,8 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
                 new_states = [step, states[1]] + encoder_attention_keys_values + autoregr_states
             else:
                 encoder_outputs = states[1]
-                source_mask = states[2]
-                new_states = [step, encoder_outputs, source_mask] + autoregr_states
+                att_valid_length = states[2]
+                new_states = [step, encoder_outputs, att_valid_length] + autoregr_states
 
             assert len(new_states) == len(states)
         else:
@@ -284,14 +283,14 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
     def hybrid_forward(self, F, step_input, states):
         mask = None
         if self.inference_only:
-            steps, source_mask, *other = states
+            steps, att_valid_length, *other = states
             source_encoded = None  # use constant pre-computed key value projections from the states
             enc_att_kv = other[:self.config.num_layers]
             autoregr_states = other[self.config.num_layers:]
         else:
             if any(layer.needs_mask for layer in self.layers):
                 mask = self.autoregressive_bias(step_input)  # mask: (1, length, length)
-            steps, source_encoded, source_mask, *autoregr_states = states
+            steps, source_encoded, att_valid_length, *autoregr_states = states
             enc_att_kv = [None for _ in range(self.config.num_layers)]
 
         if any(layer.num_state_tensors > 1 for layer in self.layers):
@@ -299,8 +298,8 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             states_iter = iter(autoregr_states)
             autoregr_states = [list(islice(states_iter, 0, layer.num_state_tensors)) for layer in self.layers]
 
-        # Fold the heads of source_mask (batch_size, num_heads, seq_len) -> (batch_size * num_heads, 1, seq_len)
-        source_mask = F.expand_dims(F.reshape(source_mask, shape=(-3, -2)), axis=1)
+        # Fold the heads of source_mask (batch_size, num_heads, seq_len) -> (batch_size * num_heads, seq_len)
+        att_valid_length = F.reshape(att_valid_length, shape=(-3, -2))
 
         # target: (batch_size, length, model_size)
         target = self.pos_embedding(step_input, steps)
@@ -315,7 +314,7 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             target, new_layer_autoregr_state = layer(target,
                                                      mask,
                                                      source_encoded,
-                                                     source_mask,
+                                                     att_valid_length,
                                                      layer_autoregr_state,
                                                      layer_enc_att_kv)
 

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -298,8 +298,8 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             autoregr_states = [list(islice(states_iter, 0, layer.num_state_tensors)) for layer in self.layers]
 
         # (batch_size * heads, query_length)
-        source_valid_length = layers.prepare_softmax_lengths(F, source_valid_length, step_input,
-                                                             num_heads=self.config.attention_heads)
+        source_valid_length = layers.prepare_source_valid_lengths(F, source_valid_length, step_input,
+                                                                  num_heads=self.config.attention_heads)
 
         # target: (batch_size, length, model_size)
         target = self.pos_embedding(step_input, steps)

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -201,10 +201,10 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             # NO encoder projection caching
             states = [step, mx.nd.transpose(encoder_outputs, axes=(1, 0, 2)), encoder_valid_length]
 
-        batch_size = encoder_outputs.shape[0]
-        dummy_autoregr_states = [mx.nd.zeros(layer.get_states_shape(batch_size),
-                                             ctx=encoder_outputs.context,
-                                             dtype=encoder_outputs.dtype)
+        _batch_size = encoder_outputs.shape[0]
+        _ctx = encoder_outputs.context
+        _dtype = encoder_outputs.dtype
+        dummy_autoregr_states = [mx.nd.zeros(layer.get_states_shape(_batch_size), ctx=_ctx, dtype=_dtype)
                                  for layer in self.layers
                                  for _ in range(layer.num_state_tensors)]
 

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -327,6 +327,8 @@ class TransformerEncoder(Encoder, mx.gluon.HybridBlock):
 
         # (batch_size * heads,)
         att_valid_length = F.repeat(valid_length, repeats=self.config.attention_heads, axis=0)
+        att_valid_length = F.broadcast_like(F.expand_dims(att_valid_length, axis=1), data, lhs_axes=(1,), rhs_axes=(1,))
+        att_valid_length = F.cast(att_valid_length, dtype='int32')
 
         data = F.transpose(data, axes=(1, 0, 2))
         for block in self.layers:

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -326,8 +326,8 @@ class TransformerEncoder(Encoder, mx.gluon.HybridBlock):
             data = F.Dropout(data=data, p=self.config.dropout_prepost)
 
         # (batch_size * heads, seq_len)
-        att_valid_length = layers.prepare_softmax_lengths(F, valid_length, data,
-                                                          num_heads=self.config.attention_heads)
+        att_valid_length = layers.prepare_source_valid_lengths(F, valid_length, data,
+                                                               num_heads=self.config.attention_heads)
 
         data = F.transpose(data, axes=(1, 0, 2))
         for block in self.layers:

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -308,9 +308,6 @@ class TransformerEncoder(Encoder, mx.gluon.HybridBlock):
                                                              prefix=C.SOURCE_POSITIONAL_EMBEDDING_PREFIX,
                                                              scale_up_input=True,
                                                              scale_down_positions=False)
-            self.valid_length_mask = transformer.TransformerValidLengthMask(num_heads=self.config.attention_heads,
-                                                                            fold_heads=True,
-                                                                            name="bias")
 
             self.layers = mx.gluon.nn.HybridSequential()
             for i in range(config.num_layers):
@@ -328,13 +325,12 @@ class TransformerEncoder(Encoder, mx.gluon.HybridBlock):
         if self.config.dropout_prepost > 0.0:
             data = F.Dropout(data=data, p=self.config.dropout_prepost)
 
-        # (batch_size * heads, 1, seq_len)
-        bias = F.expand_dims(self.valid_length_mask(data, valid_length), axis=1)
+        # (batch_size * heads,)
+        att_valid_length = F.repeat(valid_length, repeats=self.config.attention_heads, axis=0)
+
         data = F.transpose(data, axes=(1, 0, 2))
-
         for block in self.layers:
-            data = block(data, bias)
-
+            data = block(data, att_valid_length)
         data = self.final_process(data, None)
         data = F.transpose(data, axes=(1, 0, 2))
         return data, valid_length

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -325,10 +325,9 @@ class TransformerEncoder(Encoder, mx.gluon.HybridBlock):
         if self.config.dropout_prepost > 0.0:
             data = F.Dropout(data=data, p=self.config.dropout_prepost)
 
-        # (batch_size * heads,)
-        att_valid_length = F.repeat(valid_length, repeats=self.config.attention_heads, axis=0)
-        att_valid_length = F.broadcast_like(F.expand_dims(att_valid_length, axis=1), data, lhs_axes=(1,), rhs_axes=(1,))
-        att_valid_length = F.cast(att_valid_length, dtype='int32')
+        # (batch_size * heads, seq_len)
+        att_valid_length = layers.prepare_softmax_lengths(F, valid_length, data,
+                                                          num_heads=self.config.attention_heads)
 
         data = F.transpose(data, axes=(1, 0, 2))
         for block in self.layers:

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1057,10 +1057,11 @@ class Translator:
 
             # Obtain sequences for all best hypotheses in the batch
             indices = self._get_best_word_indices_for_kth_hypotheses(best_ids, best_hyp_indices)
+            indices_shape_1 = indices.shape[1]
             nbest_translations.append(
                     [self._assemble_translation(*x) for x in
                      zip(best_word_indices[indices,
-                                           np.arange(indices.shape[1])],  # pylint: disable=unsubscriptable-object
+                                           np.arange(indices_shape_1)],  # pylint: disable=unsubscriptable-object
                          lengths[best_ids],
                          seq_scores[best_ids],
                          histories,

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -13,7 +13,7 @@
 
 import logging
 from abc import abstractmethod
-from typing import Optional, Union, Tuple, List
+from typing import Optional, Union, Tuple
 from functools import lru_cache
 
 import mxnet as mx
@@ -257,31 +257,6 @@ class LengthRatio(mx.gluon.HybridBlock):
         return F.squeeze(data)
 
 
-def broadcast_to_heads(F, x: mx.sym.Symbol, num_heads: int, ndim: int, fold_heads: bool = True) -> mx.sym.Symbol:
-    """
-    Broadcasts batch-major input of shape (batch, d1 ... dn-1) to (batch*heads, d1 ... dn-1).
-
-    :param x: Batch-major input. Shape: (batch, d1 ... dn-1).
-    :param num_heads: Number of heads.
-    :param ndim: Number of dimensions in x.
-    :param fold_heads: Whether to fold heads dimension into batch dimension.
-    :return: Tensor with each sample repeated heads-many times.
-             Shape: (batch * heads, d1 ... dn-1) if fold_heads == True, (batch, heads, d1 ... dn-1) else.
-    """
-    dims = [0] * (ndim - 1)
-    # x: (batch, 1)
-    x = F.expand_dims(x, axis=1)
-    # x: (batch, heads, dims...)
-    #x = F.broadcast_to(x, shape=[0, num_heads] + dims)
-    x = F.repeat(x, repeats=num_heads, axis=1)
-    if fold_heads:
-        # (batch * heads, dims...)
-        return F.reshape(x, shape=[-3] + dims)
-    else:
-        # x: (batch, heads, dims...)
-        return x
-
-
 class DotAttentionCell(mx.gluon.HybridBlock):
 
     def __init__(self, dropout: float = 0.0, prefix: str = '') -> None:
@@ -298,23 +273,17 @@ class DotAttentionCell(mx.gluon.HybridBlock):
         # (n*h, lq, lk)
         logits = F.contrib.interleaved_matmul_encdec_qk(queries, key_values, heads=heads)
 
-        # TODO(fhieber): consider softmax with length argument once available.
-        # TODO(fhieber: Also see https://github.com/dmlc/gluon-nlp/pull/910
-        if lengths is not None:
-            # mask lk dimension
-            # (lk, n, lq)
-            logits = F.transpose(logits, axes=(2, 0, 1))
-            logits = F.SequenceMask(logits,
-                                    use_sequence_length=True,
-                                    sequence_length=lengths,
-                                    value=-C.LARGE_VALUES[self._dtype])
-            # (n, lq, lk)
-            logits = F.transpose(data=logits, axes=(1, 2, 0))
-
         if bias is not None:
             logits = F.broadcast_add(logits, bias)
 
-        probs = F.softmax(logits, axis=-1)
+        if lengths is not None:
+            # before: (n*h, 1)
+            # after: (n*h, lq)
+            lengths = F.broadcast_like(F.expand_dims(lengths, axis=1), logits, lhs_axes=(1,), rhs_axes=(1,))
+            probs = F.softmax(logits, axis=-1, length=F.cast(lengths, dtype='int32'), use_length=True)
+        else:
+            probs = F.softmax(logits, axis=-1)
+
         probs = F.Dropout(probs, p=self.dropout) if self.dropout > 0.0 else probs
         
         # key_values: (lk, n, dv * 2)
@@ -364,12 +333,10 @@ class MultiHeadAttentionBase(mx.gluon.HybridBlock):
 
         :param queries: Query tensor. Shape: (query_max_length, batch_size, depth).
         :param key_values: Keys. Shape: (memory_max_length, batch_size, depth * 2).
-        :param lengths: Optional lengths of keys. Shape: (batch_size,).
+        :param lengths: Optional lengths of keys. Shape: (batch_size*heads,).
         :param bias: Optional 3d bias.
         :return: Context vectors. Shape: (batch_size, query_max_length, output_depth).
         """
-        lengths = broadcast_to_heads(F, lengths, self.heads, ndim=1,
-                                     fold_heads=True) if lengths is not None else lengths
 
         # (query_max_length, batch, depth)
         contexts = self.dot_att(queries, key_values, self.heads, lengths, bias)

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -277,10 +277,8 @@ class DotAttentionCell(mx.gluon.HybridBlock):
             logits = F.broadcast_add(logits, bias)
 
         if lengths is not None:
-            # before: (n*h, 1)
-            # after: (n*h, lq)
-            lengths = F.broadcast_like(F.expand_dims(lengths, axis=1), logits, lhs_axes=(1,), rhs_axes=(1,))
-            probs = F.softmax(logits, axis=-1, length=F.cast(lengths, dtype='int32'), use_length=True)
+            # required shape for lengths: (n*h, lq); required dtype: int32
+            probs = F.softmax(logits, axis=-1, length=lengths, use_length=True)
         else:
             probs = F.softmax(logits, axis=-1)
 

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -293,7 +293,7 @@ class DotAttentionCell(mx.gluon.HybridBlock):
         return F.contrib.interleaved_matmul_encdec_valatt(key_values, probs, heads=heads)
 
 
-def prepare_softmax_lengths(F, valid_length, query_data, num_heads: int):
+def prepare_source_valid_lengths(F, valid_length, query_data, num_heads: int):
     """
     Returns an int32 valid length tensor of shape (batch * num_heads, query_length) to be used in
     the softmax operation in DotAttentionCell with the length argument.
@@ -302,6 +302,7 @@ def prepare_softmax_lengths(F, valid_length, query_data, num_heads: int):
     :param valid_length: Valid length information. Shape: (batch,).
     :param query_data: Tensor from which the query_length dimension is derived.
                        Expected shape: (X, query_length, ...).
+    :param num_heads: Number of attention heads.
     :return: int32 tensor of shape (batch * num_heads, query_length).
     """
     # (batch * heads,)

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -122,8 +122,8 @@ class TransformerEncoderBlock(mx.gluon.HybridBlock):
 
 class TransformerDecoderBlock(mx.gluon.HybridBlock):
     """
-    A transformer decoder block consists of an autoregressive attention block, encoder attention, and a feed-forward layer
-    with pre/post process blocks in between.
+    A transformer decoder block consists of an autoregressive attention block, encoder attention,
+    and a feed-forward layer with pre/post process blocks in between.
     """
 
     def __init__(self,
@@ -313,9 +313,11 @@ class TransformerFeedForward(mx.gluon.HybridBlock):
         super().__init__(prefix=prefix)
         self.dropout = dropout
         with self.name_scope():
-            self.ff1 = quantization.QuantizableDense(in_units=num_model, units=num_hidden, flatten=False, prefix='i2h_', dtype = dtype)
+            self.ff1 = quantization.QuantizableDense(in_units=num_model, units=num_hidden, flatten=False, prefix='i2h_',
+                                                     dtype=dtype)
             self.act = layers.get_activation(act_type)
-            self.ff2 = quantization.QuantizableDense(in_units=num_hidden, units=num_model, flatten=False, prefix='h2o_', dtype = dtype)
+            self.ff2 = quantization.QuantizableDense(in_units=num_hidden, units=num_model, flatten=False, prefix='h2o_',
+                                                     dtype=dtype)
 
     def hybrid_forward(self, F, x):
         h = self.ff1(x)

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -105,9 +105,9 @@ class TransformerEncoderBlock(mx.gluon.HybridBlock):
             if config.use_lhuc:
                 self.lhuc = layers.LHUC(config.model_size)
 
-    def hybrid_forward(self, F, data: mx.sym.Symbol, bias: mx.sym.Symbol) -> mx.sym.Symbol:
+    def hybrid_forward(self, F, data: mx.sym.Symbol, lengths: mx.sym.Symbol) -> mx.sym.Symbol:
         # self-attention
-        data_self_att, _ = self.self_attention(self.pre_self_attention(data, None), None, None, bias)
+        data_self_att, _ = self.self_attention(self.pre_self_attention(data, None), None, lengths, None)
         data = self.post_self_attention(data_self_att, data)
 
         # feed-forward
@@ -215,7 +215,7 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
                        target: mx.sym.Symbol,
                        target_bias: mx.sym.Symbol,
                        source: mx.sym.Symbol,
-                       source_bias: mx.sym.Symbol,
+                       source_att_lengths: mx.sym.Symbol,
                        autoregr_states: mx.sym.Symbol,
                        enc_att_kv: Optional[mx.sym.Symbol] = None) -> Tuple[mx.sym.Symbol,
                                                                             mx.sym.Symbol]:
@@ -229,8 +229,8 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
         # encoder attention
         target_enc_att = self.enc_attention(self.pre_enc_attention(target, None),
                                             source,
+                                            source_att_lengths,
                                             None,
-                                            source_bias,
                                             enc_att_kv)
 
         target = self.post_enc_attention(target_enc_att, target)
@@ -324,51 +324,6 @@ class TransformerFeedForward(mx.gluon.HybridBlock):
             h = F.Dropout(h, p=self.dropout)
         y = self.ff2(h)
         return y
-
-
-class TransformerValidLengthMask(mx.gluon.HybridBlock):
-    """
-    Returns bias/mask for variable sequence lengths.
-
-    :param num_heads: Number of attention heads.
-    :param fold_heads: Whether to fold heads dimension into batch dimension.
-    :param name: Name of symbol.
-    :return: Bias symbol. Shape: (batch, seq_len)
-    """
-    def __init__(self, num_heads: Optional[int] = None, fold_heads: bool = True, name: str = '') -> None:
-        super().__init__(prefix=name)
-        self.num_heads = num_heads
-        self.fold_heads = fold_heads
-        self._dtype = 'float32'
-
-    def cast(self, dtype):
-        self._dtype = dtype
-        super().cast(dtype)
-
-    def hybrid_forward(self, F, data, lengths):
-        """
-        Returns bias/mask for variable sequence lengths.
-
-        :param F: symbolic or ndarray.
-        :param data: Input data to mask. Shape: (batch, seq_len, _).
-        :param lengths: Sequence lengths. Shape: (batch,).
-        :return:
-        """
-        # (batch, 1)
-        mask = F.reshape(F.zeros_like(lengths.astype(self._dtype)), shape=(-1, 1))
-        # (batch, seq_len)
-        mask = F.broadcast_like(mask, data, lhs_axes=(1,), rhs_axes=(1,))
-        # (batch_size, max_length)
-        mask = F.SequenceMask(data=mask,
-                              use_sequence_length=True,
-                              sequence_length=lengths,
-                              axis=1,
-                              value=-C.LARGE_VALUES[self._dtype])
-        if self.num_heads is not None:
-            # (batch_size, heads, max_length) if fold_heads == False else (batch_size * heads, max_length)
-            mask = layers.broadcast_to_heads(F, mask, self.num_heads, ndim=2, fold_heads=self.fold_heads)
-
-        return F.BlockGrad(mask)
 
 
 class AutoRegressiveBias(mx.gluon.HybridBlock):


### PR DESCRIPTION
Re-introduce (again and again) the use of the length argument in the softmax call in DotAttentionCell.
Previously this caused issues with Automatic Mixed Precision training as broadcast_like does not like different dtypes for its input arguments. While this has been fixed in MXNet master, it was not yet merged back to the 1.x branches, therefore it is not part of MXNet 1.6 or 1.7 (or 1.8).

However, we can move the creation of the length tensor for softmax to a different place which avoids the differing dtype problem. 

This change is confirmed to be working with AMP and giving a slight increase in training and inference speed as previously measured.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

