### PR TITLE
Decoder class is now a complete HybridBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.3.15]
+
+### Changed
+- Optimization: Decoder class is now a complete HybridBlock (no forward method).
+
 ## [2.3.14]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.3.14'
+__version__ = '2.3.15'

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -217,7 +217,7 @@ class SockeyeModel(mx.gluon.Block):
         source_embed, source_embed_length = self.embedding_source(source, source_length)
         target_embed, target_embed_length = self.embedding_target(target, target_length)
         source_encoded, source_encoded_length = self.encoder(source_embed, source_embed_length)
-        states = self.decoder.init_state_from_encoder(source_encoded, source_encoded_length)
+        states = self.decoder.init_state_from_encoder(source_encoded, source_encoded_length, target_embed)
         return source_encoded, source_encoded_length, target_embed, states
 
     def decode_step(self, step_input, states, vocab_slice_ids=None):
@@ -245,10 +245,8 @@ class SockeyeModel(mx.gluon.Block):
 
         valid_length = mx.nd.ones(shape=(step_input.shape[0],), ctx=step_input.context)
         target_embed, _ = self.embedding_target(step_input.reshape((0, 1, -1)), valid_length=valid_length)
-        target_embed = target_embed.squeeze(axis=1)
-
         decoder_out, new_states = self.decoder(target_embed, states)
-
+        decoder_out = decoder_out.squeeze(axis=1)
         # step_output: (batch_size, target_vocab_size or vocab_slice_ids)
         step_output = self.output_layer(decoder_out, vocab_slice_ids)
 


### PR DESCRIPTION
This change moves imperative code previously in the `forward()` method of the Decoder class into the less performance-critical `init_state_from_encoder()` method and simplifies the logic a little bit (e.g. incrementing the step state regardless of inference or training mode).

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

