### PR TITLE
Return target factor sequence scores in beam search & scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.0.1]
+
+### Changed
+
+- The score of the greedily selected target factor for models using target factors is now added to the model score for 
+  an hypothesis in decoding. This enables proper scoring of data with target factors using `sockeye.score`.
+
 ## [3.0.0] Sockeye 3: Fast Neural Machine Translation with PyTorch
 
 Sockeye is now based on PyTorch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 
 ### Changed
 
-- The score of the greedily selected target factor for models using target factors is now added to the model score for 
-  an hypothesis in decoding. This enables proper scoring of data with target factors using `sockeye.score`.
+- `sockeye-translate`: Beam search now computes and returns secondary target factor scores. Secondary target factors 
+  do not participate in beam search, but are greedily chosen at every time step. Accumulated scores for secondary factors
+  are not normalized by length. Factor scores are included in JSON output (``--output-type json``).
+- `sockeye-score` now returns tab-separated scores for each target factor. Users can decide how to combine factor scores
+  depending on the downstream application. Score for the first, primary factor (i.e. output words) are normalized,
+  other factors are not.
 
 ## [3.0.0] Sockeye 3: Fast Neural Machine Translation with PyTorch
 

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'

--- a/sockeye/beam_search_pt.py
+++ b/sockeye/beam_search_pt.py
@@ -91,6 +91,7 @@ class _SingleModelInference(_Inference):
                 # Shape per factor: (batch/beam, 1, 2), where last dimension holds values and indices.
                 tf_prediction = pt.cat(tf_scores.min(dim=-1, keepdim=True), dim=1).unsqueeze(1)
                 predictions.append(tf_prediction)
+            # Shape: (batch*beam, num_secondary_factors, 2)
             target_factors = pt.cat(predictions, dim=1) if len(predictions) > 1 else predictions[0]
 
         return scores, states, target_factors

--- a/sockeye/beam_search_pt.py
+++ b/sockeye/beam_search_pt.py
@@ -86,9 +86,8 @@ class _SingleModelInference(_Inference):
                 if not self._skip_softmax:
                     tf_logits = pt.log_softmax(tf_logits, dim=-1)
                 tf_scores = -tf_logits
-                # shape: (batch, num_classes)
-                # target factors are greedily chosen, and score and index are collected via torch.max.
-                # Shape per factor: (batch/beam, 1, 2), where last dimension holds values and indices.
+                # target factors are greedily chosen, and score and index are collected via torch.min.
+                # Shape per factor: (batch*beam, 1, 2), where last dimension holds values and indices.
                 tf_prediction = pt.cat(tf_scores.min(dim=-1, keepdim=True), dim=1).unsqueeze(1)
                 predictions.append(tf_prediction)
             # Shape: (batch*beam, num_secondary_factors, 2)

--- a/sockeye/beam_search_pt.py
+++ b/sockeye/beam_search_pt.py
@@ -554,8 +554,7 @@ class GreedySearch(pt.nn.Module):
                 source: pt.Tensor,
                 source_length: pt.Tensor,
                 restrict_lexicon: Optional[lexicon.TopKLexicon],
-                max_output_lengths: pt.Tensor) -> Tuple[pt.Tensor, pt.Tensor, pt.Tensor, pt.Tensor,
-                                                        List[Optional[pt.Tensor]]]:
+                max_output_lengths: pt.Tensor) -> SearchResult:
         """
         Translates a single sentence (batch_size=1) using greedy search.
 
@@ -564,9 +563,7 @@ class GreedySearch(pt.nn.Module):
         :param restrict_lexicon: Lexicon to use for vocabulary restriction.
         :param max_output_lengths: ndarray of maximum output lengths per input in source.
                 Shape: (batch_size=1,). Dtype: int32.
-        :return List of best hypotheses indices, list of best word indices,
-                array of accumulated length-normalized negative log-probs, hypotheses lengths,
-                predicted lengths of references (if any).
+        :return SearchResult.
         """
         batch_size = source.size()[0]
         assert batch_size == 1, "Greedy Search does not support batch_size != 1"

