### PR TITLE
WIP: Masked pre-training and online back-translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.4.0]
+
+- WIP: Adding training on monolingual data via MASS and BART.
+
 ## [2.3.3]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.3.3'
+__version__ = '2.4.0'

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -30,13 +30,15 @@ BOS_SYMBOL = "<s>"
 EOS_SYMBOL = "</s>"
 UNK_SYMBOL = "<unk>"
 PAD_SYMBOL = "<pad>"
+MASK_SYMBOL = "<mask>"
 PAD_ID = 0
 PAD_FORMAT = "<pad%d>"
 TOKEN_SEPARATOR = " "
-VOCAB_SYMBOLS = [PAD_SYMBOL, UNK_SYMBOL, BOS_SYMBOL, EOS_SYMBOL]
+VOCAB_SYMBOLS = [PAD_SYMBOL, UNK_SYMBOL, BOS_SYMBOL, EOS_SYMBOL, MASK_SYMBOL]
 UNK_ID = VOCAB_SYMBOLS.index(UNK_SYMBOL)
 BOS_ID = VOCAB_SYMBOLS.index(BOS_SYMBOL)
 EOS_ID = VOCAB_SYMBOLS.index(EOS_SYMBOL)
+MASK_ID = VOCAB_SYMBOLS.index(MASK_SYMBOL)
 # reserve extra space for the EOS or BOS symbol that is added to both source and target
 SPACE_FOR_XOS = 1
 
@@ -149,6 +151,7 @@ LENRATIO_LOSS_NAME = LENRATIO_NAME + "_loss"
 LENRATIO_OUTPUT_NAME = LENRATIO_NAME + "_output"
 LEXICON_NAME = "lexicon"
 
+
 SOURCE_ENCODED_NAME = "encoded_source"
 TARGET_PREVIOUS_NAME = "prev_target_word_id"
 HIDDEN_PREVIOUS_NAME = "prev_hidden"
@@ -192,6 +195,8 @@ JSON_RESTRICT_LEXICON_KEY = "restrict_lexicon"
 JSON_CONSTRAINTS_KEY = "constraints"
 JSON_AVOID_KEY = "avoid"
 JSON_ENCODING = "utf-8"
+JSON_SOURCE_LANG_KEY = "source_lang"
+JSON_TARGET_LANG_KEY = "target_lang"
 
 # Lexical constraints
 BANK_ADJUSTMENT = 'even'
@@ -205,12 +210,15 @@ VOCAB_SRC_PREFIX = "vocab.src"
 VOCAB_SRC_NAME = VOCAB_SRC_PREFIX + ".%d" + JSON_SUFFIX
 VOCAB_TRG_PREFIX = "vocab.trg"
 VOCAB_TRG_NAME = VOCAB_TRG_PREFIX + ".%d" + JSON_SUFFIX
+VOCAB_MONO_PREFIX = "vocab.mono"
+VOCAB_MONO_NAME = VOCAB_MONO_PREFIX + ".%d" + JSON_SUFFIX
 VOCAB_ENCODING = "utf-8"
 PARAMS_PREFIX = "params."
 PARAMS_NAME = PARAMS_PREFIX + "%05d"
 PARAMS_BEST_NAME = "params.best"
 PARAMS_BEST_NAME_FLOAT32 = PARAMS_BEST_NAME + ".float32"
 DECODE_OUT_NAME = "decode.output.{{factor}}.{checkpoint:05d}"
+DECODE_OUT_NAME_BY_LANG = "decode.{source_lang}-{target_lang}.output.{{factor}}.{checkpoint:05d}"
 DECODE_IN_NAME = "decode.source.{factor}"
 DECODE_REF_NAME = "decode.target.{factor}"
 SYMBOL_NAME = "symbol" + JSON_SUFFIX
