### PR TITLE
Move to dataclasses & update version of pylint & mypiy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.3.7]
+
+### Changed
+
+- Use dataclass module to simplify Config classes. No functional change.
+
 ## [2.3.6]
 
 ### Fixed

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -3,7 +3,7 @@ pytest-cov<2.6.0
 pillow
 check-manifest
 matplotlib
-mypy==0.610
+mypy==0.790
 pylint==2.3.0
 isort<5.0.0
 setuptools>=38.6.0

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -9,3 +9,4 @@ isort<5.0.0
 setuptools>=38.6.0
 twine>=1.11.0
 wheel>=0.31.0
+dataclasses

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -4,7 +4,7 @@ pillow
 check-manifest
 matplotlib
 mypy==0.790
-pylint==2.3.0
+pylint==2.6.0
 isort<5.0.0
 setuptools>=38.6.0
 twine>=1.11.0

--- a/requirements/requirements.docs.txt
+++ b/requirements/requirements.docs.txt
@@ -3,3 +3,4 @@ sphinx_rtd_theme
 sphinx-autodoc-typehints>=1.3.0
 recommonmark
 pyyaml>=5.1
+dataclasses

--- a/requirements/requirements.gpu-cu100.txt
+++ b/requirements/requirements.gpu-cu100.txt
@@ -3,3 +3,4 @@ mxnet-cu100==1.7.0
 numpy>1.16.0,<2.0.0
 portalocker
 sacrebleu==1.4.14
+dataclasses

--- a/requirements/requirements.gpu-cu101.txt
+++ b/requirements/requirements.gpu-cu101.txt
@@ -3,3 +3,4 @@ mxnet-cu101==1.7.0
 numpy>1.16.0,<2.0.0
 portalocker
 sacrebleu==1.4.14
+dataclasses

--- a/requirements/requirements.gpu-cu102.txt
+++ b/requirements/requirements.gpu-cu102.txt
@@ -3,3 +3,4 @@ mxnet-cu102==1.7.0
 numpy>1.16.0,<2.0.0
 portalocker
 sacrebleu==1.4.14
+dataclasses

--- a/requirements/requirements.gpu-cu92.txt
+++ b/requirements/requirements.gpu-cu92.txt
@@ -3,3 +3,4 @@ mxnet-cu92==1.7.0
 numpy>1.16.0,<2.0.0
 portalocker
 sacrebleu==1.4.14
+dataclasses

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.3.6'
+__version__ = '2.3.7'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -68,7 +68,7 @@ class ConfigArgumentParser(argparse.ArgumentParser):
         group = super().add_argument_group(*args, **kwargs)
         return self._overwrite_add_argument(group)
 
-    def parse_args(self, args=None, namespace=None) -> argparse.Namespace:
+    def parse_args(self, args=None, namespace=None) -> argparse.Namespace:  # type: ignore
         # Mini argument parser to find the config file
         config_parser = argparse.ArgumentParser(add_help=False)
         config_parser.add_argument("--config", type=regular_file())

--- a/sockeye/checkpoint_decoder.py
+++ b/sockeye/checkpoint_decoder.py
@@ -1,4 +1,4 @@
-# Copyright 2017--2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017--2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License

--- a/sockeye/checkpoint_decoder.py
+++ b/sockeye/checkpoint_decoder.py
@@ -122,7 +122,7 @@ class CheckpointDecoder:
         for factor_idx, factor in enumerate(self.targets_sentences):
             write_to_file(factor, os.path.join(model_folder, C.DECODE_REF_NAME.format(factor=factor_idx)))
 