--- a/sockeye/beam_search_pt.py
+++ b/sockeye/beam_search_pt.py
@@ -13,18 +13,18 @@
 
 import functools
 import logging
-
 import operator
 from abc import abstractmethod, ABC
+from dataclasses import dataclass
 from typing import Optional, Tuple, List, Union
 
-import torch as pt
 import numpy as onp
+import torch as pt
 
-from .model_pt import PyTorchSockeyeModel
 import sockeye.constants as C
-from . import utils
 from . import lexicon
+from . import utils
+from .model_pt import PyTorchSockeyeModel
 
 logger = logging.getLogger(__name__)
 
@@ -81,14 +81,17 @@ class _SingleModelInference(_Inference):
 
         target_factors = None  # type: Optional[pt.Tensor]
         if target_factor_outputs:
-            if not self._skip_softmax:
-                target_factor_outputs = [tfo.log_softmax(dim=-1) for tfo in target_factor_outputs]
-            # shape: (batch, num_classes)
-            # target factors are greedily chosen, shape: (batch, 1)
-            factor_logits, factor_predictions = zip(*[tfo.max(dim=-1, keepdim=True) for tfo in target_factor_outputs])
-            target_factors = factor_predictions[0] if len(factor_predictions) == 1 else pt.cat(factor_predictions, 1)
-            # top-1 negative factor logits are broadcast-added to output word scores
-            scores = scores - sum(factor_logits)
+            predictions = []  # type: List[pt.Tensor]
+            for tf_logits in target_factor_outputs:
+                if not self._skip_softmax:
+                    tf_logits = pt.log_softmax(tf_logits, dim=-1)
+                tf_scores = -tf_logits
+                # shape: (batch, num_classes)
+                # target factors are greedily chosen, and score and index are collected via torch.max.
+                # Shape per factor: (batch/beam, 1, 2), where last dimension holds values and indices.
+                tf_prediction = pt.cat(tf_scores.min(dim=-1, keepdim=True), dim=1).unsqueeze(1)
+                predictions.append(tf_prediction)
+            target_factors = pt.cat(predictions, dim=1) if len(predictions) > 1 else predictions[0]
 
         return scores, states, target_factors
 
@@ -145,10 +148,11 @@ class _EnsembleInference(_Inference):
 
         target_factors = None  # type: Optional[pt.Tensor]
         if factor_outputs:
-            # target factors are greedily 'decoded'.
-            factor_predictions = [self._interpolation(fs).argmin(dim=-1, keepdim=True).int() for fs in zip(*factor_outputs)]
-            if factor_predictions:
-                target_factors = factor_predictions[0] if len(factor_predictions) == 1 else pt.cat(factor_predictions, 1)
+            predictions = []  # type: List[pt.Tensor]
+            for model_tf_logits in zip(*factor_outputs):
+                tf_prediction = pt.cat(self._interpolation(model_tf_logits).min(dim=-1, keepdim=True), dim=1).unsqueeze(1)
+                predictions.append(tf_prediction)
+            target_factors = pt.cat(predictions, dim=1) if len(predictions) > 1 else predictions[0]
         return scores, new_states, target_factors
 
     @staticmethod
@@ -159,6 +163,18 @@ class _EnsembleInference(_Inference):
     def log_linear_interpolation(predictions):
         log_probs = utils.average_tensors([p.log() for p in predictions])
         return -(log_probs.log_softmax())
+
+
+@dataclass
+class SearchResult:
+    """
+    Holds return values from Search algorithms
+    """
+    best_hyp_indices: pt.Tensor
+    best_word_indices: pt.Tensor
+    accumulated_scores: pt.Tensor
+    lengths: pt.Tensor
+    estimated_reference_lengths: pt.Tensor
 
 
 class UpdateScores(pt.nn.Module):
