### PR TITLE
Add scripts for processing benchmark files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,20 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.3.9]
+
+### Added
+
+- Added scripts for processing Sockeye benchmark output (`--output-type benchmark`):
+  - [benchmark_to_output.py](sockeye_contrib/benchmark/benchmark_to_output.py) extracts translations
+  - [benchmark_to_percentiles.py](sockeye_contrib/benchmark/benchmark_to_percentiles.py) computes percentiles
+
 ## [2.3.8]
 
 ### Fixed
 
 - Fix problem identified in issue #925 that caused learning rate
-  warmup to fail in some instances when doing continued training 
+  warmup to fail in some instances when doing continued training
 
 ## [2.3.7]
 

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017--2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017--2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.3.8'
+__version__ = '2.3.9'

--- a/sockeye_contrib/benchmark/benchmark_to_output.py
+++ b/sockeye_contrib/benchmark/benchmark_to_output.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import sys
+from typing import Dict, Iterator
+
+
+def read_benchmark_handler_output(stream: str) -> Iterator[Dict[str, str]]:
+    for line in stream:
+        fields = line.strip().split('\t')
+        entry = dict(field.split('=', 1) for field in fields)
+        yield entry
+
+
+def get_output_from_benchmark_output(input_stream) -> Iterator[str]:
+    for entry in read_benchmark_handler_output(input_stream):
+        yield entry['output']
+
+
+def main():
+    for output in get_output_from_benchmark_output(sys.stdin):
+        print(output)
+
+
+if __name__ == '__main__':
+    main()

--- a/sockeye_contrib/benchmark/benchmark_to_percentiles.py
+++ b/sockeye_contrib/benchmark/benchmark_to_percentiles.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import argparse
+from typing import Dict, Iterator, List, Tuple
+
+
+def read_benchmark_handler_output(stream: str) -> Iterator[Dict[str, str]]:
+    for line in stream:
+        fields = line.strip().split('\t')
+        entry = dict(field.split('=', 1) for field in fields)
+        yield entry
+
+
+def compute_percentiles(lengths: List[int], length_percentile: int,
+                        times: List[float], time_percentile: int) -> Tuple[int, float]:
+    # Length percentile
+    lp_i = min(int((length_percentile / 100) * len(lengths)), len(lengths) - 1)
+    lp = sorted(lengths)[lp_i]
+
+    # Time percentile (of length percentile)
+    percentile_points = sorted(zip(lengths, times))[:lp_i + 1]
+    percentile_times = [point[1] for point in percentile_points]
+    tp_i = min(int((time_percentile / 100) * len(percentile_times)), len(percentile_times) - 1)
+    tp = sorted(percentile_times)[tp_i]
+    return lp, tp
+
+
+def percentiles_from_benchmark_output(input_stream, length_percentile: int, time_percentile: int) -> Tuple[int, float]:
+    input_lengths = []
+    translation_times = []
+    for entry in read_benchmark_handler_output(input_stream):
+        input_lengths.append(int(entry['input_tokens']))
+        translation_times.append(float(entry['translation_time']))
+    return compute_percentiles(input_lengths, length_percentile, translation_times, time_percentile)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Report length and time percentiles for benchmark output')
+    parser.add_argument(
+        '--input',
+        '-i',
+        required=True,
+        help=
+        'Input file (result of sockeye.translate with \'benchmark\' output)')
+    parser.add_argument(
+        '--length-percentile',
+        '-lp',
+        type=int,
+        default=99,
+        help='Percentile to report for input length. Default: %(default)s')
+    parser.add_argument(
+        '--time-percentile',
+        '-tp',
+        type=int,
+        default=99,
+        help='Percentile to report for translation time. Default: %(default)s')
+    args = parser.parse_args()
+
+    with open(args.input) as inp:
+        lp, tp = percentiles_from_benchmark_output(inp, args.length_percentile, args.time_percentile)
+    print('P{}\t{:d}'.format(args.length_percentile, lp))
+    print('P{}/{}\t{:0.3f}'.format(args.time_percentile, args.length_percentile, tp))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit adds two simple scripts for processing benchmark output (`--output-type benchmark`):
- benchmark_to_output.py extracts translations
- benchmark_to_percentiles.py computes time percentiles for segment-level translation

These are self-contained convenience scripts that do not affect Sockeye's behavior.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