-        self.inputs_sentences = list(zip(*self.inputs_sentences))  # type: List[List[str]]
+        self.inputs_sentences = list(zip(*self.inputs_sentences))  # type: ignore
 
         scorer = inference.CandidateScorer(
             length_penalty_alpha=length_penalty_alpha,
@@ -177,7 +177,7 @@ class CheckpointDecoder:
                     if output_file is not None:
                         print(output_string, file=output_file)
         avg_time = trans_wall_time / len(self.targets_sentences[0])
-        translations = list(zip(*translations))
+        translations = list(zip(*translations))  # type: ignore
 
         # 2. Evaluate
         metrics = {C.BLEU: evaluate.raw_corpus_bleu(hypotheses=translations[0],

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -405,7 +405,7 @@ def shard_data(source_fnames: List[str],
                buckets: List[Tuple[int, int]],
                length_ratio_mean: float,
                length_ratio_std: float,
-               output_prefix: str) -> Tuple[List[Tuple[List[str], List[str], 'DataStatistics']], 'DataStatistics']:
+               output_prefix: str):
     """
     Assign int-coded source/target sentence pairs to shards at random.
 
@@ -464,8 +464,8 @@ def shard_data(source_fnames: List[str],
 
     per_shard_stats = [shard_stat_accumulator.statistics for shard_stat_accumulator in per_shard_stat_accumulators]
 
-    sources_shard_fnames_by_shards = zip(*sources_shard_fnames)  # type: List[List[str]]
-    targets_shard_fnames_by_shards = zip(*targets_shard_fnames)  # type: List[List[str]]
+    sources_shard_fnames_by_shards = zip(*sources_shard_fnames)  # type: ignore
+    targets_shard_fnames_by_shards = zip(*targets_shard_fnames)  # type: ignore
 
     return list(zip(sources_shard_fnames_by_shards, targets_shard_fnames_by_shards, per_shard_stats)), \
            data_stats_accumulator.statistics

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -79,8 +79,7 @@ class Decoder(mx.gluon.Block):
             raise ValueError('Unsupported decoder configuration %s' % config_type.__name__)
         decoder_cls, suffix = cls.__registry[config_type]
         # TODO: move final suffix/prefix construction logic into config builder
-        return decoder_cls(config=config, inference_only=inference_only,
-                           prefix=prefix + suffix, dtype=dtype)  # type: ignore
+        return decoder_cls(config=config, inference_only=inference_only, prefix=prefix + suffix, dtype=dtype)  # type: ignore
 
     @abstractmethod
     def __init__(self):

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -79,7 +79,8 @@ class Decoder(mx.gluon.Block):
             raise ValueError('Unsupported decoder configuration %s' % config_type.__name__)
         decoder_cls, suffix = cls.__registry[config_type]
         # TODO: move final suffix/prefix construction logic into config builder
-        return decoder_cls(config=config, inference_only=inference_only, prefix=prefix + suffix, dtype=dtype)
+        return decoder_cls(config=config, inference_only=inference_only,
+                           prefix=prefix + suffix, dtype=dtype)  # type: ignore
 
     @abstractmethod
     def __init__(self):

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -1,4 +1,4 @@
-# Copyright 2017--2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017--2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -17,6 +17,7 @@ Encoders for sequence-to-sequence models.
 import inspect
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from typing import List, Optional, Union
 
 import mxnet as mx
@@ -90,38 +91,27 @@ class Encoder(ABC, mx.gluon.HybridBlock):
         """
         return None
 
-
+@dataclass
 class FactorConfig(config.Config):
-
-    def __init__(self,
-                 vocab_size: int,
-                 num_embed: int,
-                 combine: str,  # From C.FACTORS_COMBINE_CHOICES
-                 share_embedding: bool) -> None:
-        super().__init__()
-        self.vocab_size = vocab_size
-        self.num_embed = num_embed
-        self.combine = combine
-        self.share_embedding = share_embedding
+    vocab_size: int
+    num_embed: int
+    combine: str  # From C.FACTORS_COMBINE_CHOICES
+    share_embedding: bool
 
 
+@dataclass
 class EmbeddingConfig(config.Config):
+    vocab_size: int
+    num_embed: int
+    dropout: float
+    num_factors: int = field(init=False)
+    factor_configs: Optional[List[FactorConfig]] = None
+    allow_sparse_grad: bool = False
 
-    def __init__(self,
-                 vocab_size: int,
-                 num_embed: int,
-                 dropout: float,
-                 factor_configs: Optional[List[FactorConfig]] = None,
-                 allow_sparse_grad: bool = False) -> None:
-        super().__init__()
-        self.vocab_size = vocab_size
-        self.num_embed = num_embed
-        self.dropout = dropout
-        self.factor_configs = factor_configs
+    def __post_init__(self):
         self.num_factors = 1
         if self.factor_configs is not None:
             self.num_factors += len(self.factor_configs)
-        self.allow_sparse_grad = allow_sparse_grad
 
 
 class Embedding(Encoder):

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -1114,7 +1114,7 @@ class Translator:
                          reference_lengths[best_ids])])
 
         # reorder and regroup lists
-        reduced_translations = [_reduce_nbest_translations(grouped_nbest) for grouped_nbest in zip(*nbest_translations)]
+        reduced_translations = [_reduce_nbest_translations(grouped_nbest) for grouped_nbest in zip(*nbest_translations)]  # type: ignore
         return reduced_translations
 
     @staticmethod

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -1,4 +1,4 @@
-# Copyright 2017--2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017--2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -13,8 +13,9 @@
 
 import logging
 from abc import abstractmethod
