### PR TITLE
Set depth_key_value in Encoder TransformerConfig

### DIFF
--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -471,6 +471,7 @@ def create_encoder_config(args: argparse.Namespace,
         postprocess_sequence=encoder_transformer_postprocess,
         max_seq_len_source=max_seq_len_source,
         max_seq_len_target=max_seq_len_target,
+        depth_key_value=encoder_transformer_model_size,
         use_lhuc=args.lhuc is not None and (C.LHUC_ENCODER in args.lhuc or C.LHUC_ALL in args.lhuc),
         decoder_type=args.decoder,
         use_glu=args.transformer_feed_forward_use_glu)


### PR DESCRIPTION
Make sure we set depth_key_value in the encoder TransformerConfig. Before, this defaulted to 0 which works because MXNet can infer input shapes when creating the key-value projection layer. But its better to be explicit with this, especially if this information is known at config construction time.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

