### PR TITLE
Fix EnsembleInference for models without target factors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.0.3]
+
+### Fixed
+
+- Fixed ensemble decoding for models without target factors.
+
 ## [3.0.2]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.0.2'
+__version__ = '3.0.3'

--- a/sockeye/beam_search_pt.py
+++ b/sockeye/beam_search_pt.py
@@ -141,8 +141,9 @@ class _EnsembleInference(_Inference):
             logits, model_states, target_factor_outputs = model.decode_step(step_input, model_states, vocab_slice_ids)
             probs = logits.softmax(dim=-1)
             outputs.append(probs)
-            target_factor_probs = [tfo.softmax(dim=-1) for tfo in target_factor_outputs]
-            factor_outputs.append(target_factor_probs)
+            if target_factor_outputs:
+                target_factor_probs = [tfo.softmax(dim=-1) for tfo in target_factor_outputs]
+                factor_outputs.append(target_factor_probs)
             new_states += model_states
         scores = self._interpolation(outputs)
 


### PR DESCRIPTION
Fixed bug with ensemble decoding using models without target factors.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

