### PR TITLE
prepare_data now supports storage of CLI flags in yaml file (like sockeye_train)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.3.12]
+
+### Added
+- Added `--config` option to `prepare_data` CLI to allow setting commandline flags via a yaml config. 
+- Flags for the `prepare_data` CLI are now stored in the output folder under `args.yaml`
+  (equivalent to the behavior of `sockeye_train`)
+
 ## [2.3.11]
 
 ### Added

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.3.11'
+__version__ = '2.3.12'

--- a/sockeye/prepare_data.py
+++ b/sockeye/prepare_data.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def main():
-    params = argparse.ArgumentParser(description='Preprocesses and shards training data.')
+    params = arguments.ConfigArgumentParser(description='Preprocesses and shards training data.')
     arguments.add_prepare_data_cli_args(params)
     args = params.parse_args()
     prepare_data(args)
@@ -39,6 +39,7 @@ def prepare_data(args: argparse.Namespace):
                       file_logging=not args.no_logfile,
                       path=os.path.join(output_folder, C.LOG_NAME))
     utils.log_basic_info(args)
+    arguments.save_args(args, os.path.join(output_folder, C.ARGS_STATE_NAME))
     utils.seed_rngs(args.seed)
 
     minimum_num_shards = args.min_num_shards


### PR DESCRIPTION
see above

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