@@ -301,15 +317,17 @@ class SortNormalizeAndUpdateFinished(pt.nn.Module):
     def __init__(self,
                  pad_id: int,
                  eos_id: int,
-                 scorer: CandidateScorer) -> None:
+                 scorer: CandidateScorer,
+                 expect_factors: bool) -> None:
         super().__init__()
         self.pad_id = pad_id
         self.eos_id = eos_id
         self._scorer = scorer
+        self.expect_factors = expect_factors
 
     def forward(self, best_hyp_indices, best_word_indices,
                 finished, scores_accumulated, lengths, reference_lengths,
-                factors=None):
+                *factor_args):
 
         # Reorder fixed-size beam data according to best_hyp_indices (ascending)
         finished = finished.index_select(0, best_hyp_indices)
@@ -320,22 +338,29 @@ class SortNormalizeAndUpdateFinished(pt.nn.Module):
         all_finished = pt.logical_or(best_word_indices == self.pad_id, best_word_indices == self.eos_id)
         newly_finished = pt.logical_xor(all_finished, finished).unsqueeze(1)
         scores_accumulated = pt.where(newly_finished,
-                                      self._scorer(scores_accumulated,
-                                                   lengths,
-                                                   reference_lengths),
+                                      self._scorer(scores_accumulated, lengths, reference_lengths),
                                       scores_accumulated)
 
         # Recompute finished. Hypotheses are finished if they are extended with <pad> or <eos>
         finished = pt.logical_or(best_word_indices == self.pad_id, best_word_indices == self.eos_id)
 
-        # Concatenate sorted secondary target factors to best_word_indices. Shape: (batch*beam, num_factors)
         best_word_indices = best_word_indices.unsqueeze(1)
 
-        if factors is not None:
-            secondary_factors = factors.index_select(0, best_hyp_indices)
-            best_word_indices = pt.cat((best_word_indices, secondary_factors), dim=1)
+        # Traced modules do not allow optional return values or None, but lists. We return
+        # primary scores and optional factor scores therefore in a list.
+        scores = [scores_accumulated]  # type: List[pt.Tensor]
+        if self.expect_factors:
+            factors, factor_scores_accumulated = factor_args
+            # factors: (batch*beam, num_secondary_factors, 2)
+            f_sorted = factors.index_select(0, best_hyp_indices)
+            factor_scores, factor_indices = f_sorted[:, :, 0], f_sorted[:, :, 1]
+            # updated_factor_scores: (batch*beam, num_secondary_factors)
+            updated_factor_scores = factor_scores_accumulated.index_select(0, best_hyp_indices) + factor_scores
+            # Concatenate sorted secondary target factors to best_word_indices. Shape: (batch*beam, num_factors)
+            best_word_indices = pt.cat((best_word_indices, factor_indices.int()), dim=1)
+            scores.append(updated_factor_scores)
 
-        return best_word_indices, finished, scores_accumulated, lengths, reference_lengths
+        return best_word_indices, finished, scores, lengths, reference_lengths
 
 
 class TopK(pt.nn.Module):
@@ -584,9 +609,15 @@ class GreedySearch(pt.nn.Module):
         stacked_outputs = pt.stack(outputs, dim=2)
         length = pt.tensor([t], dtype=pt.int32)  # shape (1,)
         hyp_indices = pt.zeros(1, t + 1, dtype=pt.int32)
-        score = pt.tensor([-1.])  # TODO: return unnormalized proper score
+        score = pt.tensor([-1.])
+        # TODO: return unnormalized proper score
+        scores = pt.zeros(1, self.num_target_factors) - 1
 
