### PR TITLE
Always load parameters to average on CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.0.1]
+
+### Fixed
+
+- Parameter averaging (`sockeye-average`) now always uses the CPU, which enables averaging parameters from GPU-trained models on CPU-only hosts.
+
 ## [3.0.0] Sockeye 3: Fast Neural Machine Translation with PyTorch
 
 Sockeye is now based on PyTorch.

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'

--- a/sockeye/average.py
+++ b/sockeye/average.py
@@ -45,7 +45,7 @@ def average(param_paths: Iterable[str]) -> Dict[str, torch.Tensor]:
     for path in param_paths:
         logger.info("Loading parameters from '%s'", path)
         try:
-            params = torch.load(path)
+            params = torch.load(path, map_location=torch.device('cpu'))
         except:
             logger.info('Converting from MXNet')
             from mxnet import npx


### PR DESCRIPTION
When a model is trained on GPUs, parameters are serialized on disk with metadata indicating the original device (cuda:N).

When parameters are deserialized for averaging, PyTorch attempts to load them onto the original device, which causes an error if the device doesn't exist.

With this commit, we always deserialize parameters to the CPU when averaging.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