-from typing import Optional, Union, Tuple
+from dataclasses import dataclass
 from functools import lru_cache
+from typing import Optional, Union, Tuple
 
 import mxnet as mx
 import numpy as np
@@ -194,18 +195,10 @@ class OutputLayer(mx.gluon.HybridBlock):
                                     name=C.LOGITS_NAME)
 
 
+@dataclass
 class LengthRatioConfig(config.Config):
-    """
-    Configuration of the length ratio predictor.
-
-    :param num_layers: Number of layers.
-    :param weight: Weight of this loss.
-    """
-
-    def __init__(self, num_layers: int, weight: float) -> None:
-        super().__init__()
-        self.num_layers = num_layers
-        self.weight = weight
+    num_layers: int  # Number of layers
+    weight: float  # Weight of this loss
 
 
 class LengthRatio(mx.gluon.HybridBlock):

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -1,4 +1,4 @@
-# Copyright 2017--2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017--2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -30,10 +30,11 @@ from . import layers
 from . import quantization
 from . import utils
 from . import vocab
-
+from dataclasses import dataclass
 logger = logging.getLogger(__name__)
 
 
+@dataclass
 class ModelConfig(Config):
     """
     ModelConfig defines model parameters defined at training time which are relevant to model inference.
@@ -54,33 +55,18 @@ class ModelConfig(Config):
     :param intgemm_custom_lib: Path to intgemm custom operator library used for dtype is int8.  Default: libintgemm.so
                                in the same directory as this script.
     """
-
-    def __init__(self,
-                 config_data: data_io.DataConfig,
-                 vocab_source_size: int,
-                 vocab_target_size: int,
-                 config_embed_source: encoder.EmbeddingConfig,
-                 config_embed_target: encoder.EmbeddingConfig,
-                 config_encoder: encoder.EncoderConfig,
-                 config_decoder: decoder.DecoderConfig,
-                 config_length_task: layers.LengthRatioConfig= None,
-                 weight_tying_type: str = C.WEIGHT_TYING_SRC_TRG_SOFTMAX,
-                 lhuc: bool = False,
-                 dtype: str = C.DTYPE_FP32,
-                 intgemm_custom_lib: str = os.path.join(os.path.dirname(__file__), "libintgemm.so")) -> None:
-        super().__init__()
-        self.config_data = config_data
-        self.vocab_source_size = vocab_source_size
-        self.vocab_target_size = vocab_target_size
-        self.config_embed_source = config_embed_source
-        self.config_embed_target = config_embed_target
-        self.config_encoder = config_encoder
-        self.config_decoder = config_decoder
-        self.config_length_task = config_length_task
-        self.weight_tying_type = weight_tying_type
-        self.lhuc = lhuc
-        self.dtype = dtype
-        self.intgemm_custom_lib = intgemm_custom_lib
+    config_data: data_io.DataConfig
+    vocab_source_size: int
+    vocab_target_size: int
+    config_embed_source: encoder.EmbeddingConfig
+    config_embed_target: encoder.EmbeddingConfig
+    config_encoder: encoder.EncoderConfig
+    config_decoder: decoder.DecoderConfig
+    config_length_task: Optional[layers.LengthRatioConfig] = None
+    weight_tying_type: str = C.WEIGHT_TYING_SRC_TRG_SOFTMAX
+    lhuc: bool = False
+    dtype: str = C.DTYPE_FP32
+    intgemm_custom_lib: str = os.path.join(os.path.dirname(__file__), "libintgemm.so")
 
 
 class SockeyeModel(mx.gluon.Block):

--- a/sockeye/optimizers.py
+++ b/sockeye/optimizers.py
@@ -1,4 +1,4 @@
-# Copyright 2017--2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017--2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 import mxnet as mx
@@ -19,24 +20,15 @@ from . import config
 from .lr_scheduler import LearningRateScheduler
 
 
+@dataclass
 class OptimizerConfig(config.Config):
