### PR TITLE
Fused Multihead Attention for training

### DIFF
--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.0.5'
+__version__ = '3.0.6'

--- a/sockeye/decoder_pt.py
+++ b/sockeye/decoder_pt.py
@@ -252,6 +252,7 @@ class PyTorchTransformerDecoder(PyTorchDecoder):
 
         batch, heads, source_max_len = source_mask.size()
         source_mask_view = source_mask.view(batch * heads, 1, source_max_len)
+        source_mask_view = source_mask_view.repeat_interleave(step_input.size()[1], dim=1)
 
         # target: (batch_size, length, model_size)
         target = self.pos_embedding(step_input, steps)

--- a/sockeye/encoder_pt.py
+++ b/sockeye/encoder_pt.py
@@ -197,8 +197,10 @@ class PyTorchTransformerEncoder(PyTorchEncoder):
         if self.dropout is not None:
             data = self.dropout(data)
 
-        # inverted length_mask for attention masking, (batch_size * heads, 1, max_len)
-        att_mask = layers_pt.prepare_source_length_mask(valid_length, self.config.attention_heads, data.size()[1])
+        _, max_len, __ = data.size()
+        # length_mask for source attention masking. Shape: (batch_size * heads, 1, max_len)
+        att_mask = layers_pt.prepare_source_length_mask(valid_length, self.config.attention_heads, max_length=max_len)
+        att_mask = att_mask.repeat(1, max_len, 1)
 
         data = data.transpose(1, 0)  # batch to time major
         for layer in self.layers:

