### PR TITLE
Make source/target data required for scoring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.2.8]
+
+### Changed
+- Make source/target data parameters required for the scoring CLI to avoid cryptic error messages.
+
+
 ## [2.2.7]
 
 ### Added

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.2.7'
+__version__ = '2.2.8'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1053,7 +1053,7 @@ def add_translate_cli_args(params):
 
 
 def add_score_cli_args(params):
-    add_training_data_args(params, required=False)
+    add_training_data_args(params, required=True)
     add_vocab_args(params)
     add_device_args(params)
     add_batch_args(params, default_batch_size=56, default_batch_type=C.BATCH_TYPE_SENTENCE)


### PR DESCRIPTION
The source/target arguments are required by the scoring CLI, but this wasn't enforced on the argparse level leading to cryptic error messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

