### PR TITLE
save and restore lr_scheduler as needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.3.6]
+
+### Fixed
+
+- Fixes the problem identified in issue #890, where the lr_scheduler
+  does not behave as expected when continuing training. The problem is
+  that the lr_scheduler is kept as part of the optimizer, but the
+  optimizer is not saved when saving state. Therefore, every time
+  training is restarted, a new lr_scheduler is created with initial
+  parameter settings. Fix by saving and restoring the lr_scheduling
+  separately.
+
 ## [2.3.5]
 
 ### Fixed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.3.5'
+__version__ = '2.3.6'

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -221,9 +221,15 @@ TENSORBOARD_NAME = "tensorboard"
 TRAINING_STATE_DIRNAME = "training_state"
 TRAINING_STATE_TEMP_DIRNAME = "tmp.training_state"
 TRAINING_STATE_TEMP_DELETENAME = "delete.training_state"
+
 OPT_STATES_LAST = "mx_optimizer_last.pkl"
 OPT_STATES_BEST = "mx_optimizer_best.pkl"
 OPT_STATES_INITIAL = "mx_optimizer_initial.pkl"
+
+LR_SCHEDULER_LAST = "lr_scheduler_last.pkl"
+LR_SCHEDULER_BEST = "lr_scheduler_best.pkl"
+LR_SCHEDULER_INITIAL = "lr_scheduler_initial.pkl"
+
 BUCKET_ITER_STATE_NAME = "bucket.pkl"
 RNG_STATE_NAME = "rng.pkl"
 TRAINING_STATE_NAME = "training.pkl"

--- a/sockeye/lr_scheduler.py
+++ b/sockeye/lr_scheduler.py
@@ -176,7 +176,13 @@ class LearningRateSchedulerPlateauReduce(AdaptiveLearningRateScheduler):
         return lr
 
     def __repr__(self):