-
-    def __init__(self,
-                 name: str,
-                 params: Dict[str, Any],
-                 kvstore: str,
-                 initializer: mx.initializer.Initializer,
-                 gradient_clipping_type: str,
-                 gradient_clipping_threshold: Optional[float],
-                 update_interval: int = 1) -> None:
-        super().__init__()
-        self.name = name
-        self.params = params
-        self.kvstore = kvstore
-        self.initializer = initializer
-        self.gradient_clipping_type = gradient_clipping_type
-        self.gradient_clipping_threshold = gradient_clipping_threshold
-        self.update_interval = update_interval
+    name: str
+    params: Dict[str, Any]
+    kvstore: str
+    initializer: mx.initializer.Initializer
+    gradient_clipping_type: str
+    gradient_clipping_threshold: Optional[float]
+    update_interval: int = 1
 
     @property
     def lr_scheduler(self) -> Optional[LearningRateScheduler]:

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -471,7 +471,7 @@ def create_encoder_config(args: argparse.Namespace,
         postprocess_sequence=encoder_transformer_postprocess,
         max_seq_len_source=max_seq_len_source,
         max_seq_len_target=max_seq_len_target,
-        lhuc=args.lhuc is not None and (C.LHUC_ENCODER in args.lhuc or C.LHUC_ALL in args.lhuc),
+        use_lhuc=args.lhuc is not None and (C.LHUC_ENCODER in args.lhuc or C.LHUC_ALL in args.lhuc),
         decoder_type=args.decoder)
     encoder_num_hidden = encoder_transformer_model_size
 
@@ -522,7 +522,7 @@ def create_decoder_config(args: argparse.Namespace,
         postprocess_sequence=decoder_transformer_postprocess,
         max_seq_len_source=max_seq_len_source,
         max_seq_len_target=max_seq_len_target,
-        lhuc=args.lhuc is not None and (C.LHUC_DECODER in args.lhuc or C.LHUC_ALL in args.lhuc),
+        use_lhuc=args.lhuc is not None and (C.LHUC_DECODER in args.lhuc or C.LHUC_ALL in args.lhuc),
         depth_key_value=encoder_num_hidden,
         decoder_type=args.decoder)
 

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -38,7 +38,7 @@ class TransformerConfig(config.Config):
     max_seq_len_source: int
     max_seq_len_target: int
     decoder_type: str = C.TRANSFORMER_TYPE
-    lhuc: bool = False
+    use_lhuc: bool = False
     depth_key_value: int = 0
 
 
@@ -85,7 +85,7 @@ class TransformerEncoderBlock(mx.gluon.HybridBlock):
                                                    prefix="ff_post_",
                                                    num_hidden=config.model_size)
             self.lhuc = None
-            if config.lhuc:
+            if config.use_lhuc:
                 self.lhuc = layers.LHUC(config.model_size)
 
     def hybrid_forward(self, F, data: mx.sym.Symbol, lengths: mx.sym.Symbol) -> mx.sym.Symbol:
@@ -174,7 +174,7 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
                                                    num_hidden=config.model_size)
 
             self.lhuc = None
-            if config.lhuc:
+            if config.use_lhuc:
                 self.lhuc = layers.LHUC(config.model_size)
 
     @property

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -1,4 +1,4 @@
-# Copyright 2017--2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017--2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from dataclasses import dataclass
 from typing import Optional, Tuple
 
 import mxnet as mx
@@ -21,42 +22,24 @@ from . import layers
 from . import quantization
 
 
+@dataclass
 class TransformerConfig(config.Config):
-
-    def __init__(self,
-                 model_size: int,
-                 attention_heads: int,
-                 feed_forward_num_hidden: int,
-                 act_type: str,
-                 num_layers: int,
-                 dropout_attention: float,
-                 dropout_act: float,
-                 dropout_prepost: float,
-                 positional_embedding_type: str,
-                 preprocess_sequence: str,
-                 postprocess_sequence: str,
-                 max_seq_len_source: int,
-                 max_seq_len_target: int,
-                 decoder_type: str = C.TRANSFORMER_TYPE,
-                 lhuc: bool = False,
-                 depth_key_value: int = 0) -> None:  # type: ignore
-        super().__init__()
-        self.model_size = model_size
-        self.attention_heads = attention_heads
-        self.feed_forward_num_hidden = feed_forward_num_hidden
-        self.act_type = act_type
-        self.num_layers = num_layers
-        self.dropout_attention = dropout_attention
-        self.dropout_act = dropout_act
-        self.dropout_prepost = dropout_prepost
-        self.positional_embedding_type = positional_embedding_type
-        self.preprocess_sequence = preprocess_sequence
-        self.postprocess_sequence = postprocess_sequence
-        self.max_seq_len_source = max_seq_len_source
-        self.max_seq_len_target = max_seq_len_target
-        self.use_lhuc = lhuc
-        self.depth_key_value = depth_key_value
-        self.decoder_type = decoder_type
+    model_size: int
+    attention_heads: int
+    feed_forward_num_hidden: int
+    act_type: str
+    num_layers: int
+    dropout_attention: float
+    dropout_act: float
+    dropout_prepost: float
+    positional_embedding_type: str
+    preprocess_sequence: str
+    postprocess_sequence: str
+    max_seq_len_source: int
+    max_seq_len_target: int
+    decoder_type: str = C.TRANSFORMER_TYPE
+    lhuc: bool = False
+    depth_key_value: int = 0
 
 
 class TransformerEncoderBlock(mx.gluon.HybridBlock):
