### PR TITLE
Add option to use Gated Linear Units in Transformer feed-forward networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.3.16]
+
+### Added
+- Added option `--transformer-feed-forward-use-glu` to use Gated Linear Units in transformer feed forward networks ([Dauphin et al., 2016](https://arxiv.org/abs/1612.08083); [Shazeer, 2020](https://arxiv.org/abs/2002.05202)).
+
 ## [2.3.15]
 
 ### Changed
@@ -32,7 +37,7 @@ Each version section may have have subsections for: _Added_, _Changed_, _Removed
 ## [2.3.12]
 
 ### Added
-- Added `--config` option to `prepare_data` CLI to allow setting commandline flags via a yaml config. 
+- Added `--config` option to `prepare_data` CLI to allow setting commandline flags via a yaml config.
 - Flags for the `prepare_data` CLI are now stored in the output folder under `args.yaml`
   (equivalent to the behavior of `sockeye_train`)
 

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.3.15'
+__version__ = '2.3.16'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -690,6 +690,12 @@ def add_model_parameters(params):
                               default=(2048, 2048),
                               help='Number of hidden units in transformers feed forward layers. '
                                    'Use "x:x" to specify separate values for encoder & decoder. Default: %(default)s.')
+    model_params.add_argument('--transformer-feed-forward-use-glu',
+                              action='store_true',
+                              default=False,
+                              help='Use Gated Linear Units in transformer feed forward networks (Daupin et al. 2016, '
+                                   'arxiv.org/abs/1612.08083; Shazeer 2020, arxiv.org/abs/2002.05202). Default: '
+                                   '%(default)s.')
     model_params.add_argument('--transformer-activation-type',
                               type=multiple_values(num_values=2, greater_or_equal=None, data_type=str),
                               default=(C.RELU, C.RELU),

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -472,7 +472,8 @@ def create_encoder_config(args: argparse.Namespace,
         max_seq_len_source=max_seq_len_source,
         max_seq_len_target=max_seq_len_target,
         use_lhuc=args.lhuc is not None and (C.LHUC_ENCODER in args.lhuc or C.LHUC_ALL in args.lhuc),
-        decoder_type=args.decoder)
+        decoder_type=args.decoder,
+        use_glu=args.transformer_feed_forward_use_glu)
     encoder_num_hidden = encoder_transformer_model_size
 
     return config_encoder, encoder_num_hidden
@@ -524,7 +525,8 @@ def create_decoder_config(args: argparse.Namespace,
         max_seq_len_target=max_seq_len_target,
         use_lhuc=args.lhuc is not None and (C.LHUC_DECODER in args.lhuc or C.LHUC_ALL in args.lhuc),
         depth_key_value=encoder_num_hidden,
-        decoder_type=args.decoder)
+        decoder_type=args.decoder,
+        use_glu=args.transformer_feed_forward_use_glu)
 
     return config_decoder
 

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -121,6 +121,7 @@ def test_device_args(test_params, expected_params):
               weight_tying_type="src_trg_softmax",
               transformer_attention_heads=(8, 8),
               transformer_feed_forward_num_hidden=(2048, 2048),
+              transformer_feed_forward_use_glu=False,
               transformer_activation_type=(C.RELU, C.RELU),
               transformer_model_size=(512, 512),
               transformer_positional_embedding_type="fixed",

--- a/test/unit/test_transformer.py
+++ b/test/unit/test_transformer.py
@@ -11,6 +11,8 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+import pytest
+
 import mxnet as mx
 import numpy as np
 
@@ -43,3 +45,19 @@ def test_auto_regressive_bias_output():
 
     expected = np.array([[0.0, -1.0e8], [0.0, 0.0]]).reshape((1, 2, 2))
     np.testing.assert_array_equal(bias.asnumpy(), expected)
+
+
+@pytest.mark.parametrize('use_glu', [(False), (True)])
+def test_transformer_feed_forward(use_glu):
+    block = sockeye.transformer.TransformerFeedForward(num_hidden=2,
+                                                       num_model=2,
+                                                       act_type=C.RELU,
+                                                       dropout=0.1,
+                                                       dtype=C.DTYPE_FP32,
+                                                       prefix='ff_',
+                                                       use_glu=use_glu)
+    block.initialize()
+    block.hybridize()
+
+    data = mx.nd.ones((1, 10, 2), dtype=C.DTYPE_FP32)
+    block(data)


### PR DESCRIPTION
Recent work shows that using Gated Linear Units in transformer feed-forward networks can yield quality improvements ([Shazeer, 2020](https://arxiv.org/abs/2002.05202)).  This PR adds the option to use GLU variants in Sockeye.

When using the option `--transformer-feed-forward-use-glu`, the output of the first densely-connected layer of each feed-forward network is multiplied element-wise with the output of a linear projection.  For example, a feed-forward network with ReLU activation becomes a feed-forward network with a "ReGLU" layer:

<img src="https://render.githubusercontent.com/render/math?math=\FFN_{\ReLU}(x,W_1,W_2)=\ReLU(xW_1)W_2">

becomes

<img src="https://render.githubusercontent.com/render/math?math=\FFN_{\ReGLU}(x,W_1,V,W_2)=(\ReLU(xW_1)\otimes{}xV)W_2">

(biases omitted for simplicity)

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