-        return hyp_indices, stacked_outputs, score, length, None  # type: ignore
+        return SearchResult(best_hyp_indices=hyp_indices,
+                            best_word_indices=stacked_outputs,
+                            accumulated_scores=scores,
+                            lengths=length,
+                            estimated_reference_lengths=None)  # type: ignore
 
 
 class GreedyTop1(pt.nn.Module):
@@ -657,7 +688,8 @@ class BeamSearch(pt.nn.Module):
         self._sort_norm_and_update_finished = SortNormalizeAndUpdateFinished(
             pad_id=C.PAD_ID,
             eos_id=eos_id,
-            scorer=scorer)
+            scorer=scorer,
+            expect_factors=self.num_target_factors > 1)
         self._traced_sort_norm_and_update_finished = None  # type: Optional[pt.jit.ScriptModule]
 
         self._sample = None  # type: Optional[pt.nn.Module]
@@ -672,8 +704,7 @@ class BeamSearch(pt.nn.Module):
                 source: pt.Tensor,
                 source_length: pt.Tensor,
                 restrict_lexicon: Optional[lexicon.TopKLexicon],
-                max_output_lengths: pt.Tensor) -> Tuple[pt.Tensor, pt.Tensor, pt.Tensor, pt.Tensor,
-                                                        List[Optional[pt.Tensor]]]:
+                max_output_lengths: pt.Tensor) -> SearchResult:
         """
         Translates multiple sentences using beam search.
 
@@ -682,9 +713,7 @@ class BeamSearch(pt.nn.Module):
         :param restrict_lexicon: Lexicon to use for vocabulary restriction.
         :param max_output_lengths: Tensor of maximum output lengths per input in source.
                 Shape: (batch_size,). Dtype: int32.
-        :return List of best hypotheses indices, list of best word indices,
-                array of accumulated length-normalized negative log-probs, hypotheses lengths,
-                predicted lengths of references (if any).
+        :return SearchResult.
         """
         batch_size = source.size()[0]
         logger.debug("beam_search batch size: %d", batch_size)
@@ -724,6 +753,11 @@ class BeamSearch(pt.nn.Module):
 
         # scores_accumulated: chosen smallest scores in scores (ascending).
         scores_accumulated = pt.zeros(batch_size * self.beam_size, 1, device=self.device, dtype=self.dtype)
+        # Accumulated (greedily chosen) factor scores. Factor scores are not normalized by length.
+        # TODO: Consider joint tensor for all target factors
+        # Embedded in a list to efficiently assign return values and avoid if-branching
+        factor_scores_accumulated = [pt.zeros(batch_size * self.beam_size, self.num_target_factors - 1,
+                                              device=self.device, dtype=self.dtype)]
 
         output_vocab_size = self.output_vocab_size
 
@@ -755,6 +789,8 @@ class BeamSearch(pt.nn.Module):
         for t in range(1, max_iterations + 1):  # max_iterations + 1 required to get correct results
             # (1) obtain next predictions and advance models' state
             # target_dists: (batch_size * beam_size, target_vocab_size)
+            # target_factors: (batch_size * beam_size, num_secondary_factors, 2),
+            # where last dimension holds indices and scores
             target_dists, model_states, target_factors = self._inference.decode_step(best_word_indices,
                                                                                      model_states,
                                                                                      vocab_slice_ids)
@@ -788,13 +824,14 @@ class BeamSearch(pt.nn.Module):
             # next call to topk(), hypotheses may not be in sorted order.
             _sort_inputs = [best_hyp_indices, best_word_indices, finished, scores_accumulated, lengths,
                             estimated_reference_lengths]
-            if target_factors is not None:
-                _sort_inputs.append(target_factors)
+            if self.num_target_factors > 1:
+                _sort_inputs += [target_factors, *factor_scores_accumulated]
             if self._traced_sort_norm_and_update_finished is None:
                 self._traced_sort_norm_and_update_finished = pt.jit.trace(self._sort_norm_and_update_finished,
                                                                           _sort_inputs)
