### PR TITLE
Fix horovod and bleu/chrf as optimized metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.3.1]
+### Fixed
+
+- Optimizing for BLEU/CHRF with horovod required the secondary workers to also create checkpoint decoders.
+
 ## [2.3.0]
 
 ### Added

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.3.0'
+__version__ = '2.3.1'

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -204,16 +204,16 @@ def create_checkpoint_decoder(
     :return: A CheckpointDecoder if --decode-and-evaluate != 0, else None.
     """
     sample_size = args.decode_and_evaluate
-    if args.optimized_metric == C.BLEU and sample_size == 0:
-        logger.info("You chose BLEU as the optimized metric, will turn on BLEU monitoring during training. "
-                    "To control how many validation sentences are used for calculating bleu use "
-                    "the --decode-and-evaluate argument.")
+    if args.optimized_metric in C.METRICS_REQUIRING_DECODER and sample_size == 0:
+        logger.info(f"You chose {args.optimized_metric} as the optimized metric, will turn on BLEU monitoring during training. "
+                     "To control how many validation sentences are used for calculating bleu use "
+                     "the --decode-and-evaluate argument.")
         sample_size = -1
 
     if sample_size == 0:
         return None
 
-    if horovod_mpi.using_horovod() and horovod_mpi.hvd.rank() > 0:
+    if horovod_mpi.using_horovod() and horovod_mpi.hvd.rank() > 0 and args.optimized_metric not in C.METRICS_REQUIRING_DECODER:
         logger.info("This is a secondary worker, not creating a checkpoint decoder for this training instance")
         return None
 

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -205,9 +205,9 @@ def create_checkpoint_decoder(
     """
     sample_size = args.decode_and_evaluate
     if args.optimized_metric in C.METRICS_REQUIRING_DECODER and sample_size == 0:
-        logger.info("You chose %s as the optimized metric, will turn on BLEU monitoring during training. "
+        logger.info("You chose %s as the optimized metric, will turn on %s monitoring during training. "
                     "To control how many validation sentences are used for calculating bleu use "
-                    "the --decode-and-evaluate argument.", args.optimized_metric)
+                    "the --decode-and-evaluate argument.", args.optimized_metric, args.optimized_metric)
         sample_size = -1
 
     if sample_size == 0:

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -205,9 +205,9 @@ def create_checkpoint_decoder(
     """
     sample_size = args.decode_and_evaluate
     if args.optimized_metric in C.METRICS_REQUIRING_DECODER and sample_size == 0:
-        logger.info(f"You chose {args.optimized_metric} as the optimized metric, will turn on BLEU monitoring during training. "
-                     "To control how many validation sentences are used for calculating bleu use "
-                     "the --decode-and-evaluate argument.")
+        logger.info("You chose %s as the optimized metric, will turn on BLEU monitoring during training. "
+                    "To control how many validation sentences are used for calculating bleu use "
+                    "the --decode-and-evaluate argument.", args.optimized_metric)
         sample_size = -1
 
     if sample_size == 0:


### PR DESCRIPTION
With this PR we make sure to also create checkpoint decoders on secondary workers when Horovod is enabled as otherwise training will fail.

The reason is that otherwise secondary workers will not find the evaluation metric and fail here: https://github.com/awslabs/sockeye/blob/master/sockeye/training.py#L442

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

