### PR TITLE
Fix issue with checkpoint decoder metrics for distributed training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.0.6]
+
+### Fixed
+
+- Fixed checkpoint decoder issue that prevented using `bleu` as `--optimized-metric` for distributed training ([#995](https://github.com/awslabs/sockeye/issues/995)).
+
 ## [3.0.5]
 
 ### Fixed
@@ -33,7 +39,7 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 
 ### Changed
 
-- `sockeye-translate`: Beam search now computes and returns secondary target factor scores. Secondary target factors 
+- `sockeye-translate`: Beam search now computes and returns secondary target factor scores. Secondary target factors
   do not participate in beam search, but are greedily chosen at every time step. Accumulated scores for secondary factors
   are not normalized by length. Factor scores are included in JSON output (``--output-type json``).
 - `sockeye-score` now returns tab-separated scores for each target factor. Users can decide how to combine factor scores

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.0.5'
+__version__ = '3.0.6'

--- a/sockeye/training_pt.py
+++ b/sockeye/training_pt.py
@@ -405,9 +405,9 @@ class PyTorchEarlyStoppingTrainer:
             for loss_metric, (loss_value, num_samples) in zip(val_metrics, loss_outputs):
                 loss_metric.update(loss_value.item(), num_samples.item())
 
-        # Optionally run the checkpoint decoder
+        # Primary worker optionally runs the checkpoint decoder
         decoder_metrics = {}  # type: Dict[str, float]
-        if checkpoint_decoder is not None:
+        if utils.is_primary_worker() and checkpoint_decoder is not None:
             output_name = os.path.join(self.config.output_dir, C.DECODE_OUT_NAME.format(checkpoint=checkpoint))
             decoder_metrics = checkpoint_decoder.decode_and_evaluate(output_name=output_name)
         # Broadcast decoder metrics (if any) from primary worker to secondary


### PR DESCRIPTION
During distributed training, only the primary worker runs the checkpoint decoder.  When using `--optimized-metric bleu`, secondary workers raise errors because they aren't configured to run their own checkpoint decoders and thus won't have access to the specified metric (#995).

In this update, the primary worker broadcasts the checkpoint decoder metrics (if any) to secondary workers.  This enables secondary workers to access these metrics without running their own checkpoint decoders.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