-            best_word_indices, finished, scores_accumulated, lengths, estimated_reference_lengths = \
-                self._traced_sort_norm_and_update_finished(*_sort_inputs)
+            best_word_indices, finished, \
+            (scores_accumulated, *factor_scores_accumulated), \
+            lengths, estimated_reference_lengths = self._traced_sort_norm_and_update_finished(*_sort_inputs)
 
             # Collect best hypotheses, best word indices
             best_word_indices_list.append(best_word_indices)
@@ -817,16 +854,21 @@ class BeamSearch(pt.nn.Module):
         # 1 = scores_accumulated.size()[1]
         best_hyp_indices = indices.div(1, rounding_mode='floor').int() + offset
         scores_accumulated = scores_accumulated.index_select(0, best_hyp_indices)
+        if self.num_target_factors > 1:
+            accumulated_factor_scores = factor_scores_accumulated[0].index_select(0, best_hyp_indices)
+            # (batch*beam, num_target_factors)
+            scores_accumulated = pt.cat((scores_accumulated, accumulated_factor_scores), dim=1)
+
         best_hyp_indices_list.append(best_hyp_indices)
         lengths = lengths.index_select(0, best_hyp_indices)
         all_best_hyp_indices = pt.stack(best_hyp_indices_list, dim=1)
         all_best_word_indices = pt.stack(best_word_indices_list, dim=2)
 
-        return all_best_hyp_indices, \
-               all_best_word_indices, \
-               scores_accumulated, \
-               lengths, \
-               estimated_reference_lengths
+        return SearchResult(best_hyp_indices=all_best_hyp_indices,
+                            best_word_indices=all_best_word_indices,
+                            accumulated_scores=scores_accumulated,
+                            lengths=lengths,
+                            estimated_reference_lengths=estimated_reference_lengths)
 
     def _should_stop(self, finished: pt.Tensor, batch_size: int) -> bool:
         if self.beam_search_stop == C.BEAM_SEARCH_STOP_FIRST:

--- a/sockeye/layers_pt.py
+++ b/sockeye/layers_pt.py
@@ -332,7 +332,6 @@ class PyTorchMultiHeadAttentionBase(pt.nn.Module):
         :param queries: Query tensor. Shape: (queries_length, batch_size, depth).
         :param key_values: Keys/Values. Shape: (keys_values_length, batch_size, depth * 2).
         :param mask: Optional boolean attention mask. See DotAttentionCell for shape requirements.
-        :param bias: Optional 3d bias.
         :return: Context vectors. Shape: (batch_size, query_max_length, output_depth).
         """
 
@@ -479,7 +478,6 @@ class PyTorchMultiHeadAttention(PyTorchMultiHeadAttentionBase):
         :param queries: Query tensor. Shape: (queries_length, batch, input_depth).
         :param key_values: Memory data to attend to. Shape: (key_values_length, batch, input_depth).
         :param mask: Optional attention mask. See DotAttentionCell for shape information.
-        :param bias: Optional 3d bias tensor to mask attention scores.
         :param projected_memory_kv: Optional previously projected memory keys and values.
         :return: tensor of shape (query_seq_len, batch, output_depth).
         """