@@ -102,7 +85,7 @@ class TransformerEncoderBlock(mx.gluon.HybridBlock):
                                                    prefix="ff_post_",
                                                    num_hidden=config.model_size)
             self.lhuc = None
-            if config.use_lhuc:
+            if config.lhuc:
                 self.lhuc = layers.LHUC(config.model_size)
 
     def hybrid_forward(self, F, data: mx.sym.Symbol, lengths: mx.sym.Symbol) -> mx.sym.Symbol:
@@ -191,7 +174,7 @@ class TransformerDecoderBlock(mx.gluon.HybridBlock):
                                                    num_hidden=config.model_size)
 
             self.lhuc = None
-            if config.use_lhuc:
+            if config.lhuc:
                 self.lhuc = layers.LHUC(config.model_size)
 
     @property

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1,110 +1,101 @@
-# # Copyright 2017--2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# #
-# # Licensed under the Apache License, Version 2.0 (the "License"). You may not
-# # use this file except in compliance with the License. A copy of the License
-# # is located at
-# #
-# #     http://aws.amazon.com/apache2.0/
-# #
-# # or in the "license" file accompanying this file. This file is distributed on
-# # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# # express or implied. See the License for the specific language governing
-# # permissions and limitations under the License.
+# Copyright 2017--2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# import tempfile
-# import os
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
 #
-# import pytest
+#     http://aws.amazon.com/apache2.0/
 #
