### PR TITLE
Fix dtype mismatch for float16 decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.3.4]
+
+### Fixed
+
+- Fixed issue with dtype mismatch in beam search when translating with `--dtype float16`.
+
 ## [2.3.3]
 
 ### Changed
@@ -39,8 +45,8 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
   At inference, target factors are decoded greedily, they do not participate in beam search.
   The predicted factor at each time step is the argmax over its separate output
   layer distribution. To receive the target factor predictions at inference time, use
-  `--output-type translation_with_factors`. 
-  
+  `--output-type translation_with_factors`.
+
 ### Changed
 
 - `load_model(s)` now returns a list of target vocabs.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.3.3'
+__version__ = '2.3.4'

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -648,9 +648,9 @@ class BeamSearch(mx.gluon.Block):
                                                dim=0)
 
             pad_dist = mx.nd.full((batch_size * self.beam_size, vocab_slice_ids_shape - 1),
-                                  val=np.inf, ctx=self.context)
+                                  val=np.inf, ctx=self.context, dtype=self.dtype)
             eos_dist = mx.nd.full((batch_size * self.beam_size, vocab_slice_ids_shape),
-                                  val=np.inf, ctx=self.context)
+                                  val=np.inf, ctx=self.context, dtype=self.dtype)
             eos_dist[:, C.EOS_ID] = 0
 
         # Initialize the beam to track constraint sets, where target-side lexical constraints are present


### PR DESCRIPTION
There were two places where `self.dtype` was not passed to ndarrays created in `BeamSearch.forward`.  This caused an error when running `sockeye.translate` with `--dtype float16`.

This PR updates the dtype logic to match [beam_search.py#L602-L605](https://github.com/awslabs/sockeye/blob/b990354d343e4c785dbcb01603d49fc10e0f523a/sockeye/beam_search.py#L602-L605).

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