--- a/sockeye/output_handler.py
+++ b/sockeye/output_handler.py
@@ -146,7 +146,11 @@ class ScoreOutputHandler(OutputHandler):
         :param t_output: Translator output.
         :param t_walltime: Total walltime for translation.
         """
-        print("{:.6f}".format(t_output.score), file=self.stream, flush=True)
+        result = "{:.6f}".format(t_output.score)
+        if hasattr(t_output, 'factor_scores') and t_output.factor_scores:
+            factor_scores = "\t".join("{:.6f}".format(fs) for fs in t_output.factor_scores)
+            result = f"{result}\t{factor_scores}"
+        print(result, file=self.stream, flush=True)
 
     def reports_score(self) -> bool:
         return True

--- a/sockeye/score_pt.py
+++ b/sockeye/score_pt.py
@@ -56,7 +56,7 @@ def score(args: argparse.Namespace):
         logger.info("CUDA not available, using cpu")
         use_cpu = True
     device = pt.device('cpu') if use_cpu else pt.device('cuda', args.device_id)
-    logger.info("Scoring device: {device}")
+    logger.info(f"Scoring device: {device}")
 
     model, source_vocabs, target_vocabs = load_model(args.model, device=device, dtype=args.dtype)
     model.eval()

--- a/sockeye/scoring_pt.py
+++ b/sockeye/scoring_pt.py
@@ -17,7 +17,7 @@ Code for scoring.
 import logging
 import math
 import time
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch as pt
@@ -130,7 +130,7 @@ class Scorer:
                          batch.labels[C.TARGET_LABEL_NAME].long(),
                          outputs.get(C.LENRATIO_NAME, pt.zeros_like(batch.source_length)),
                          batch.source_length,
-                         batch.target_length]
+                         batch.target_length]  # type: List[Union[pt.Tensor, List[Tuple[pt.Tensor, pt.Tensor]]]]
 
         if self.num_target_factors > 1:
             factor_logits_and_labels = [(outputs[C.FACTOR_LOGITS_NAME % i],

--- a/sockeye/scoring_pt.py
+++ b/sockeye/scoring_pt.py
@@ -66,26 +66,27 @@ class BatchScorer(pt.nn.Module):
         # logprobs and scores: (batch_size, target_seq_len)
         token_scores = logprobs.gather(dim=-1, index=labels.unsqueeze(-1)).squeeze()
         if self.score_type == C.SCORING_TYPE_NEGLOGPROB:
-            token_scores *= -1
+            token_scores = -token_scores
 
-        if factor_logits_and_labels is not None:
-            for factor_logit, factor_label in factor_logits_and_labels:
-                factor_logprobs = factor_logit.log_softmax(dim=-1)
-                factor_scores = factor_logprobs.gather(dim=-1, index=factor_label.unsqueeze(-1)).squeeze()
-                if self.score_type == C.SCORING_TYPE_NEGLOGPROB:
-                    factor_scores *= -1
-                token_scores += factor_scores
-
-        # Sum, then apply length penalty. The call to `pt.where` masks out invalid values from scores.
-        # zeros and sums: (batch_size, 1)
-        scores = token_scores.where(labels.not_equal(0), pt.zeros_like(token_scores)).sum(dim=1, keepdims=True)
-
+        # Mask pad positions, sum, then apply length penalty. Shape: (batch_size, 1)
+        scores = token_scores.masked_fill_(labels == C.PAD_ID, .0).sum(dim=-1, keepdims=True)
         if self.constant_length_ratio is not None and self.constant_length_ratio > 0.0:
             predicted_output_length = source_length * self.constant_length_ratio
         else:
             predicted_output_length = source_length * length_ratio
-
         scores = self.scorer(scores, target_length, predicted_output_length)
+
+        if factor_logits_and_labels is not None:
+            factor_scores = []  # type: List[pt.Tensor]
+            for factor_logit, factor_label in factor_logits_and_labels:
+                factor_logprobs = factor_logit.log_softmax(dim=-1)
+                factor_token_scores = factor_logprobs.gather(dim=-1, index=factor_label.unsqueeze(-1)).squeeze()
+                if self.score_type == C.SCORING_TYPE_NEGLOGPROB:
+                    factor_token_scores = -factor_token_scores
+                fs = factor_token_scores.masked_fill_(factor_label == C.PAD_ID, .0).sum(dim=-1, keepdims=True)  # type: ignore
+                # Note: factor_scores are not normalized by length
+                factor_scores.append(fs)
+            scores = pt.cat([scores] + factor_scores, dim=1)
 
         return scores
 
@@ -141,9 +142,9 @@ class Scorer:
         if self.traced_batch_scorer is None:
             logger.debug("Tracing batch_scorer")
             self.traced_batch_scorer = pt.jit.trace(self.batch_scorer, scorer_inputs, strict=False)
-        scores = self.traced_batch_scorer(*scorer_inputs)
+        scores = self.traced_batch_scorer(*scorer_inputs)  # (batch, num_target_factors)
 
-        return scores.squeeze(1).numpy()
+        return scores.numpy()
 
     @pt.inference_mode(True)
     def score(self, score_iter: data_io_pt.BaseParallelSampleIter, output_handler: OutputHandler):
@@ -152,12 +153,12 @@ class Scorer:
         batch_no = 0
         for batch_no, batch in enumerate(score_iter, 1):
             batch_tic = time.time()
-            scores = self.score_batch(batch)
+            batch_scores = self.score_batch(batch)
             batch_time = time.time() - batch_tic
             total_time += batch_time
-            for sentno, (source, target, score) in enumerate(zip(batch.source[:, :, 0],
-                                                                 batch.target[:, :, 0],
-                                                                 scores), 1):
+            for sentno, (source, target, scores) in enumerate(zip(batch.source[:, :, 0],
+                                                                  batch.target[:, :, 0],
+                                                                  batch_scores), 1):
                 sentence_no += 1
 
                 # Transform arguments in preparation for printing
@@ -169,12 +170,14 @@ class Scorer:
 
                 # Report a score of -inf for invalid sentence pairs (empty source and/or target)
                 if source[0] == C.PAD_ID or target[0] == C.PAD_ID:
-                    score = -np.inf
+                    scores = [-np.inf] * self.num_target_factors
 
                 # Output handling routines require us to make use of inference classes.
                 output_handler.handle(inference_pt.TranslatorInput(sentence_no, source_tokens),
                                       inference_pt.TranslatorOutput(sentence_no, target_string,
-                                                                    target_tokens, score),
+                                                                    target_tokens,
+                                                                    score=scores[0],
+                                                                    factor_scores=scores[1:]),
                                       batch_time)
 
         if sentence_no != 0:

--- a/test/common.py
+++ b/test/common.py
@@ -210,12 +210,13 @@ def test_scoring(data: Dict[str, Any], translate_params: str, test_similar_score
 
     # Collect scores from output file
     with open(out_path) as score_out:
-        score_scores = [float(line.strip()) for line in score_out]
+        data_scoring = [[float(x) for x in line.strip().split('\t')] for line in score_out]
 
     if test_similar_scores:
-        for inp, translate_json, score_score in zip(data['test_inputs'],
-                                                    data['test_outputs'],
-                                                    score_scores):
+        for inp, translate_json, score_scores in zip(data['test_inputs'],
+                                                     data['test_outputs'],
+                                                     data_scoring):
+            score_score, *factor_scores = score_scores
             translate_tokens = translate_json['translation'].split()
             translate_score = translate_json['score']
             logger.info("tokens: %s || translate score: %.4f || score score: %.4f",

--- a/test/common.py
+++ b/test/common.py
@@ -248,7 +248,7 @@ def _translate_output_is_valid(translate_outputs: List[str]) -> bool:
 def test_odd_even_target_factors(data: Dict):
     num_target_factors = len(data['train_target_factors'])
     for json in data['test_outputs']:
-        factor_keys = [k for k in json.keys() if k.startswith("factor")]
+        factor_keys = [k for k in json.keys() if k.startswith("factor") and not k.endswith("score")]
         assert len(factor_keys) == num_target_factors
         primary_tokens = json['translation'].split()
         secondary_factor_tokens = [json[factor_key].split() for factor_key in factor_keys]

--- a/test/unit/test_beam_search.py
+++ b/test/unit/test_beam_search.py
@@ -615,9 +615,9 @@ def test_beam_search():
     max_output_lengths = pt.tensor([max_length], dtype=pt.int)
 
     bs_out = bs(source, source_length, restrict_lexicon, max_output_lengths)
-    best_hyp_indices, best_word_indices, scores, lengths, estimated_ref_lengths = bs_out
+    r = bs_out
 
-    print('beam search lengths', lengths)
+    print('beam search lengths', r.lengths)
     print('internal lengths', inference.states[0])
-    pt.testing.assert_allclose(lengths, inference.states[0].squeeze(1))
+    pt.testing.assert_allclose(r.lengths, inference.states[0].squeeze(1))
     assert inference.states[1] == max_length

--- a/test/unit/test_beam_search.py
+++ b/test/unit/test_beam_search.py
@@ -342,11 +342,11 @@ def test_pytorch_greedytop1(target_vocab_size):
     assert best_word_index.shape == (1, 1)
     assert best_word_index[0, 0] == expected_word_index[0]
 
-    target_factors = pt.ones(1, 1, dtype=pt.int32)
+    target_factors = pt.ones(1, 1, 2, dtype=pt.int32)
     best_word_index_with_factors = greedy_top1(pt.tensor(scores), None, target_factors).detach().numpy()
     assert best_word_index_with_factors.shape == (1, 2)
     assert best_word_index_with_factors[0, 0] == expected_word_index[0]
-    assert best_word_index_with_factors[0, 1] == target_factors.item()
+    assert best_word_index_with_factors[0, 1] == target_factors[:, :, 1].item()
 
 
 @pytest.mark.parametrize("batch_size, beam_size, target_vocab_size, top_n",

--- a/test/unit/test_output_handler.py
+++ b/test/unit/test_output_handler.py
@@ -45,10 +45,11 @@ stream_handler_tests = [(sockeye.output_handler.StringOutputHandler(io.StringIO(
                                           nbest_tokens=[["ein", "Test"], ["der", "Test"]],
                                           nbest_scores=[0., 0.1],
                                           factor_translations=['f11 f12', 'f21 f22'],
+                                          factor_scores=[0.1, 0.2],
                                           nbest_factor_translations=[['f11 f12', 'f21 f22'],
                                                                      ['f11 f12', 'f21 f22']]),
                          0.5,
-                         '{"factor1": "f11 f12", "factor2": "f21 f22", "pass_through_test": "success!", "score": 0.0, "scores": [0.0, 0.1], "sentence_id": 0, "translation": "ein Test", "translations": ["ein Test", "der Test"], "translations_factors": [{"factor1": "f11 f12", "factor2": "f21 f22"}, {"factor1": "f11 f12", "factor2": "f21 f22"}]}\n')]
+                         '{"factor1": "f11 f12", "factor1_score": 0.1, "factor2": "f21 f22", "factor2_score": 0.2, "pass_through_test": "success!", "score": 0.0, "scores": [0.0, 0.1], "sentence_id": 0, "translation": "ein Test", "translations": ["ein Test", "der Test"], "translations_factors": [{"factor1": "f11 f12", "factor2": "f21 f22"}, {"factor1": "f11 f12", "factor2": "f21 f22"}]}\n')]
 
 
 @pytest.mark.parametrize("handler, translation_input, translation_output, translation_walltime, expected_string", stream_handler_tests)


### PR DESCRIPTION
Adds recording of target factor scores in beam search and for scoring. Sequence scores for secondary target factors remain unnormalized and are returned separately from the primary hypothesis scores (which are normalized).
Downstream applications can decide how to use these scores.

As part of this change a few internal classes / interfaces were changed:
- search algorithms now return a dataclass `SearchResult`
- `score` attribute of `Translation` class changed to `scores` holding all target-side scores. Index 0: primary hypothesis score, Indices 1+: scores for other factor sequences
- `score` attribute of `NbestTranslations` class changed to `scores`
- `factor_scores` attribute added to `TranslatorOutput`

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

