### PR TITLE
Reduce calls to ndarray.shape and number of casts

### DIFF
--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -603,20 +603,20 @@ class BeamSearch(mx.gluon.Block):
                                      mode='constant', constant_values=self.eos_id)
             vocab_slice_ids = mx.nd.array(vocab_slice_ids, ctx=self.context, dtype='int32')
 
-            vocab_slice_ids_shape = vocab_slice_ids.shape
-            if vocab_slice_ids_shape[0] < self.beam_size + 1:
+            vocab_slice_ids_shape = vocab_slice_ids.shape[0]
+            if vocab_slice_ids_shape < self.beam_size + 1:
                 # This fixes an edge case for toy models, where the number of vocab ids from the lexicon is
                 # smaller than the beam size.
                 logger.warning("Padding vocab_slice_ids (%d) with EOS to have at least %d+1 elements to expand",
-                               vocab_slice_ids_shape[0], self.beam_size)
-                n = self.beam_size - vocab_slice_ids_shape[0] + 1
+                               vocab_slice_ids_shape, self.beam_size)
+                n = self.beam_size - vocab_slice_ids_shape + 1
                 vocab_slice_ids = mx.nd.concat(vocab_slice_ids,
                                                mx.nd.full((n,), val=self.eos_id, ctx=self.context, dtype='int32'),
                                                dim=0)
 