@@ -244,6 +252,7 @@ ARGS_MAY_DIFFER = ["overwrite_output", "use_tensorboard", "quiet",
 TRAINING_ARG_SOURCE = "--source"
 TRAINING_ARG_TARGET = "--target"
 TRAINING_ARG_PREPARED_DATA = "--prepared-data"
+TRAINING_ARG_PREPARED_MONO_DATA = "--prepared-mono-data"
 TRAINING_ARG_MAX_SEQ_LEN = "--max-seq-len"
 
 VOCAB_ARG_SHARED_VOCAB = "--shared-vocab"
@@ -404,6 +413,7 @@ FIXED_PARAM_STRATEGY_CHOICES = [FIXED_PARAM_STRATEGY_ALL_EXCEPT_DECODER,
 
 # data sharding
 SHARD_NAME = "shard.%05d"
+SHARD_MONO = SHARD_NAME + ".mono"
 SHARD_SOURCE = SHARD_NAME + ".source"
 SHARD_TARGET = SHARD_NAME + ".target"
 DATA_INFO = "data.info"

--- a/sockeye/mass.py
+++ b/sockeye/mass.py
@@ -1,0 +1,500 @@
+import random
+from typing import Optional
+
+import mxnet as mx
+import numpy as np
+
+from . import constants as C
+from . import data_io
+
+
+def get_segments(mask_len, span_len):
+    """Generate the masked segments up to the mask length. """
+    segs = []
+    while mask_len >= span_len:
+        segs.append(span_len)
+        mask_len -= span_len
+    if mask_len != 0:
+        segs.append(mask_len)
+    return segs
+
+
+def get_segments_poisson(mask_len, span_len):
+    """ Generate the masked segments up to the mask length with span lengths sampled according to a poisson distribution, similar to BART. """
+    segs = []
+    while mask_len > 0:
+        curr_span_len = np.random.poisson(lam=span_len)
+        curr_span_len = min(mask_len, max(1, curr_span_len))
+        segs.append(curr_span_len)
+        mask_len -= curr_span_len
+    if mask_len != 0:
+        segs.append(mask_len)
+    return segs
+
+
+def shuffle_segments(segs, unmasked_tokens):
+    """
+    We control 20% mask segment is at the start of sentences
+                20% mask segment is at the end   of sentences
+                60% mask segment is at random positions,
+    """
+    # TODO: base this on an instance of a random number generator to base this on the seed
+
+    p = np.random.random()
+    if p >= 0.8:
+        shuf_segs = segs[1:] + unmasked_tokens
+    elif p >= 0.6:
+        shuf_segs = segs[:-1] + unmasked_tokens
+    else:
+        shuf_segs = segs + unmasked_tokens
+
+    random.shuffle(shuf_segs)
+
+    if p >= 0.8:
+        shuf_segs = segs[0:1] + shuf_segs
+    elif p >= 0.6:
+        shuf_segs = shuf_segs + segs[-1:]
+    return shuf_segs
+
+
+def unfold_segments(segs, start=1):
+    """Unfold the random mask segments, for example:
+        The shuffle segment is [2, 0, 0, 2, 0],
+        so the masked segment is like:
+        [1, 1, 0, 0, 1, 1, 0]
+        [1, 2, 3, 4, 5, 6, 7] (positions)
+        (1 means this token will be masked, otherwise not)
+        We return the position of the masked tokens like:
+        [1, 2, 5, 6]
+    """
+    pos = []
+    curr = start  # We (optionally) do not mask the start token
+    for l in segs:
+        if l >= 1:
+            pos.extend([curr + i for i in range(l)])
+            curr += l
+        else:
+            curr += 1
+    return pos
+
+
+def mask_word(data: mx.nd.NDArray, pred_probs: mx.nd.NDArray, num_vocab: Optional[int], mask_index: int):
+    """[summary]
+
+    :param data: (seq_len,)
+    :param pred_probs: 3d: (mask_prob, real_prob, rand_prob)
+    :param num_vocab: [description]
+    :param mask_index: [description]
+    :return: [description]
+    :rtype: [type]
+    """
+
+    if num_vocab is None:
+        data_real = data
+        data_mask = mx.nd.full(data.shape, val=mask_index, dtype=data.dtype, ctx=data.context)
+
+        choice = mx.nd.random.multinomial(pred_probs, shape=len(data))
+
+        # TODO: alternatively concat and then take!?
+        # TODO: try masked addition?!
+        # _w = _w_mask * (choice == 0).numpy() + _w_real * (choice == 1).numpy() + _w_rand * (choice == 2).numpy()
+        # TODO: this could be simplified to just a single condition
+        out_data = mx.nd.where(
+            condition=(choice == 0),
+            x=data_mask,
+            y=mx.nd.where(
+                condition=(choice == 1),
+                x=data_real,
+                y=data_mask
+            )
+        )
+        return out_data
+    else:
+
+        # data_real = data.copy()
+        data_real = data
+        # We sample words at random (excluding special symbols)
+        data_rand = mx.nd.random.randint(len(C.VOCAB_SYMBOLS), num_vocab, shape=data.shape, dtype=data.dtype,
+                                         ctx=data.context)
+        data_mask = mx.nd.full(data.shape, val=mask_index, dtype=data.dtype, ctx=data.context)
+
+        choice = mx.nd.random.multinomial(pred_probs, shape=len(data))
+
+        # TODO: alternatively concat and then take!?
+        # TODO: try masked addition similar to MASS code?!
+        # _w = _w_mask * (choice == 0).numpy() + _w_real * (choice == 1).numpy() + _w_rand * (choice == 2).numpy()
+        out_data = mx.nd.where(
+            condition=(choice == 0),
+            x=data_mask,
+            y=mx.nd.where(
+                condition=(choice == 1),
+                x=data_real,
+                y=data_rand
+            )
+        )
+        return out_data
+
+
+def mask_bart_flat(data: mx.nd.NDArray, data_length: mx.nd.NDArray, pred_probs: mx.nd.NDArray,
+                   vocab_size: Optional[int] = None, mask_index: int = C.MASK_ID,
+                   span_len: int = 8, span_len_distribution=None,
+                   word_mass: float = 0.5, vocab=None, mask_eos=True, word_mass_sampled=False):
+    """ Mask the data.
+
+    :param data: (batch_size, seq_len, 1)
+    :param span_len: The size of the spans that are masked.
+    :param word_mass: The percent to words to mask per sentence.
+    :return: source, target, target_pos.
+    """
+    source = data.copy()
+
+    positions = []
+    for i in range(data.shape[0]):
+        sent_length = data_length[i].asscalar()
+
+        if mask_eos:
+            mask_sent_length = sent_length
+        else:
+            mask_sent_length = sent_length - 1
+
+        if mask_sent_length == 1:
+            # single tokens we always 'mask'
+            mask_len = 1
+        else:
+            if word_mass_sampled:
+                curr_word_mass = random.random() * word_mass
+            else:
+                curr_word_mass = word_mass
+            mask_len = int(round(mask_sent_length * curr_word_mass))
+        # Note: MASS originally used start=1 (to not mask their BOS symbol, but we don't have a BOS symbol)
+        start = 0
+        unmasked_tokens = [0 for _ in range(mask_sent_length - mask_len - start)]
+        # TODO: optionally sample the span_len instead of taking a fixed length
+        if span_len_distribution is None:
+            segs = get_segments(mask_len, span_len)
+        elif span_len_distribution == "poisson":
+            segs = get_segments_poisson(mask_len, span_len)
+        else:
+            raise ValueError("unknown")
+        shuf_segs = shuffle_segments(segs, unmasked_tokens)
+        pos_i = unfold_segments(shuf_segs, start=start)
+        # Take the global index into the flat version of source:
+        positions.extend([i * data.shape[1] + p for p in pos_i])
+
+    if len(positions) == 0:
+        # If nothing is to be masked we can just return source as is
+        return source
+    positions = mx.nd.array(positions, dtype=np.int32, ctx=source.context)
+    source = source.reshape(shape=(-1,))
+    source[positions] = mask_word(source[positions], pred_probs, vocab_size, mask_index)
+    source = source.reshape(shape=data.shape)
+
+    return source
+
+
+def mask_dae_flat(data: mx.nd.NDArray, data_length: mx.nd.NDArray, pdrop=0.1, k=3):
+    """ We apply the noising by Lample et al. (2017), namely: dropping and shuffling words.
+    """
+    source = mx.nd.zeros(shape=(np.prod(data.shape),), ctx=data.context, dtype=np.int32)
+
+    positions = []
+    words = []
+    for i in range(data.shape[0]):
+        sent_length = data_length[i].asscalar()
+
+        sent = data[i, :sent_length].reshape(-1).asnumpy().tolist()
+        # randomly drop words, don't drop EOS:
+        sent = [w for w in sent if w == sent[-1] or random.random() > pdrop]
+        # Sligthly change the sentence order:
+        sent = [w for _, w in sorted((p + random.random() * k + 1, w) for p, w in enumerate(sent[:-1]))] + [sent[-1]]
+        words.extend(sent)
+        positions.extend([i * data.shape[1] + p for p in range(0, len(sent))])
+
+    positions = mx.nd.array(positions, dtype=np.int32, ctx=source.context)
+    words = mx.nd.array(words, dtype=np.int32, ctx=source.context)
+    source[positions] = words
+    source = source.reshape(shape=data.shape)
+
+    return source
+
+
+def mask_mass(data: mx.nd.NDArray, data_length: mx.nd.NDArray, pred_probs: mx.nd.NDArray, vocab_size: int,
+              mask_index: int, span_len: int = 8, word_mass: float = 0.5, vocab=None, mask_eos=True):
+    """ Mask the data.
+
+    :param data: (batch_size, seq_len, 1)
+    :param span_len: The size of the spans that are masked.
+    :param word_mass: The percent to words to mask per sentence.
+    :return: source, target, target_pos.
+    """
+    source = data.copy()
+    squeezed_data = mx.nd.reshape(data, shape=(0, 0))
+
+    # Target is the data but replacing the EOS with a BOS at the beginning of the sentence
+    target = squeezed_data[:, :-1]  # skip last column (for longest-possible sequence, this already removes <eos>)
+    target = mx.nd.where(target == C.EOS_ID, mx.nd.zeros_like(target), target)  # replace other <eos>'s with <pad>
+    # target: (batch_size, seq_len, 1)
+    target = mx.nd.concat(mx.nd.full((target.shape[0], 1), val=C.BOS_ID, dtype=np.int32), target)
+
+    all_positions, all_targets, all_labels = [], [], []
+
+    flat_eos_indices = []
+
+    max_len = -1
+
+    for i in range(data.shape[0]):
+        sent_length = data_length[i].asscalar()
+
+        mask_sent_length = sent_length
+        if mask_sent_length < 2:
+            # We expect at least one token and EOS
+            assert False
+        else:
+            mask_len = int(round(mask_sent_length * word_mass))
+            start = 0
+            unmasked_tokens = [0 for _ in range(mask_sent_length - mask_len - start)]
+            segs = get_segments(mask_len, span_len)
+            shuf_segs = shuffle_segments(segs, unmasked_tokens)
+            pos_i = unfold_segments(shuf_segs, start=start)
+            all_positions.append(pos_i)
+
+            flat_eos_indices.append(i * data.shape[1] + sent_length - 1)
+
+            if len(pos_i) > max_len:
+                max_len = len(pos_i)
+
+    flat_indices_from = []
+    flat_indices_to = []
+    positions = []
+    for i, pos_i in enumerate(all_positions):
+        flat_indices_from.extend([i * data.shape[1] + p for p in pos_i])
+        flat_indices_to.extend([i * max_len + j for j, _ in enumerate(pos_i)])
+        positions.extend(pos_i)
+
+    flat_indices_from = mx.nd.array(flat_indices_from, dtype=np.int32)
+    flat_indices_to = mx.nd.array(flat_indices_to, dtype=np.int32)
+    positions = mx.nd.array(positions, dtype=np.int32)
+    flat_eos_indices = mx.nd.array(flat_eos_indices, dtype=np.int32)
+
+    source = source.reshape(shape=(-1,))
+    source[flat_indices_from] = mask_word(source[flat_indices_from], pred_probs, vocab_size, mask_index)
+    # Optionally restore EOS symbols instead of masks if EOS bad been masked (the reason to not exclude it from masking
+    # in the first place is that we want EOS to still appear on the target side)
+    if not mask_eos:
+        source[flat_eos_indices] = C.EOS_ID
+    source = source.reshape(shape=data.shape)
+
+    target_new = mx.nd.full(shape=(data.shape[0] * max_len), val=C.PAD_ID, dtype=np.int32)
+    labels_new = mx.nd.full(shape=(data.shape[0] * max_len), val=C.PAD_ID, dtype=np.int32)
+    positions_new = mx.nd.full(shape=(data.shape[0] * max_len), val=C.PAD_ID, dtype=np.int32)
+
+    target_flat = target.reshape((-1,))
+    target_new[flat_indices_to] = target_flat[flat_indices_from]
+    target_new = target_new.reshape((data.shape[0], max_len))
+
+    squeezed_data_flat = squeezed_data.reshape((-1,))
+    labels_new[flat_indices_to] = squeezed_data_flat[flat_indices_from]
+    labels_new = labels_new.reshape((data.shape[0], max_len))
+
+    positions_new[flat_indices_to] = positions
+    positions_new = positions_new.reshape(shape=(data.shape[0], max_len))
+
+    return source, target_new, labels_new, positions_new
+
+
+def mask_data(data, data_length, vocab_size: Optional[int] = None, vocab=None, style: str = "BART", word_mass=0.5,
+              word_mass_sampled=False):
+    if style == "BART":
+        pred_probs = mx.nd.array([0.8, 0.05, 0.15])
+        data = mask_bart_flat(data, data_length, pred_probs=pred_probs, vocab_size=vocab_size, mask_index=C.MASK_ID,
+                              vocab=vocab, word_mass=word_mass, word_mass_sampled=word_mass_sampled)
+    elif style == "BART_NOMASKEOS":
+        pred_probs = mx.nd.array([0.8, 0.05, 0.15])
+        data = mask_bart_flat(data, data_length, pred_probs=pred_probs, vocab_size=vocab_size, mask_index=C.MASK_ID,
+                              vocab=vocab, mask_eos=False, word_mass=word_mass, word_mass_sampled=word_mass_sampled)
+    elif style == "BART_NOMASKEOS_NORANDWORD":
+        pred_probs = mx.nd.array([0.9, 0.1, 0.0])
+        data = mask_bart_flat(data, data_length, pred_probs=pred_probs, vocab_size=vocab_size, mask_index=C.MASK_ID,
+                              vocab=vocab, mask_eos=False, word_mass=word_mass, word_mass_sampled=word_mass_sampled)
+    elif style == "BART_NOMASKEOS_POISSON":
+        pred_probs = mx.nd.array([0.8, 0.05, 0.15])
+        data = mask_bart_flat(data, data_length, pred_probs=pred_probs,
+                              vocab_size=vocab_size, mask_index=C.MASK_ID,
+                              span_len=4, span_len_distribution="poisson",
+                              vocab=vocab, mask_eos=False, word_mass=word_mass, word_mass_sampled=word_mass_sampled)
+    elif style == "BART_NOMASKEOS_POSSION_NORANDWORD":
+        pred_probs = mx.nd.array([0.9, 0.1, 0.])
+        data = mask_bart_flat(data, data_length, pred_probs=pred_probs,
+                              vocab_size=vocab_size, mask_index=C.MASK_ID,
+                              span_len=3, span_len_distribution="poisson",
+                              vocab=vocab, mask_eos=False, word_mass=word_mass, word_mass_sampled=word_mass_sampled)
+    elif style == "DAE":
+        data = mask_dae_flat(data, data_length)
+    elif style == "BART_PAD":
+        raise NotImplemented()
+    elif style == "BART_PAD_MASK":
+        raise NotImplemented()
+    elif style == "MASS":
+        raise NotImplemented()
+    elif style == "MASS_NOMASKEOS":
+        raise NotImplemented()
+    else:
+        raise ValueError(f"Unknown style {style}")
+    return data
+
+
+def mono_batch_to_parallel_batch(batch: 'data_io.MonoBatch', vocab_size: int, vocab, style: str = "BART",
+                                 word_mass=0.5,
+                                 word_mass_sampled=False) -> 'data_io.Batch':
+    """ Converts a monolingual batch to a parallel batch through by masking the source and predicting the full target. """
+    # note: the data has EOS but no BOS
+    # TODO: directly expose data as int in the monolingual data iterator!
+
+    source_lang = batch.lang
+    target_lang = batch.lang
+
+    # mx.nd.full((1,), val=self.lang_vocab[self.source_lang])
+    if style == "BART":
+        # BART: The BART style 'noises' the input, but uses the full sequence as the target (including tokens not masked on the source side)
+
+        # note: the data has EOS but not BOS
+        data = batch.data.astype(np.int32)
+        data_length = batch.data_length.astype(np.int32)
+        squeezed_data = mx.nd.reshape(data, shape=(0, 0))
+        label = squeezed_data
+        target = squeezed_data[:, :-1]  # skip last column (for longest-possible sequence, this already removes <eos>)
+        target = mx.nd.where(target == C.EOS_ID, mx.nd.zeros_like(target), target)  # replace other <eos>'s with <pad>
+        # target: (batch_size, seq_len, 1)
+        target = mx.nd.concat(mx.nd.full((target.shape[0], 1), val=C.BOS_ID, dtype=np.int32), target)
+
+        # Creating a fake target factor:
+        # TODO: full target factor support
+        target = mx.nd.reshape(target, shape=(0, 0, 1))
+        label = mx.nd.reshape(target, shape=(0, 0, 1))
+
+        source = mask_data(data, data_length, vocab_size=vocab_size, vocab=vocab, style=style, word_mass=word_mass,
+                           word_mass_sampled=word_mass_sampled)
+
+        batch = data_io.create_batch_from_parallel_sample(source.astype(np.float32), target.astype(np.float32),
+                                                          label.astype(np.float32), source_lang=source_lang,
+                                                          target_lang=target_lang)
+
+        return batch
+    if style == "DAE":
+        # BART: The BART style 'noises' the input, but uses the full sequence as the target (including tokens not masked on the source side)
+
+        # note: the data has EOS but not BOS
+        data = batch.data.astype(np.int32)
+        data_length = batch.data_length.astype(np.int32)
+        squeezed_data = mx.nd.reshape(data, shape=(0, 0))
+        label = squeezed_data
+        target = squeezed_data[:, :-1]  # skip last column (for longest-possible sequence, this already removes <eos>)
+        target = mx.nd.where(target == C.EOS_ID, mx.nd.zeros_like(target), target)  # replace other <eos>'s with <pad>
+        # target: (batch_size, seq_len, 1)
+        target = mx.nd.concat(mx.nd.full((target.shape[0], 1), val=C.BOS_ID, dtype=np.int32), target)
+
+        source = mask_data(data, data_length, vocab_size=vocab_size, vocab=vocab, style=style, word_mass=word_mass,
+                           word_mass_sampled=word_mass_sampled)
+
+        batch = data_io.create_batch_from_parallel_sample(source.astype(np.float32), target.astype(np.float32),
+                                                          label.astype(np.float32), source_lang=source_lang,
+                                                          target_lang=target_lang)
+
+        return batch
+    if style == "BART_NOMASKEOS":
+        # BART: The BART style 'noises' the input, but uses the full sequence as the target (including tokens not masked on the source side)
+
+        # note: the data has EOS but not BOS
+        data = batch.data.astype(np.int32)
+        data_length = batch.data_length.astype(np.int32)
+        squeezed_data = mx.nd.reshape(data, shape=(0, 0))
+        label = squeezed_data
+        target = squeezed_data[:, :-1]  # skip last column (for longest-possible sequence, this already removes <eos>)
+        target = mx.nd.where(target == C.EOS_ID, mx.nd.zeros_like(target), target)  # replace other <eos>'s with <pad>
+        # target: (batch_size, seq_len, 1)
+        target = mx.nd.concat(mx.nd.full((target.shape[0], 1), val=C.BOS_ID, dtype=np.int32), target)
+
+        source = mask_data(data, data_length, vocab_size=vocab_size, vocab=vocab, style=style, word_mass=word_mass,
+                           word_mass_sampled=word_mass_sampled)
+
+        batch = data_io.create_batch_from_parallel_sample(source.astype(np.float32), target.astype(np.float32),
+                                                          label.astype(np.float32), source_lang=source_lang,
+                                                          target_lang=target_lang)
+
+        return batch
+    if style == "BART_NOMASKEOS_NORANDWORD":
+        # BART: The BART style 'noises' the input, but uses the full sequence as the target (including tokens not masked on the source side)
+
+        # note: the data has EOS but not BOS
+        data = batch.data.astype(np.int32)
+        data_length = batch.data_length.astype(np.int32)
+        squeezed_data = mx.nd.reshape(data, shape=(0, 0))
+        label = squeezed_data
+        target = squeezed_data[:, :-1]  # skip last column (for longest-possible sequence, this already removes <eos>)
+        target = mx.nd.where(target == C.EOS_ID, mx.nd.zeros_like(target), target)  # replace other <eos>'s with <pad>
+        # target: (batch_size, seq_len, 1)
+        target = mx.nd.concat(mx.nd.full((target.shape[0], 1), val=C.BOS_ID, dtype=np.int32), target)
+
+        source = mask_data(data, data_length, vocab_size=vocab_size, vocab=vocab, style=style, word_mass=word_mass,
+                           word_mass_sampled=word_mass_sampled)
+
+        batch = data_io.create_batch_from_parallel_sample(source.astype(np.float32), target.astype(np.float32),
+                                                          label.astype(np.float32), source_lang=source_lang,
+                                                          target_lang=target_lang)
+
+        return batch
+    if style == "BART_NOMASKEOS_POISSON" or "BART_NOMASKEOS_POSSION_NORANDWORD":
+        # BART: The BART style 'noises' the input, but uses the full sequence as the target (including tokens not masked on the source side)
+
+        # note: the data has EOS but not BOS
+        data = batch.data.astype(np.int32)
+        data_length = batch.data_length.astype(np.int32)
+        squeezed_data = mx.nd.reshape(data, shape=(0, 0))
+        label = squeezed_data
+        target = squeezed_data[:, :-1]  # skip last column (for longest-possible sequence, this already removes <eos>)
+        target = mx.nd.where(target == C.EOS_ID, mx.nd.zeros_like(target), target)  # replace other <eos>'s with <pad>
+        # target: (batch_size, seq_len, 1)
+        target = mx.nd.concat(mx.nd.full((target.shape[0], 1), val=C.BOS_ID, dtype=np.int32), target)
+
+        source = mask_data(data, data_length, vocab_size=vocab_size, vocab=vocab, style=style, word_mass=word_mass,
+                           word_mass_sampled=word_mass_sampled)
+
+        batch = data_io.create_batch_from_parallel_sample(source.astype(np.float32), target.astype(np.float32),
+                                                          label.astype(np.float32), source_lang=source_lang,
+                                                          target_lang=target_lang)
+
+        return batch
+    elif style == "MASS":
+        data = batch.data.astype(np.int32)
+        data_length = batch.data_length.astype(np.int32)
+        pred_probs = mx.nd.array([0.8, 0.05, 0.15])
+
+        assert word_mass_sampled is False, "Not supported."
+
+        source, target, labels, positions = mask_mass(data, data_length, pred_probs=pred_probs, vocab_size=vocab_size,
+                                                      mask_index=C.MASK_ID, vocab=vocab, mask_eos=True,
+                                                      word_mass=word_mass)
+
+        batch = data_io.create_batch_from_parallel_sample(source.astype(np.float32), target.astype(np.float32),
+                                                          labels.astype(np.float32), source_lang=source_lang,
+                                                          target_lang=target_lang, target_steps=positions)
+
+        return batch
+    elif style == "MASS_NOMASKEOS":
+        data = batch.data.astype(np.int32)
+        data_length = batch.data_length.astype(np.int32)
+        pred_probs = mx.nd.array([0.8, 0.05, 0.15])
+
+        assert word_mass_sampled is False, "Not supported."
+
+        source, target, labels, positions = mask_mass(data, data_length, pred_probs=pred_probs, vocab_size=vocab_size,
+                                                      mask_index=C.MASK_ID, vocab=vocab, mask_eos=False,
+                                                      word_mass=word_mass)
+
+        batch = data_io.create_batch_from_parallel_sample(source.astype(np.float32), target.astype(np.float32),
+                                                          labels.astype(np.float32), source_lang=source_lang,
+                                                          target_lang=target_lang, target_steps=positions)
+
+        return batch
+    else:
+        raise ValueError(f"Unknown style {style}")

--- a/sockeye/prepare_data.py
+++ b/sockeye/prepare_data.py
@@ -97,7 +97,9 @@ def prepare_data(args: argparse.Namespace):
                          min_num_shards=minimum_num_shards,
                          output_prefix=output_folder,
                          bucket_scaling=bucket_scaling,
-                         max_processes=args.max_processes)
+                         max_processes=args.max_processes,
+                         source_lang=args.source_language,
+                         target_lang=args.target_language)
 
 
 if __name__ == "__main__":

