### PR TITLE
Attempt to fix pylint error: sockeye/data_io.py:1834:15: E1102: self.shard_iter.next is not callable (not-callable)

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         pylint --version
         pylint --rcfile=pylintrc sockeye -E
-        pylint --rcfile=pylintrc test -E
+        pylint --rcfile=pylintrc test -E --disable=E1102
     - name: MyPy
       run: |
         mypy --version

--- a/sockeye/data_io.py
+++ b/sockeye/data_io.py
@@ -1831,7 +1831,7 @@ class ShardedParallelSampleIter(BaseParallelSampleIter):
                 self._load_shard()
             else:
                 raise StopIteration
-        return self.shard_iter.next()
+        return self.shard_iter.next()  # pylint: disable=E1102
 
     def save_state(self, fname: str):
         with open(fname, "wb") as fp:

--- a/style-check.sh
+++ b/style-check.sh
@@ -7,7 +7,7 @@ pylint --rcfile=pylintrc sockeye -E
 SOCKEYE_LINT_RESULT=$?
 
 # Run pylint on test package, failing on any reported errors.
-pylint --rcfile=pylintrc test -E
+pylint --rcfile=pylintrc test -E --disable=E1102
 TESTS_LINT_RESULT=$?
 
 # Run mypy, we are currently limiting to modules in typechecked-files


### PR DESCRIPTION
A new version of pylint/astroid(?) throws a bunch of errors related to the `next()` method. This PR ignores these errors for now.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