--- a/sockeye/layers_pt.py
+++ b/sockeye/layers_pt.py
@@ -471,7 +471,10 @@ class PyTorchMultiHeadSelfAttention(PyTorchMultiHeadAttentionBase, Autoregressiv
         :return: tensor of shape (max_length, batch, output_depth).
         """
         if self.training:  # use fused multi-head attention op during training
-            assert not self.kv_interleaved
+            assert not self.kv_interleaved, 'Cannot run PyTorch multi-head attention with interleaved key-value ' \
+                                            'parameters. Please separate these parameters by calling ' \
+                                            '`module.train()` for the top-level module before starting training ' \
+                                            '(likely an instance of PyTorchSockeyeModel).'
             contexts, _ = F.multi_head_attention_forward(query=inputs, key=inputs, value=inputs,
                                                          embed_dim_to_check=self.depth, num_heads=self.heads,
                                                          in_proj_weight=self.ff_in.weight,

--- a/sockeye/layers_pt.py
+++ b/sockeye/layers_pt.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 import torch as pt
+import torch.nn.functional as F
 
 from sockeye import constants as C, utils
 from . import config
@@ -73,7 +74,7 @@ class PyTorchWeightNormalization(pt.nn.Module):
         self._axis_arg = tuple(range(1, ndim))
 
     def forward(self, weight: pt.Tensor) -> pt.Tensor:
-        return pt.nn.functional.normalize(weight, p=2, dim=self._axis_arg, eps=0) * self.scale  # type: ignore
+        return F.normalize(weight, p=2, dim=self._axis_arg, eps=0) * self.scale  # type: ignore
 
 
 class PyTorchOutputLayer(pt.nn.Module):
@@ -133,7 +134,7 @@ class PyTorchOutputLayer(pt.nn.Module):
         else:
             weight, bias = self.weight, self.bias
 
-        return pt.nn.functional.linear(data, weight, bias)
+        return F.linear(data, weight, bias)
 
     def weights_from_mxnet_block(self, block_mx: 'OutputLayer'):  # type: ignore
         self.weight.data[:] = pt.as_tensor(block_mx.weight.data().asnumpy())
@@ -214,11 +215,10 @@ def pytorch_interleaved_matmul_encdec_qk(q: pt.Tensor,
     q = q.contiguous().view(qlen, batch * heads, head_dim).transpose(0, 1)
     q = q * head_dim ** -0.5
 
-    kvlen, batch, hidden2 = kv.size()
-    tmp = kv.reshape(kvlen, batch, heads, 2, head_dim)
+    tmp = kv.reshape(-1, batch, heads, 2, head_dim)
     k = tmp[:, :, :, 0, :]  # pick keys
     k = k.permute(1, 2, 3, 0)  # (batch, heads, head_dim, kvlen)
-    k = k.reshape(batch * heads, head_dim, kvlen)  # (batch * heads, head_dim, kvlen)
+    k = k.reshape(batch * heads, head_dim, -1)  # (batch * heads, head_dim, kvlen)
 
     return pt.bmm(q, k)  # (batch * heads, qlen, klen)
 
@@ -239,9 +239,6 @@ def pytorch_interleaved_matmul_encdec_valatt(kv: pt.Tensor,
     :return: (qlen, batch, hidden)
     """
     kvlen, batch, hidden2 = kv.size()
-    batch_heads, qlen, kvlen_ = att.size()
-    assert kvlen == kvlen_
-    assert batch_heads // heads == batch
     hidden = hidden2 // 2
     head_dim = hidden // heads
 
@@ -251,7 +248,7 @@ def pytorch_interleaved_matmul_encdec_valatt(kv: pt.Tensor,
     v = v.reshape(-1, kvlen, head_dim)  # bsz * heads, kvlen, head_dim
 
     output = pt.bmm(att, v)  # bsz * heads, qlen, head_dim
-    output = output.transpose(0, 1).contiguous().view(qlen, batch, hidden)
+    output = output.transpose(0, 1).contiguous().view(-1, batch, hidden)
     return output
 
 
@@ -281,7 +278,7 @@ class PyTorchDotAttentionCell(pt.nn.Module):
         if mask is not None:
             logits = logits.masked_fill(mask, -C.LARGE_VALUES[logits.dtype])
 
-        probs = pt.nn.functional.softmax(logits, dim=-1)
+        probs = F.softmax(logits, dim=-1)
 
         probs = self.dropout(probs) if self.dropout is not None else probs
 
@@ -460,9 +457,42 @@ class PyTorchMultiHeadAttention(PyTorchMultiHeadAttentionBase):
                  dropout: float = 0.0,
                  depth_key_value: int = 512) -> None:
         super().__init__(depth_att, heads, depth_out, dropout)
-
         self.ff_q = pt.nn.Linear(in_features=depth_out, out_features=depth_att, bias=False)
         self.ff_kv = pt.nn.Linear(in_features=depth_key_value, out_features=depth_att * 2, bias=False)
+        self.kv_interleaved = False  # indicates whether self.ff_kv.weight is in interleaved format or not
+        self._drop_p = dropout
+        # interleaved format is used for inference, non-interleaved format is used for fused MHA in training.
+
+    def separate_kv(self):
+        assert self.kv_interleaved
+        with pt.no_grad():
+            k, v = self.ff_kv.weight.data.view(self.heads, 2 * self.depth_per_head, self.depth).split(self.depth_per_head, dim=1)
+            k = k.reshape(self.depth, self.depth)
+            v = v.reshape(self.depth, self.depth)
+        self.ff_kv.weight.data[:] = pt.cat((k, v), dim=0)
+        self.kv_interleaved = False
+
+    def interleave_kv(self):
+        assert not self.kv_interleaved
+        with pt.no_grad():
+            k, v = self.ff_kv.weight.data.split(self.depth, dim=0)
+            k = k.reshape(self.heads, -1, self.depth)
+            v = v.reshape(self.heads, -1, self.depth)
+        self.ff_kv.weight.data[:] = pt.cat((k, v), dim=1).reshape(self.depth * 2, self.depth)
+        self.kv_interleaved = True
+
+    def train(self, mode: bool = True):
+        if mode and self.kv_interleaved:
+            # training operates with non-interleaved format
+            self.separate_kv()
+        elif not mode and not self.kv_interleaved:
+            # eval/inference operates in interleaved format
+            self.interleave_kv()
+        return super().train(mode)
+
+    def _load_from_state_dict(self, *args):
+        self.kv_interleaved = True  # see SockeyeModel.save_parameters(): models store kv weight in interleaved format
+        super()._load_from_state_dict(*args)
 
     def forward(self,
                 queries: pt.Tensor,
@@ -481,15 +511,47 @@ class PyTorchMultiHeadAttention(PyTorchMultiHeadAttentionBase):
         :param projected_memory_kv: Optional previously projected memory keys and values.
         :return: tensor of shape (query_seq_len, batch, output_depth).
         """
-
-        queries = self.ff_q(queries)
-        key_values = projected_memory_kv if projected_memory_kv is not None else self.ff_kv(key_values)
-        return self._attend(queries=queries, key_values=key_values, mask=mask)
+        if self.training:
+            assert not self.kv_interleaved
+            assert projected_memory_kv is None, "caching not supported in training"
+            contexts, _ = F.multi_head_attention_forward(query=queries, key=key_values, value=key_values,
+                                                         embed_dim_to_check=self.depth, num_heads=self.heads,
+                                                         in_proj_weight=None,
+                                                         in_proj_bias=None,
+                                                         bias_k=None, bias_v=None, add_zero_attn=False,
+                                                         dropout_p=self._drop_p,
+                                                         out_proj_weight=self.ff_out.weight,
+                                                         out_proj_bias=self.ff_out.bias,
+                                                         training=self.training,
+                                                         key_padding_mask=None,
+                                                         need_weights=False,
+                                                         attn_mask=mask,
+                                                         use_separate_proj_weight=True,
+                                                         q_proj_weight=self.ff_q.weight,
+                                                         k_proj_weight=self.ff_kv.weight[:self.depth, :],
+                                                         v_proj_weight=self.ff_kv.weight[self.depth:, :])
+            return contexts
+        else:
+            queries = self.ff_q(queries)
+            key_values = projected_memory_kv if projected_memory_kv is not None else self.ff_kv(key_values)
+            return self._attend(queries=queries, key_values=key_values, mask=mask)
 
     def weights_from_mxnet_block(self, block_mx: 'MultiHeadAttention'):  # type: ignore
         self.ff_q.weight.data[:] = pt.as_tensor(block_mx.ff_q.weight.data().asnumpy())
         self.ff_kv.weight.data[:] = pt.as_tensor(block_mx.ff_kv.weight.data().asnumpy())
         self.ff_out.weight.data[:] = pt.as_tensor(block_mx.ff_out.weight.data().asnumpy())
+
+
+def interleave_kv(module: pt.nn.Module):
+    if isinstance(module, PyTorchMultiHeadAttention):
+        if not module.kv_interleaved:
+            module.interleave_kv()
+
+
+def separate_kv(module: pt.nn.Module):
+    if isinstance(module, PyTorchMultiHeadAttention):
+        if module.kv_interleaved:
+            module.separate_kv()
 
 
 @pt.jit.script
@@ -564,7 +626,7 @@ class PyTorchPositionalEmbeddings(pt.nn.Module):
             # (batch_size or 1, seq_len, num_embed)
             # NOTE: temporary fix until we decide how to handle output steps > max_supported_seq_len_target
             steps = pt.clip(steps, max=self.max_seq_len - 1)
-            pos_embedding = pt.nn.functional.embedding(steps, self.weight)
+            pos_embedding = F.embedding(steps, self.weight)
 
         if self.weight_type == C.FIXED_POSITIONAL_EMBEDDING:
             pos_embedding = pos_embedding.detach()

--- a/sockeye/layers_pt.py
+++ b/sockeye/layers_pt.py
@@ -492,8 +492,13 @@ class PyTorchMultiHeadSelfAttention(PyTorchMultiHeadAttentionBase, Autoregressiv
             return self._attend(queries=queries, key_values=states, mask=mask), states
 
     def weights_from_mxnet_block(self, block_mx: 'MultiHeadSelfAttention'):  # type: ignore
+        was_train = self.training
+        if was_train:
+            self.eval()
         self.ff_in.weight.data[:] = pt.as_tensor(block_mx.ff_in.weight.data().asnumpy())
         self.ff_out.weight.data[:] = pt.as_tensor(block_mx.ff_out.weight.data().asnumpy())
+        if was_train:
+            self.train()
 
 
 class PyTorchMultiHeadAttention(PyTorchMultiHeadAttentionBase):
@@ -595,9 +600,14 @@ class PyTorchMultiHeadAttention(PyTorchMultiHeadAttentionBase):
             return self._attend(queries=queries, key_values=key_values, mask=mask)
 
     def weights_from_mxnet_block(self, block_mx: 'MultiHeadAttention'):  # type: ignore
+        was_train = self.training
+        if was_train:
+            self.eval()
         self.ff_q.weight.data[:] = pt.as_tensor(block_mx.ff_q.weight.data().asnumpy())
         self.ff_kv.weight.data[:] = pt.as_tensor(block_mx.ff_kv.weight.data().asnumpy())
         self.ff_out.weight.data[:] = pt.as_tensor(block_mx.ff_out.weight.data().asnumpy())
+        if was_train:
+            self.train()
 
 
 def interleave_kv(module: pt.nn.Module):

--- a/sockeye/layers_pt.py
+++ b/sockeye/layers_pt.py
@@ -471,10 +471,7 @@ class PyTorchMultiHeadSelfAttention(PyTorchMultiHeadAttentionBase, Autoregressiv
         :return: tensor of shape (max_length, batch, output_depth).
         """
         if self.training:  # use fused multi-head attention op during training
-            assert not self.kv_interleaved, 'Cannot run PyTorch multi-head attention with interleaved key-value ' \
-                                            'parameters. Please separate these parameters by calling ' \
-                                            '`module.train()` for the top-level module before starting training ' \
-                                            '(likely an instance of PyTorchSockeyeModel).'
+            assert not self.kv_interleaved
             contexts, _ = F.multi_head_attention_forward(query=inputs, key=inputs, value=inputs,
                                                          embed_dim_to_check=self.depth, num_heads=self.heads,
                                                          in_proj_weight=self.ff_in.weight,

--- a/sockeye/model_pt.py
+++ b/sockeye/model_pt.py
@@ -557,8 +557,10 @@ def initialize_parameters(module: pt.nn.Module):
     For some background on the equivalence of mx.init.Xavier and pt.nn.init.xavier_uniform_, see
     https: // jamesmccaffrey.wordpress.com / 2020 / 11 / 20 / the - gain - parameter -
     """
+    import math
     if isinstance(module, pt.nn.Linear) or isinstance(module, layers_pt.PyTorchOutputLayer):
-        pt.nn.init.xavier_uniform_(module.weight, gain=1.0)
+        # TODO: consider using gain=1 / math.sqrt(2)
+        pt.nn.init.xavier_uniform_(module.weight, gain=1)
         if module.bias is not None:
             pt.nn.init.zeros_(module.bias)
     elif isinstance(module, pt.nn.Embedding):

--- a/sockeye/model_pt.py
+++ b/sockeye/model_pt.py
@@ -397,6 +397,11 @@ class PyTorchSockeyeModel(pt.nn.Module):
             utils.check_condition(not missing, f"missing keys: {missing}")
         if not ignore_extra:
             utils.check_condition(not unexpected, f"extra keys: {unexpected}")
+        # Models are saved with interleaved key-value params. If the current
+        # model is in training mode, separate the loaded params to match the
+        # format used during training.
+        if self.training:
+            self.apply(layers_pt.separate_kv)
         logger.info('Loaded params from "%s" to "%s"', filename, pt.device('cpu') if device is None else device)
 
     def set_parameters(self,

--- a/sockeye/model_pt.py
+++ b/sockeye/model_pt.py
@@ -359,7 +359,9 @@ class PyTorchSockeyeModel(pt.nn.Module):
         :param fname: Path to save parameters to.
         See https://pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-model-for-inference
         """
+        self.apply(layers_pt.interleave_kv)
         pt.save(self.state_dict(), fname)
+        self.apply(layers_pt.separate_kv)
         logging.info('Saved params/state_dict to "%s"', fname)
 
     def load_parameters(self,

--- a/sockeye/train_pt.py
+++ b/sockeye/train_pt.py
@@ -997,10 +997,6 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
 
     utils.log_parameters_pt(sockeye_model)
 
-    # Guarantee special implementations of `train()` run for all layers before
-    # starting training
-    sockeye_model.train()
-
     optimizer, zero_grad_kwargs = optimizers.get_optimizer(sockeye_model, optimizer_config)
 
     # This starts as a reference to the original Sockeye model. It is

--- a/sockeye/train_pt.py
+++ b/sockeye/train_pt.py
@@ -997,6 +997,10 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
 
     utils.log_parameters_pt(sockeye_model)
 
+    # Guarantee special implementations of `train()` run for all layers before
+    # starting training
+    sockeye_model.train()
+
     optimizer, zero_grad_kwargs = optimizers.get_optimizer(sockeye_model, optimizer_config)
 
     # This starts as a reference to the original Sockeye model. It is

--- a/sockeye/transformer_pt.py
+++ b/sockeye/transformer_pt.py
@@ -336,7 +336,8 @@ class PyTorchTransformerFeedForward(pt.nn.Module):
 
 class AutoRegressiveMask(pt.nn.Module):
 
-    def forward(self, x):
+    def forward(self, x: pt.Tensor) -> pt.Tensor:
+        """ Input tensor with length on dimension 1 """
         mask = pt.full((x.shape[1], x.shape[1]), fill_value=1, device=x.device, dtype=pt.bool)
-        mask = pt.triu(mask, diagonal=1).unsqueeze(0)
-        return mask.detach()
+        mask = pt.triu(mask, diagonal=1)
+        return mask.detach()  # Shape: (len, len)

--- a/test/unit/test_decoder.py
+++ b/test/unit/test_decoder.py
@@ -106,6 +106,7 @@ def test_mx_pt_eq_transformer_decoder(inference_only):
     # pt
     decoder_pt = sockeye.decoder_pt.pytorch_get_decoder(config_pt, inference_only=inference_only)
     decoder_pt.weights_from_mxnet_block(decoder_mx)
+    decoder_pt.eval()
     init_states_pt = decoder_pt.init_state_from_encoder(encoder_outputs_pt, encoder_valid_length_pt)
     output_pt, new_states_pt = decoder_pt(inputs_pt, init_states_pt)
     if inference_only:  # do a second decoder step

--- a/test/unit/test_layers.py
+++ b/test/unit/test_layers.py
@@ -367,6 +367,7 @@ def test_mx_pt_eq_multi_head_self_attention(seq_len, batch_size, hidden, heads):
     b_mx = sockeye.layers.MultiHeadSelfAttention(hidden, heads, hidden, dropout=0.0)
     b_mx.initialize()
     b_pt = sockeye.layers_pt.PyTorchMultiHeadSelfAttention(hidden, heads, hidden, dropout=0.0)
+    b_pt.eval()
     b_pt.weights_from_mxnet_block(b_mx)
 
     r_mx, states_mx = b_mx(inputs_mx, None, None, None)

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -213,6 +213,7 @@ def test_mx_pt_eq_sockeye_model():
             assert np.allclose(s_mx.asnumpy(), s_pt.detach().numpy(), atol=1e-05)
 
     # test decode_step()
+    b_pt.eval()
     states_mx = init_states_mx
     states_pt = init_states_pt
     step_output_mx, states_mx, factor_outputs_mx = b_mx.decode_step(step_inputs_mx, states_mx,


### PR DESCRIPTION
Use `torch.nn.functional.multi_head_attention_forward` for self- and encoder-attention during training. Requires some fiddling with the parameter layout of the key-value input projections, as the current Sockeye attention interleaves for faster inference. Attention masks (both for source masking and autoregressive masks need some shape tweaking as requirements for the fused MHA op differ slightly).

Non-interleaved format for joint key-value input projection parameters:
`in_features=hidden, out_features=2*hidden -> Shape: (2*hidden, hidden)`
Interleaved format for joint-key-value input projection stores key and value parameters, grouped by heads:
`Shape: ((num_heads * 2 * hidden_per_head), hidden)`

- Models save and load key-value projection parameters in interleaved format.
- When `model.training == True` key-value projection parameters are put into non-interleaved format for `torch.nn.functional.multi_head_attention_forward`
- When `model.training == False`, i.e. `model.eval()` is called, key-value projection parameters are again converted into interleaved format in place.

This change improves training speed by about 10% but keeps inference speed the same.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