--- a/sockeye/prepare_mono_data.py
+++ b/sockeye/prepare_mono_data.py
@@ -1,0 +1,86 @@
+# Copyright 2017--2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import argparse
+import os
+import logging
+
+from . import arguments
+from . import constants as C
+from . import data_io
+from . import utils
+from . import vocab
+from .log import setup_main_logger
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    params = argparse.ArgumentParser(description='Preprocesses and shards monolingual data.')
+    arguments.add_prepare_mono_data_cli_args(params)
+    args = params.parse_args()
+    prepare_data(args)
+
+
+def prepare_data(args: argparse.Namespace):
+    output_folder = os.path.abspath(args.output)
+    os.makedirs(output_folder, exist_ok=True)
+    setup_main_logger(console=not args.quiet,
+                      file_logging=not args.no_logfile,
+                      path=os.path.join(output_folder, C.LOG_NAME))
+    utils.log_basic_info(args)
+    utils.seed_rngs(args.seed)
+
+    minimum_num_shards = args.min_num_shards
+    samples_per_shard = args.num_samples_per_shard
+    bucket_width = args.bucket_width
+
+    mono_data = [args.monolingual] + args.monolingual_factors
+    mono_data = [str(os.path.abspath(data)) for data in mono_data]
+
+    num_words = args.mono_num_words if args.mono_num_words > 0 else None
+
+    factor_vocab_paths = [args.mono_factor_vocabs[i] if i < len(args.mono_factor_vocabs)
+                          else None for i in range(len(args.monolingual_factors))]
+    vocab_paths = [args.mono_vocab] + factor_vocab_paths
+
+    word_min_count = args.mono_word_min_count
+
+    max_seq_len, max_seq_len_other = args.max_seq_len
+    utils.check_condition(max_seq_len == max_seq_len_other,
+                          "The source and target maximum length must match for monolingual data preparation.")
+
+    # The maximum length is the length before we add the BOS/EOS symbols
+    max_seq_len = max_seq_len + C.SPACE_FOR_XOS
+    logger.info("Adjusting maximum length to reserve space for a BOS/EOS marker. New maximum length: %d",
+                max_seq_len)
+
+    vocabs = vocab.load_or_create_mono_vocab(data_paths=mono_data, vocab_paths=vocab_paths,
+                                             factor_vocab_same_as_main=args.mono_factors_use_mono_vocab,
+                                             num_words=num_words, word_min_count=word_min_count,
+                                             pad_to_multiple_of=args.mono_pad_vocab_to_multiple_of)
+
+    data_io.prepare_mono_data(fnames=mono_data,
+                              vocabs=vocabs,
+                              vocab_paths=vocab_paths,
+                              lang=args.monolingual_language,
+                              max_seq_len=max_seq_len,
+                              bucket_width=bucket_width,
+                              samples_per_shard=samples_per_shard,
+                              min_num_shards=minimum_num_shards,
+                              output_prefix=output_folder,
+                              max_processes=args.max_processes)
+
+
+if __name__ == "__main__":
+    main()

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -39,7 +39,10 @@ class TransformerConfig(config.Config):
                  max_seq_len_target: int,
                  decoder_type: str = C.TRANSFORMER_TYPE,
                  lhuc: bool = False,