-# from sockeye import config
-#
-#
-# class ConfigTest(config.Config):
-#     yaml_tag = "!ConfigTest"
-#
-#     def __init__(self, param, config=None):
-#         super().__init__()
-#         self.param = param
-#         self.config = config
-#
-#
-# def test_config_repr():
-#     c1 = ConfigTest(param=1, config=ConfigTest(param=3))
-#     assert str(c1) == "Config[config=Config[config=None, param=3], param=1]"
-#
-#
-# def test_config_eq():
-#     basic_c = config.Config()
-#     c1 = ConfigTest(param=1)
-#     c1_other = ConfigTest(param=1)
-#     c2 = ConfigTest(param=2)
-#
-#     c_nested = ConfigTest(param=1, config=c1)
-#     c_nested_other = ConfigTest(param=1, config=c1_other)
-#     c_nested_c2 = ConfigTest(param=1, config=c2)
-#
-#     assert c1 != "OTHER_TYPE"
-#     assert c1 != basic_c
-#     assert c1 == c1_other
-#     assert c1 != c2
-#     assert c_nested == c_nested_other
-#     assert c_nested != c_nested_c2
-#
-#
-# def test_config_no_self_attribute():
-#     c1 = ConfigTest(param=1)
-#     with pytest.raises(AttributeError) as e:
-#         c1.config = c1
-#     assert str(e.value) == "Cannot set self as attribute"
-#
-#
-# def test_config_serialization():
-#     c1 = ConfigTest(param=1, config=ConfigTest(param=2))
-#     expected_serialization = """!ConfigTest
-# config: !ConfigTest
-#   config: null
-#   param: 2
-# param: 1
-# """
-#     with tempfile.TemporaryDirectory() as tmp_dir:
-#         fname = os.path.join(tmp_dir, "config")
-#         c1.save(fname)
-#         assert os.path.exists(fname)
-#         with open(fname) as f:
-#             assert f.read() == expected_serialization
-#
-#         c2 = config.Config.load(fname)
-#         assert c2.param == c1.param
-#         assert c2.config.param == c1.config.param
-#
-#
-# def test_config_copy():
-#     c1 = ConfigTest(param=1)
-#     copy_c1 = c1.copy()
-#     # should be a different object that is equal to the original object
-#     assert c1 is not copy_c1
-#     assert c1 == copy_c1
-#
-#     # optionally you can modify attributes when copying:
-#     mod_c1 = ConfigTest(param=5)
-#     mod_copy_c1 = c1.copy(param=5)
-#     assert mod_c1 is not mod_copy_c1
-#     assert mod_c1 == mod_copy_c1
-#     assert c1 != mod_copy_c1
-#
-#
-# class ConfigWithMissingAttributes(config.Config):
-#     def __init__(self, existing_attribute, new_attribute="new_attribute"):
-#         super().__init__()
-#         self.existing_attribute = existing_attribute
-#         self.new_attribute = new_attribute
-#
-#
-# def test_config_missing_attributes_filled_with_default():
-#     # when we load a configuration object that does not contain all attributes as the current version of the
-#     # configuration object we expect the missing attributes to be filled with the default values taken from the
-#     # __init__ method.
-#
-#     config_obj = config.Config.load("test/data/config_with_missing_attributes.yaml")
-#     assert config_obj.new_attribute == "new_attribute"
-#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import tempfile
+from dataclasses import dataclass
+import os
+from typing import Any, Optional
+from sockeye.config import Config
+
+import pytest
+
+
+@dataclass
+class ConfigTest(Config):
+    #yaml_tag = "!ConfigTest"
+    param: Any
+    config: Optional[Config] = None
+
+
+def test_config_repr():
+    c1 = ConfigTest(param=1, config=ConfigTest(param=3))
+    assert str(c1) == "ConfigTest(param=1, config=ConfigTest(param=3, config=None))"
+
+
+def test_config_eq():
+    basic_c = Config()
+    c1 = ConfigTest(param=1)
+    c1_other = ConfigTest(param=1)
+    c2 = ConfigTest(param=2)
+
+    c_nested = ConfigTest(param=1, config=c1)
+    c_nested_other = ConfigTest(param=1, config=c1_other)
+    c_nested_c2 = ConfigTest(param=1, config=c2)
+
+    assert c1 != "OTHER_TYPE"
+    assert c1 != basic_c
+    assert c1 == c1_other
+    assert c1 != c2
+    assert c_nested == c_nested_other
+    assert c_nested != c_nested_c2
+
+
+def test_config_serialization():
+    c1 = ConfigTest(param=1, config=ConfigTest(param=2))
+    expected_serialization = """!ConfigTest
+config: !ConfigTest
+  config: null
+  param: 2
+param: 1
+"""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        fname = os.path.join(tmp_dir, "config")
+        c1.save(fname)
+        assert os.path.exists(fname)
+        with open(fname) as f:
+            assert f.read() == expected_serialization
+
+        c2 = Config.load(fname)
+        assert c2.param == c1.param
+        assert c2.config.param == c1.config.param
+
+
+def test_config_copy():
+    c1 = ConfigTest(param=1)
+    copy_c1 = c1.copy()
+    # should be a different object that is equal to the original object
+    assert c1 is not copy_c1
+    assert c1 == copy_c1
+
+    # optionally you can modify attributes when copying:
+    mod_c1 = ConfigTest(param=5)
+    mod_copy_c1 = c1.copy(param=5)
+    assert mod_c1 is not mod_copy_c1
+    assert mod_c1 == mod_copy_c1
+    assert c1 != mod_copy_c1
+
+
+@dataclass
+class ConfigWithMissingAttributes(Config):
+    existing_attribute: str
+    new_attribute: str = "new_attribute"
+
+
+def test_config_missing_attributes_filled_with_default():
+    # when we load a configuration object that does not contain all attributes as the current version of the
+    # configuration object we expect the missing attributes to be filled with the default values taken from the
+    # __init__ method.
+
+    config_obj = Config.load("test/data/config_with_missing_attributes.yaml")
+    assert config_obj.new_attribute == "new_attribute"
+

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -17,12 +17,9 @@ import os
 from typing import Any, Optional
 from sockeye.config import Config
 
-import pytest
-
 
 @dataclass
 class ConfigTest(Config):
-    #yaml_tag = "!ConfigTest"
     param: Any
     config: Optional[Config] = None
 
@@ -93,8 +90,7 @@ class ConfigWithMissingAttributes(Config):
 
 def test_config_missing_attributes_filled_with_default():
     # when we load a configuration object that does not contain all attributes as the current version of the
