### PR TITLE
Log level for secondary workers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.2.7]
+
+### Added
+- Added an argument to specify the log level of secondary workers. Defaults to ERROR to hide any logs except for exception.
+
+
 ## [2.2.6]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ## [2.2.7]
 
 ### Added
-- Added an argument to specify the log level of secondary workers. Defaults to ERROR to hide any logs except for exception.
+- Added an argument to specify the log level of secondary workers. Defaults to ERROR to hide any logs except for exceptions.
 
 
 ## [2.2.6]

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.2.6'
+__version__ = '2.2.7'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -388,10 +388,15 @@ def add_logging_args(params):
                                 default=False,
                                 action="store_true",
                                 help='Suppress file logging')
+    log_levels = ['INFO', 'DEBUG', 'ERROR']
     logging_params.add_argument('--loglevel',
                                 default='INFO',
-                                choices=['INFO', 'DEBUG'],
+                                choices=log_levels,
                                 help='Log level. Default: %(default)s.')
+    logging_params.add_argument('--loglevel-secondary-workers',
+                                default='ERROR',
+                                choices=log_levels,
+                                help='Log level for secondary workers. Default: %(default)s.')
 
 
 def add_training_data_args(params, required=False):

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -394,7 +394,7 @@ def add_logging_args(params):
                                 choices=log_levels,
                                 help='Log level. Default: %(default)s.')
     logging_params.add_argument('--loglevel-secondary-workers',
-                                default='ERROR',
+                                default='INFO',
                                 choices=log_levels,
                                 help='Console log level for secondary workers. Default: %(default)s.')
 

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -396,7 +396,7 @@ def add_logging_args(params):
     logging_params.add_argument('--loglevel-secondary-workers',
                                 default='ERROR',
                                 choices=log_levels,
-                                help='Log level for secondary workers. Default: %(default)s.')
+                                help='Console log level for secondary workers. Default: %(default)s.')
 
 
 def add_training_data_args(params, required=False):

--- a/sockeye/log.py
+++ b/sockeye/log.py
@@ -130,8 +130,8 @@ def setup_main_logger(file_logging=True, console=True, path: Optional[str] = Non
     for _, handler_config in log_config['handlers'].items():  # type: ignore
         handler_config['level'] = level
 
-    if 'console' in log_config['handlers'] and console_level is not None:
-        log_config['handlers']['console']['level'] = console_level
+    if 'console' in log_config['handlers'] and console_level is not None:  # type: ignore
+        log_config['handlers']['console']['level'] = console_level  # type: ignore
 
     logging.config.dictConfig(log_config)  # type: ignore
 

--- a/sockeye/log.py
+++ b/sockeye/log.py
@@ -103,7 +103,8 @@ LOGGING_CONFIGS = {
 }
 
 
-def setup_main_logger(file_logging=True, console=True, path: Optional[str] = None, level=logging.INFO):
+def setup_main_logger(file_logging=True, console=True, path: Optional[str] = None, level=logging.INFO,
+                      console_level=None):
     """
     Configures logging for the main application.
 
@@ -111,6 +112,7 @@ def setup_main_logger(file_logging=True, console=True, path: Optional[str] = Non
     :param console: Whether to log to the console.
     :param path: Optional path to write logfile to.
     :param level: Log level. Default: INFO.
+    :param console_level: Optionally specify a separate log level for the console.
     """
     if file_logging and console:
         log_config = LOGGING_CONFIGS["file_console"]  # type: ignore
@@ -127,6 +129,9 @@ def setup_main_logger(file_logging=True, console=True, path: Optional[str] = Non
 
     for _, handler_config in log_config['handlers'].items():  # type: ignore
         handler_config['level'] = level
+
+    if 'console' in log_config['handlers'] and console_level is not None:
+        log_config['handlers']['console']['level'] = console_level
 
     logging.config.dictConfig(log_config)  # type: ignore
 

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -804,6 +804,7 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
     # training run) and a local rank (unique on the current host).  For example,
     # running on 2 hosts with 4 slots each will assign ranks 0-7 and local ranks
     # 0-3.
+    console_level = None
     if args.horovod:
         if horovod_mpi.hvd is None or horovod_mpi.MPI is None:
             raise RuntimeError('Horovod training requires the following packages to be installed: horovod mpi4py')
@@ -825,7 +826,7 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
             # If requested, suppress console output for secondary workers
             if args.quiet_secondary_workers:
                 args.quiet = True
-            args.loglevel = args.loglevel_secondary_workers
+            console_level = args.loglevel_secondary_workers
 
     check_arg_compatibility(args)
     output_folder = os.path.abspath(args.output)
@@ -834,7 +835,8 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
     setup_main_logger(file_logging=not args.no_logfile,
                       console=not args.quiet,
                       path=os.path.join(output_folder, C.LOG_NAME),
-                      level=args.loglevel)
+                      level=args.loglevel,
+                      console_level=console_level)
     utils.log_basic_info(args)
     arguments.save_args(args, os.path.join(output_folder, C.ARGS_STATE_NAME))
 

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -825,6 +825,7 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
             # If requested, suppress console output for secondary workers
             if args.quiet_secondary_workers:
                 args.quiet = True
+            args.loglevel = args.loglevel_secondary_workers
 
     check_arg_compatibility(args)
     output_folder = os.path.abspath(args.output)

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -72,6 +72,7 @@ def test_io_args(test_params, expected_params):
     ('', dict(quiet=False,
               quiet_secondary_workers=False,
               loglevel='INFO',
+              loglevel_secondary_workers='ERROR',
               no_logfile=False)),
 ])
 def test_logging_args(test_params, expected_params):
@@ -277,6 +278,7 @@ def test_tutorial_averaging_args(test_params, expected_params, expected_params_p
           quiet=False,
           quiet_secondary_workers=False,
           loglevel='INFO',
+          loglevel_secondary_workers='ERROR',
           no_logfile=False,
           max_processes=1
           ))
@@ -309,6 +311,7 @@ def test_tutorial_prepare_data_cli_args(test_params, expected_params):
           quiet=False,
           quiet_secondary_workers=False,
           loglevel='INFO',
+          loglevel_secondary_workers='ERROR',
           no_logfile=False,
           max_processes=1
           ))

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -72,7 +72,7 @@ def test_io_args(test_params, expected_params):
     ('', dict(quiet=False,
               quiet_secondary_workers=False,
               loglevel='INFO',
-              loglevel_secondary_workers='ERROR',
+              loglevel_secondary_workers='INFO',
               no_logfile=False)),
 ])
 def test_logging_args(test_params, expected_params):
@@ -278,7 +278,7 @@ def test_tutorial_averaging_args(test_params, expected_params, expected_params_p
           quiet=False,
           quiet_secondary_workers=False,
           loglevel='INFO',
-          loglevel_secondary_workers='ERROR',
+          loglevel_secondary_workers='INFO',
           no_logfile=False,
           max_processes=1
           ))
@@ -311,7 +311,7 @@ def test_tutorial_prepare_data_cli_args(test_params, expected_params):
           quiet=False,
           quiet_secondary_workers=False,
           loglevel='INFO',
-          loglevel_secondary_workers='ERROR',
+          loglevel_secondary_workers='INFO',
           no_logfile=False,
           max_processes=1
           ))


### PR DESCRIPTION
Allow specifying a different log level for secondary workers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