-        return "LearningRateSchedulerPlateauReduce(reduce_factor=%.2f, reduce_num_not_improved=%d, num_not_improved=%d, base_lr=%s, lr=%s, warmup=%d, warmed_up=%s)" % (self.reduce_factor, self.reduce_num_not_improved, self.num_not_improved, self.base_lr, self.lr, self.warmup, self.warmed_up)
+        return (
+            "LearningRateSchedulerPlateauReduce(reduce_factor=%.2f, reduce_num_not_improved=%d, num_not_improved=%d,"
+            " base_lr=%s, lr=%s, warmup=%d, warmed_up=%s)"
+            %
+            (self.reduce_factor, self.reduce_num_not_improved,
+             self.num_not_improved, self.base_lr, self.lr, self.warmup, self.warmed_up)
+        )
 
 
 def get_lr_scheduler(scheduler_type: str,

--- a/sockeye/lr_scheduler.py
+++ b/sockeye/lr_scheduler.py
@@ -138,6 +138,7 @@ class LearningRateSchedulerPlateauReduce(AdaptiveLearningRateScheduler):
         self.lr = None  # type: Optional[float]
         self.t_last_log = -1
         self.warmed_up = not self.warmup > 0
+        
         logger.info("Will reduce the learning rate by a factor of %.2f whenever"
                     " the validation score doesn't improve %d times.",
                     reduce_factor, reduce_num_not_improved)
@@ -175,8 +176,7 @@ class LearningRateSchedulerPlateauReduce(AdaptiveLearningRateScheduler):
         return lr
 
     def __repr__(self):
-        return "LearningRateSchedulerPlateauReduce(reduce_factor=%.2f, " \
-               "reduce_num_not_improved=%d)" % (self.reduce_factor, self.reduce_num_not_improved)
+        return "LearningRateSchedulerPlateauReduce(reduce_factor=%.2f, reduce_num_not_improved=%d, num_not_improved=%d, base_lr=%s, lr=%s, warmup=%d, warmed_up=%s)" % (self.reduce_factor, self.reduce_num_not_improved, self.num_not_improved, self.base_lr, self.lr, self.warmup, self.warmed_up)
 
 
 def get_lr_scheduler(scheduler_type: str,

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -591,14 +591,13 @@ class GluonEarlyStoppingTrainer:
     def _save_lr_scheduler(self, fname):
         with open(fname, "wb") as fp:
             pickle.dump(self.trainer.optimizer.lr_scheduler, fp)
-        logger.info('Saved lr_scheduler to "%s"', fname)
-        logger.info('Saved lr_scheduler %s', self.trainer.optimizer.lr_scheduler.__repr__())
+        logger.info("Saved '%s' to '%s'", self.trainer.optimizer.lr_scheduler, fname)
 
     def _load_lr_scheduler(self, fname):
-        with open(fname, "rb") as fp:
-            self.trainer.optimizer.lr_scheduler = pickle.load(fp)
-        logger.info('Loaded lr_scheduler from "%s"', fname)
-        logger.info('Loaded lr_scheduler %s', self.trainer.optimizer.lr_scheduler.__repr__())
+        if os.path.exists(fname):
+            with open(fname, "rb") as fp:
+                self.trainer.optimizer.lr_scheduler = pickle.load(fp)
+                logger.info("Loaded '%s' from '%s'", self.trainer.optimizer.lr_scheduler, fname)
 
     def _save_training_state(self, train_iter: data_io.BaseParallelSampleIter):
         """

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -589,15 +589,16 @@ class GluonEarlyStoppingTrainer:
         logger.info('Loaded optimizer states from "%s"', fname)
 
     def _save_lr_scheduler(self, fname):
-        with open(fname, "wb") as fp:
-            pickle.dump(self.trainer.optimizer.lr_scheduler, fp)
-        logger.info("Saved '%s' to '%s'", self.trainer.optimizer.lr_scheduler, fname)
+        if self.trainer.optimizer.lr_scheduler is not None:
+            with open(fname, "wb") as fp:
+                pickle.dump(self.trainer.optimizer.lr_scheduler, fp)
+            logger.info("Saved '%s' to '%s'", self.trainer.optimizer.lr_scheduler, fname)
 
     def _load_lr_scheduler(self, fname):
         if os.path.exists(fname):
             with open(fname, "rb") as fp:
                 self.trainer.optimizer.lr_scheduler = pickle.load(fp)
-                logger.info("Loaded '%s' from '%s'", self.trainer.optimizer.lr_scheduler, fname)
+            logger.info("Loaded '%s' from '%s'", self.trainer.optimizer.lr_scheduler, fname)
 
     def _save_training_state(self, train_iter: data_io.BaseParallelSampleIter):
         """

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -307,6 +307,7 @@ class GluonEarlyStoppingTrainer:
         if has_improved:
             self._update_best_params()
             self._save_trainer_states(self.best_optimizer_states_fname)
+            self._save_lr_scheduler(self.best_lr_scheduler_fname)
         self._write_and_log_metrics(train_metrics=train_metrics, val_metrics=val_metrics)
         for metric in train_metrics:
             metric.reset()
@@ -587,6 +588,18 @@ class GluonEarlyStoppingTrainer:
         self.trainer.load_states(fname)
         logger.info('Loaded optimizer states from "%s"', fname)
 
+    def _save_lr_scheduler(self, fname):
+        with open(fname, "wb") as fp:
+            pickle.dump(self.trainer.optimizer.lr_scheduler, fp)
+        logger.info('Saved lr_scheduler to "%s"', fname)
+        logger.info('Saved lr_scheduler %s', self.trainer.optimizer.lr_scheduler.__repr__())
+
+    def _load_lr_scheduler(self, fname):
+        with open(fname, "rb") as fp:
+            self.trainer.optimizer.lr_scheduler = pickle.load(fp)
+        logger.info('Loaded lr_scheduler from "%s"', fname)
+        logger.info('Loaded lr_scheduler %s', self.trainer.optimizer.lr_scheduler.__repr__())
+
     def _save_training_state(self, train_iter: data_io.BaseParallelSampleIter):
         """
         Saves current training state.
@@ -606,6 +619,10 @@ class GluonEarlyStoppingTrainer:
         # (2) Optimizer states
         opt_state_fname = os.path.join(training_state_dirname, C.OPT_STATES_LAST)
         self._save_trainer_states(opt_state_fname)
+
+        # (2.5) lr_scheduler
+        lr_scheduler_fname = os.path.join(training_state_dirname, C.LR_SCHEDULER_LAST)
+        self._save_lr_scheduler(lr_scheduler_fname)
 
         # (3) Data iterator
         train_iter.save_state(os.path.join(training_state_dirname, C.BUCKET_ITER_STATE_NAME))
@@ -658,6 +675,10 @@ class GluonEarlyStoppingTrainer:
         opt_state_fname = os.path.join(self.training_state_dirname, C.OPT_STATES_LAST)
         self._load_trainer_states(opt_state_fname)
 
+        # (2.5) lr_scheduler
+        lr_scheduler_fname = os.path.join(self.training_state_dirname, C.LR_SCHEDULER_LAST)
+        self._load_lr_scheduler(lr_scheduler_fname)
+
         # (3) Data Iterator
         train_iter.load_state(os.path.join(self.training_state_dirname, C.BUCKET_ITER_STATE_NAME))
 
@@ -697,6 +718,8 @@ class GluonEarlyStoppingTrainer:
                 shutil.rmtree(self.training_state_dirname)
             if os.path.exists(self.best_optimizer_states_fname):
                 os.remove(self.best_optimizer_states_fname)
+            if os.path.exists(self.best_lr_scheduler_fname):
+                os.remove(self.best_lr_scheduler_fname)
 
     @property
     def metrics_fname(self) -> str:
@@ -717,6 +740,10 @@ class GluonEarlyStoppingTrainer:
     @property
     def best_optimizer_states_fname(self) -> str:
         return os.path.join(self.config.output_dir, C.OPT_STATES_BEST)
+
+    @property
+    def best_lr_scheduler_fname(self) -> str:
+        return os.path.join(self.config.output_dir, C.LR_SCHEDULER_BEST)
 
 
 class ParallelModel(parallel.Parallelizable):


### PR DESCRIPTION
This change fixes the problem in issue #890, where the lr_scheduler does not behave as expected when continuing training. The problem is that the lr_scheduler is kept as part of the optimizer, but the optimizer is not saved when saving state. Therefore, every time training is restarted, a new lr_scheduler is created with initial parameter settings.

#### Pull Request Checklist ##
- [ x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.

- [x] Unit tests pass (`pytest`)
        --- There are failures, but these are the same failures exhibited by the master branch
- [no] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
         --- There are failures, but these are the same failures exhibited by the master branch
- [x] Passed code style checking (`./style-check.sh`)
         --- There are failures, but these are the same failures exhibited by the master branch
- [no] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