-    # configuration object we expect the missing attributes to be filled with the default values taken from the
-    # __init__ method.
+    # configuration object we expect the missing attributes to be filled with the default values of the dataclass
 
     config_obj = Config.load("test/data/config_with_missing_attributes.yaml")
     assert config_obj.new_attribute == "new_attribute"

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1,110 +1,110 @@
-# Copyright 2017--2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# # Copyright 2017--2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# # use this file except in compliance with the License. A copy of the License
+# # is located at
+# #
+# #     http://aws.amazon.com/apache2.0/
+# #
+# # or in the "license" file accompanying this file. This file is distributed on
+# # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# # express or implied. See the License for the specific language governing
+# # permissions and limitations under the License.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not
-# use this file except in compliance with the License. A copy of the License
-# is located at
+# import tempfile
+# import os
 #
-#     http://aws.amazon.com/apache2.0/
+# import pytest
 #
-# or in the "license" file accompanying this file. This file is distributed on
-# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language governing
-# permissions and limitations under the License.
-
-import tempfile
-import os
-
-import pytest
-
-from sockeye import config
-
-
-class ConfigTest(config.Config):
-    yaml_tag = "!ConfigTest"
-
-    def __init__(self, param, config=None):
-        super().__init__()
-        self.param = param
-        self.config = config
-
-
-def test_config_repr():
-    c1 = ConfigTest(param=1, config=ConfigTest(param=3))
-    assert str(c1) == "Config[config=Config[config=None, param=3], param=1]"
-
-
-def test_config_eq():
-    basic_c = config.Config()
-    c1 = ConfigTest(param=1)
-    c1_other = ConfigTest(param=1)
-    c2 = ConfigTest(param=2)
-
-    c_nested = ConfigTest(param=1, config=c1)
-    c_nested_other = ConfigTest(param=1, config=c1_other)
-    c_nested_c2 = ConfigTest(param=1, config=c2)
-
-    assert c1 != "OTHER_TYPE"
-    assert c1 != basic_c
-    assert c1 == c1_other
-    assert c1 != c2
-    assert c_nested == c_nested_other
-    assert c_nested != c_nested_c2
-
-
-def test_config_no_self_attribute():
-    c1 = ConfigTest(param=1)
-    with pytest.raises(AttributeError) as e:
-        c1.config = c1
-    assert str(e.value) == "Cannot set self as attribute"
-
-
-def test_config_serialization():
-    c1 = ConfigTest(param=1, config=ConfigTest(param=2))
-    expected_serialization = """!ConfigTest
-config: !ConfigTest
-  config: null
-  param: 2
-param: 1
-"""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        fname = os.path.join(tmp_dir, "config")
-        c1.save(fname)
-        assert os.path.exists(fname)
-        with open(fname) as f:
-            assert f.read() == expected_serialization
-
-        c2 = config.Config.load(fname)
-        assert c2.param == c1.param
-        assert c2.config.param == c1.config.param
-
-
-def test_config_copy():
-    c1 = ConfigTest(param=1)
-    copy_c1 = c1.copy()
-    # should be a different object that is equal to the original object
-    assert c1 is not copy_c1
-    assert c1 == copy_c1
-
-    # optionally you can modify attributes when copying:
-    mod_c1 = ConfigTest(param=5)
-    mod_copy_c1 = c1.copy(param=5)
-    assert mod_c1 is not mod_copy_c1
-    assert mod_c1 == mod_copy_c1
-    assert c1 != mod_copy_c1
-
-
-class ConfigWithMissingAttributes(config.Config):
-    def __init__(self, existing_attribute, new_attribute="new_attribute"):
-        super().__init__()
-        self.existing_attribute = existing_attribute
-        self.new_attribute = new_attribute
-
-
-def test_config_missing_attributes_filled_with_default():
-    # when we load a configuration object that does not contain all attributes as the current version of the
-    # configuration object we expect the missing attributes to be filled with the default values taken from the
-    # __init__ method.
-
-    config_obj = config.Config.load("test/data/config_with_missing_attributes.yaml")
-    assert config_obj.new_attribute == "new_attribute"
-
+# from sockeye import config
+#
+#
+# class ConfigTest(config.Config):
+#     yaml_tag = "!ConfigTest"
+#
+#     def __init__(self, param, config=None):
+#         super().__init__()
+#         self.param = param
+#         self.config = config
+#
+#
+# def test_config_repr():
+#     c1 = ConfigTest(param=1, config=ConfigTest(param=3))
+#     assert str(c1) == "Config[config=Config[config=None, param=3], param=1]"
+#
+#
+# def test_config_eq():
+#     basic_c = config.Config()
+#     c1 = ConfigTest(param=1)
+#     c1_other = ConfigTest(param=1)
+#     c2 = ConfigTest(param=2)
+#
+#     c_nested = ConfigTest(param=1, config=c1)
+#     c_nested_other = ConfigTest(param=1, config=c1_other)
+#     c_nested_c2 = ConfigTest(param=1, config=c2)
+#
+#     assert c1 != "OTHER_TYPE"
+#     assert c1 != basic_c
+#     assert c1 == c1_other
+#     assert c1 != c2
+#     assert c_nested == c_nested_other
+#     assert c_nested != c_nested_c2
+#
+#
+# def test_config_no_self_attribute():
+#     c1 = ConfigTest(param=1)
+#     with pytest.raises(AttributeError) as e:
+#         c1.config = c1
+#     assert str(e.value) == "Cannot set self as attribute"
+#
+#
+# def test_config_serialization():
+#     c1 = ConfigTest(param=1, config=ConfigTest(param=2))
+#     expected_serialization = """!ConfigTest
+# config: !ConfigTest
+#   config: null
+#   param: 2
+# param: 1
+# """
+#     with tempfile.TemporaryDirectory() as tmp_dir:
+#         fname = os.path.join(tmp_dir, "config")
+#         c1.save(fname)
+#         assert os.path.exists(fname)
+#         with open(fname) as f:
+#             assert f.read() == expected_serialization
+#
+#         c2 = config.Config.load(fname)
+#         assert c2.param == c1.param
+#         assert c2.config.param == c1.config.param
+#
+#
+# def test_config_copy():
+#     c1 = ConfigTest(param=1)
+#     copy_c1 = c1.copy()
+#     # should be a different object that is equal to the original object
+#     assert c1 is not copy_c1
+#     assert c1 == copy_c1
+#
+#     # optionally you can modify attributes when copying:
+#     mod_c1 = ConfigTest(param=5)
+#     mod_copy_c1 = c1.copy(param=5)
+#     assert mod_c1 is not mod_copy_c1
+#     assert mod_c1 == mod_copy_c1
+#     assert c1 != mod_copy_c1
+#
+#
+# class ConfigWithMissingAttributes(config.Config):
+#     def __init__(self, existing_attribute, new_attribute="new_attribute"):
+#         super().__init__()
+#         self.existing_attribute = existing_attribute
+#         self.new_attribute = new_attribute
+#
+#
+# def test_config_missing_attributes_filled_with_default():
+#     # when we load a configuration object that does not contain all attributes as the current version of the
+#     # configuration object we expect the missing attributes to be filled with the default values taken from the
+#     # __init__ method.
+#
+#     config_obj = config.Config.load("test/data/config_with_missing_attributes.yaml")
+#     assert config_obj.new_attribute == "new_attribute"
+#

