### PR TITLE
Simplify mxnet nightly build action

### DIFF
--- a/.github/workflows/mxnet_nightly.yml
+++ b/.github/workflows/mxnet_nightly.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-      with:
-        ref: sockeye_2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -36,9 +34,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install "pyyaml>=5.1" "numpy>1.16.0,<2.0.0" "portalocker" "sacrebleu==1.4.3"
-        pip install -r requirements/requirements.dev.txt --use-deprecated=legacy-resolver
-        pip install --pre "mxnet<2" -f https://dist.mxnet.io/python
+        pip install -r requirements/requirements.txt
+        pip install -r requirements/requirements.dev.txt
+        pip install --upgrade --pre "mxnet<2" -f https://dist.mxnet.io/python
     - name: Print mxnet build
       run: pip list | grep mxnet
     - name: Unit tests

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Sockeye requirements
       run: pip install -r requirements/requirements.txt
     - name: Development requirements
-      run: pip install -r requirements/requirements.dev.txt --use-deprecated=legacy-resolver
+      run: pip install -r requirements/requirements.dev.txt
     - name: Unit tests
       run: |
         pytest --version


### PR DESCRIPTION
Simplifies mxnet nightly build action:
- remove legacy resolver flag, no longer necessary
- use requirements.txt and update mxnet to nightly afterwards

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