-                 depth_key_value: int = 0) -> None:  # type: ignore
+                 depth_key_value: int = 0,
+                 # TODO: rename to something like `num_languages`
+                 num_lang_embed: int = 0,
+                 lang_specific_layers: bool = False) -> None:  # type: ignore
         super().__init__()
         self.model_size = model_size
         self.attention_heads = attention_heads
@@ -57,6 +60,8 @@ class TransformerConfig(config.Config):
         self.use_lhuc = lhuc
         self.depth_key_value = depth_key_value
         self.decoder_type = decoder_type
+        self.num_lang_embed = num_lang_embed
+        self.lang_specific_layers = lang_specific_layers
 
 
 class TransformerEncoderBlock(mx.gluon.HybridBlock):


### PR DESCRIPTION

This PR adds support for monolingual data. Monolingual data can be used either for masking ([MASS](https://arxiv.org/abs/1905.02450), [BART](https://arxiv.org/abs/1910.13461), DAE) or for online back-translation.

The PR is still in quite a rough state with several thing still outstanding. For example (non-exhaustive):

- [ ] Support for target factors.
- [ ] I'd like to revamp the CLI interface for monolingual data
- [ ] Reduce duplicate code in `data_io.py` by sharing code between monolingual and bilingual classes/functions.
- [ ] Add unit/system/integration tests + doc strings.
- [ ] Revise the way loss prefixing is done in training.py/loss.py
- [ ] Correct training resumption with monolingual iterators
- [ ] Use of monolingual data without prepared data folders
- [ ] ...

Because the PR is still WIP at this point I'd mainly like to get comments/suggestions on the high level structure (e.g. masking in the data iterator vs masking in the trainer, a potential decoupling of different 'tasks' in the trainer brought up by Felix in the past) and the CLI interface.


#### Pull Request Checklist ##
- [ ] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
- [ ] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [ ] System tests pass (`pytest test/system`)
- [ ] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

