### PR TITLE
Turn off autograd when training only the decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [2.3.19]
+### Changed
+
+- When training only the decoder (`--fixed-param-strategy all_except_decoder`), disable autograd for the encoder and embeddings to save memory.
+
 ## [2.3.18]
 ### Changed
 

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '2.3.18'
+__version__ = '2.3.19'

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -1026,7 +1026,9 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
                                            max_seq_len_target=max_seq_len_target,
                                            config_data=config_data)
 
-        training_model = model.SockeyeModel(model_config)
+        training_model = model.SockeyeModel(
+            model_config,
+            train_decoder_only=args.fixed_param_strategy == C.FIXED_PARAM_STRATEGY_ALL_EXCEPT_DECODER)
 
         # Handle options that override training settings
         trainer_config = training.TrainerConfig(

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -750,3 +750,11 @@ def log_parameters(params: mx.gluon.ParameterDict):
                 total_fixed, total_fixed / total_parameters * 100)
     logger.info("Trainable parameters: \n%s", pprint.pformat(learned_parameter_names))
     logger.info("Fixed parameters:\n%s", pprint.pformat(fixed_parameter_names))
+
+
+@contextmanager
+def no_context():
+    """
+    No-op context manager that can be used in "with" statements
+    """
+    yield None

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -51,7 +51,7 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --weight-tying-type src_trg_softmax"
      " --weight-init-scale=3.0 --weight-init-xavier-factor-type=avg"
      " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
-     # Note: We set the checkpoint interval > max updates in order to make sure we create a checkpoint when reaching 
+     # Note: We set the checkpoint interval > max updates in order to make sure we create a checkpoint when reaching
      # max updates independent of the checkpoint interval
      " --checkpoint-interval 20 --optimizer adam --initial-learning-rate 0.01",
      "--beam-size 2 --nbest-size 2",
@@ -117,6 +117,18 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --length-task length --length-task-weight 1.0 --length-task-layers 2",
      "--beam-size 2"
      " --brevity-penalty-type constant --brevity-penalty-weight 2.0 --brevity-penalty-constant-length-ratio 1.5",
+     False, 0, 0),
+    # Basic transformer, training only the decoder
+    ("--encoder transformer --decoder {decoder}"
+     " --num-layers 2 --transformer-attention-heads 2 --transformer-model-size 8 --num-embed 8"
+     " --transformer-feed-forward-num-hidden 16"
+     " --transformer-dropout-prepost 0.1 --transformer-preprocess n --transformer-postprocess dr"
+     " --weight-tying-type src_trg_softmax"
+     " --weight-init-scale=3.0 --weight-init-xavier-factor-type=avg"
+     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
+     " --checkpoint-interval 2 --optimizer adam --initial-learning-rate 0.01"
+     " --fixed-param-strategy " + C.FIXED_PARAM_STRATEGY_ALL_EXCEPT_DECODER,
+     "--beam-size 2",
      False, 0, 0),
 ]
 


### PR DESCRIPTION
This PR automatically disables autograd for the encoder and source/target embeddings when training only the decoder: `python3 -m sockeye.train ... --fixed-param-strategy all_except_decoder`.

MXNet uses substantially less memory when it doesn't have to allocate space to track computation for a backward pass.  This enables increasing the batch size for faster model training.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