--- a/test/unit/test_decoder.py
+++ b/test/unit/test_decoder.py
@@ -17,6 +17,7 @@ import sockeye.constants as C
 import sockeye.decoder
 import sockeye.transformer
 
+
 @pytest.mark.parametrize('lhuc', [
     (False,),
     (True,)

--- a/test/unit/test_decoder.py
+++ b/test/unit/test_decoder.py
@@ -37,7 +37,7 @@ def test_get_decoder(lhuc):
         postprocess_sequence='test_post_seq',
         max_seq_len_source=60,
         max_seq_len_target=70,
-        lhuc=lhuc)
+        use_lhuc=lhuc)
     decoder = sockeye.decoder.get_decoder(config, inference_only=False, prefix='test_')
 
     assert type(decoder) == sockeye.decoder.TransformerDecoder

--- a/test/unit/test_encoder.py
+++ b/test/unit/test_encoder.py
@@ -50,7 +50,7 @@ def test_get_transformer_encoder(lhuc):
                                                    postprocess_sequence='test_post',
                                                    max_seq_len_source=50,
                                                    max_seq_len_target=60,
-                                                   lhuc=lhuc)
+                                                   use_lhuc=lhuc)
     encoder = sockeye.encoder.get_transformer_encoder(config, prefix=prefix, dtype = C.DTYPE_FP32)
     encoder.initialize()
     encoder.hybridize(static_alloc=True)


### PR DESCRIPTION
Python 3.7+ adds Dataclasses, which are convenient syntactic sugar to simplify `Config` classes: https://docs.python.org/3/library/dataclasses.html

There is also a Python 3.6 backport module that we now depend on (until we remove support for Python 3.6).

Also updated versions of pylint and mypy.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