-            pad_dist = mx.nd.full((batch_size * self.beam_size, vocab_slice_ids_shape[0] - 1),
+            pad_dist = mx.nd.full((batch_size * self.beam_size, vocab_slice_ids_shape - 1),
                                   val=np.inf, ctx=self.context)
-            eos_dist = mx.nd.full((batch_size * self.beam_size, vocab_slice_ids_shape[0]),
+            eos_dist = mx.nd.full((batch_size * self.beam_size, vocab_slice_ids_shape),
                                   val=np.inf, ctx=self.context)
             eos_dist[:, C.EOS_ID] = 0
 

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -722,8 +722,7 @@ class BeamSearch(mx.gluon.Block):
         scores_accumulated_shape = scores_accumulated.shape
         folded_accumulated_scores = scores_accumulated.reshape((batch_size,
                                                                 self.beam_size * scores_accumulated_shape[-1]))
-        indices = mx.nd.cast(mx.nd.argsort(folded_accumulated_scores.astype('float32'),
-                                           axis=1), dtype='int32').reshape((-1,))
+        indices = mx.nd.argsort(folded_accumulated_scores.astype('float32'), axis=1, dtype='int32').reshape((-1,))
         best_hyp_indices, _ = mx.nd.unravel_index(indices, scores_accumulated_shape) + offset
         scores_accumulated = scores_accumulated.take(best_hyp_indices)
         best_hyp_indices_list.append(best_hyp_indices)

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -365,9 +365,9 @@ class TopK(mx.gluon.HybridBlock):
         return best_hyp_indices, best_word_indices, values
 
     def hybrid_forward(self, F, scores):
-        values, indices = F.topk(scores, axis=1, k=self.k, ret_typ='both', is_ascend=True)
+        values, indices = F.topk(scores, axis=1, k=self.k, ret_typ='both', is_ascend=True, dtype='int32')
         # Project indices back into original shape (which is different for t==1 and t>1)
-        return F.reshape(F.cast(indices, 'int32'), shape=(-1,)), F.reshape(values, shape=(-1, 1))
+        return F.reshape(indices, shape=(-1,)), F.reshape(values, shape=(-1, 1))
 
 
 class SampleK(mx.gluon.HybridBlock):

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -428,6 +428,7 @@ def _repeat_states(states: List, beam_size: int, state_structure: List) -> List:
         repeated_states.append(repeated_state)
     return repeated_states
 
+
 class SortStates(mx.gluon.HybridBlock):
 
     def __init__(self, state_structure, prefix):
@@ -460,7 +461,7 @@ class BeamSearch(mx.gluon.Block):
     - constraints (pos & neg)
     - ensemble decoding
     - vocabulary selection
-    - sampling (TODO: check if its working correctly)
+    - sampling
 
     Not supported:
     - beam pruning
@@ -638,7 +639,7 @@ class BeamSearch(mx.gluon.Block):
         # item on the beam for each sentence
         inactive = mx.nd.zeros((batch_size * self.beam_size), dtype='int32', ctx=self.context)
         t = 1
-        for t in range(1, max_iterations + 1):  # TODO: max_iterations + 1 is the MINIMUM to get correct results right now
+        for t in range(1, max_iterations + 1):  # max_iterations + 1 required to get correct results
             # (1) obtain next predictions and advance models' state
             # target_dists: (batch_size * beam_size, target_vocab_size)
             target_dists, model_states = self._inference.decode_step(best_word_indices, model_states, vocab_slice_ids)
@@ -721,7 +722,8 @@ class BeamSearch(mx.gluon.Block):
         scores_accumulated_shape = scores_accumulated.shape
         folded_accumulated_scores = scores_accumulated.reshape((batch_size,
                                                                 self.beam_size * scores_accumulated_shape[-1]))
-        indices = mx.nd.cast(mx.nd.argsort(folded_accumulated_scores.astype('float32'), axis=1), dtype='int32').reshape((-1,))
+        indices = mx.nd.cast(mx.nd.argsort(folded_accumulated_scores.astype('float32'),
+                                           axis=1), dtype='int32').reshape((-1,))
         best_hyp_indices, _ = mx.nd.unravel_index(indices, scores_accumulated_shape) + offset
         scores_accumulated = scores_accumulated.take(best_hyp_indices)
         best_hyp_indices_list.append(best_hyp_indices)

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -29,7 +29,8 @@ logger = logging.getLogger(__name__)
 DecoderConfig = Union[transformer.TransformerConfig]
 
 
-def get_decoder(config: DecoderConfig, inference_only: bool = False, prefix: str = '', dtype: str = C.DTYPE_FP32) -> 'Decoder':
+def get_decoder(config: DecoderConfig, inference_only: bool = False,
+                prefix: str = '', dtype: str = C.DTYPE_FP32) -> 'Decoder':
     return Decoder.get_decoder(config, inference_only, prefix, dtype)
 
 
@@ -123,7 +124,8 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
 
     :param config: Transformer configuration.
     :param prefix: Name prefix for symbols of this decoder.
-    :param inference_only: Only use the model for inference enabling some optimizations, such as disabling the auto-regressive mask.
+    :param inference_only: Only use the model for inference enabling some optimizations,
+                           such as disabling the auto-regressive mask.
     """
 
     def __init__(self,

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -253,7 +253,7 @@ class TransformerDecoder(Decoder, mx.gluon.HybridBlock):
             # Replace the single step by multiple steps for training
             step, *states = states
             # Create steps (1, trg_seq_len,)
-            steps = mx.nd.expand_dims(mx.nd.arange(step_input.shape[1], ctx=step_input.context), axis=0)
+            steps = mx.nd.expand_dims(mx.nd.arange(input_shape[1], ctx=step_input.context), axis=0)
             states = [steps] + states
 
         # run decoder op

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -13,7 +13,7 @@
 
 import logging
 from abc import abstractmethod
-from typing import Optional, Union, Tuple, List
+from typing import Optional, Union, Tuple
 from functools import lru_cache
 
 import mxnet as mx
@@ -125,7 +125,9 @@ class OutputLayer(mx.gluon.HybridBlock):
 
         with self.name_scope():
             if dtype == C.DTYPE_INT8:
-                self.scaling = self.params.get('scaling', shape=(1,), init=mx.initializer.Constant(-1.0), dtype=C.DTYPE_FP32, allow_deferred_init=False)
+                self.scaling = self.params.get('scaling',
+                                               shape=(1,), init=mx.initializer.Constant(-1.0),
+                                               dtype=C.DTYPE_FP32, allow_deferred_init=False)
                 # This is only for inference but MXNet tries to create an
                 # initializer anyway, then fails because most random
                 # generators don't support int8 output.
@@ -143,7 +145,8 @@ class OutputLayer(mx.gluon.HybridBlock):
             self.bias = self.params.get("bias",
                                         shape=(vocab_size,),
                                         init=bias_initializer,
-                                        dtype=dtype if dtype != C.DTYPE_INT8 else C.DTYPE_FP32, # Bias stays fp32 even with int8 weights.
+                                        # Bias stays fp32 even with int8 weights.
+                                        dtype=dtype if dtype != C.DTYPE_INT8 else C.DTYPE_FP32,
                                         allow_deferred_init=False)
 
     @lru_cache(maxsize=1)
@@ -173,15 +176,15 @@ class OutputLayer(mx.gluon.HybridBlock):
                                             name=C.LOGITS_NAME)
         return super().forward(data)
 
-    def hybrid_forward(self, F, data, weight, bias, scaling = None):
+    def hybrid_forward(self, F, data, weight, bias, scaling=None):
         if self.weight.dtype == C.DTYPE_INT8:
             return F.contrib.intgemm_fully_connected(data=data,
-                                    num_hidden=self.vocab_size,
-                                    weight=weight,
-                                    scaling=scaling,
-                                    bias=bias,
-                                    flatten=False,
-                                    name=C.LOGITS_NAME)
+                                                     num_hidden=self.vocab_size,
+                                                     weight=weight,
+                                                     scaling=scaling,
+                                                     bias=bias,
+                                                     flatten=False,
+                                                     name=C.LOGITS_NAME)
         else:
             return F.FullyConnected(data=data,
                                     num_hidden=self.vocab_size,
@@ -351,7 +354,8 @@ class MultiHeadAttentionBase(mx.gluon.HybridBlock):
 
         with self.name_scope():
             self.dot_att = DotAttentionCell(dropout=dropout, prefix='dot_att')
-            self.ff_out = quantization.QuantizableDense(in_units=depth_att, units=depth_out, flatten=False, use_bias=False, prefix='h2o_', dtype = dtype)
+            self.ff_out = quantization.QuantizableDense(in_units=depth_att, units=depth_out,
+                                                        flatten=False, use_bias=False, prefix='h2o_', dtype=dtype)
 
     def _attend(self,
                 F,
@@ -441,7 +445,8 @@ class MultiHeadSelfAttention(MultiHeadAttentionBase, AutoregressiveLayer):
 
         self.depth_att = depth_att
         with self.name_scope():
-            self.ff_in = quantization.QuantizableDense(in_units=depth_att, units=depth_att * 3, flatten=False, use_bias=False, prefix='i2h_', dtype=dtype)
+            self.ff_in = quantization.QuantizableDense(in_units=depth_att, units=depth_att * 3,
+                                                       flatten=False, use_bias=False, prefix='i2h_', dtype=dtype)
 
     @property
     def prefix(self) -> str:
@@ -522,8 +527,10 @@ class MultiHeadAttention(MultiHeadAttentionBase):
         super().__init__(prefix, depth_att, heads, depth_out, dropout, dtype)
 
         with self.name_scope():
-            self.ff_q = quantization.QuantizableDense(in_units=depth_out, units=depth_att, flatten=False, use_bias=False, prefix='q2h_', dtype=dtype)
-            self.ff_kv = quantization.QuantizableDense(in_units=depth_key_value, units=2*depth_att, flatten=False, use_bias=False, prefix='kv2h_', dtype=dtype)
+            self.ff_q = quantization.QuantizableDense(in_units=depth_out, units=depth_att,
+                                                      flatten=False, use_bias=False, prefix='q2h_', dtype=dtype)
+            self.ff_kv = quantization.QuantizableDense(in_units=depth_key_value, units=2*depth_att,
+                                                       flatten=False, use_bias=False, prefix='kv2h_', dtype=dtype)
 
     def hybrid_forward(self, F,
                        queries: mx.sym.Symbol,
@@ -791,7 +798,6 @@ class SSRU(AutoregressiveLayer):
             step_input, forget_rate = step_input_and_forget_rate  # each of shape (batch_size, model_size)
             current_step_state = forget_rate * previous_step_state + step_input
             return current_step_state, current_step_state
-
 
         # (max_length, batch, input_depth), (batch, input_depth)
         cell_state, last_step_state = F.contrib.foreach(_time_step_update,


### PR DESCRIPTION
Each call to `ndarray.shape` is a library call to MXNet. This PR reduces the number of calls in some of the critical code paths.

Also, return topk indices directly as int, avoiding a separate casting.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

