### PR TITLE
Fix "none" learning rate scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.0.11]
+
+### Fixed
+
+- Fixed training with a single, fixed learning rate instead of a rate scheduler (`--learning-rate-scheduler none --initial-learning-rate ...`).
+
 ## [3.0.10]
 
 ### Changed
@@ -27,7 +33,7 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 
 ### Changed
 
-- Add support for JIT tracing source/target embeddings and JIT scripting the output layer during inference. 
+- Add support for JIT tracing source/target embeddings and JIT scripting the output layer during inference.
 
 ## [3.0.7]
 

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.0.10'
+__version__ = '3.0.11'

--- a/sockeye/training_pt.py
+++ b/sockeye/training_pt.py
@@ -366,7 +366,8 @@ class PyTorchEarlyStoppingTrainer:
                                                          self.optimizer_config.gradient_clipping_threshold)
             # Set learning rate for current step
             for param_group in self.optimizer.param_groups:
-                param_group['lr'] = self.optimizer_config.lr_scheduler(self.state.updates)
+                param_group['lr'] = self.optimizer_config.lr_scheduler(self.state.updates) \
+                                    if self.optimizer_config.lr_scheduler is not None else self.optimizer_config.lr
             # Update weights and reset gradients
             if self.using_amp:
                 self._scaler.step(self.optimizer)

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -50,7 +50,7 @@ _TEST_MAX_LENGTH = 20
 
 # tuple format: (train_params, translate_params, use_prepared_data, use_source_factors)
 ENCODER_DECODER_SETTINGS_TEMPLATE = [
-    # Basic transformer, nbest=2 decoding
+    # Basic transformer, nbest=2 decoding, no learning rate scheduler
     ("--encoder transformer --decoder {decoder}"
      " --num-layers 2 --transformer-attention-heads 2 --transformer-model-size 8 --num-embed 8"
      " --transformer-feed-forward-num-hidden 16"
@@ -60,7 +60,7 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
      # Note: We set the checkpoint interval > max updates in order to make sure we create a checkpoint when reaching
      # max updates independent of the checkpoint interval
-     " --checkpoint-interval 20 --optimizer adam --initial-learning-rate 0.01",
+     " --checkpoint-interval 20 --optimizer adam --initial-learning-rate 0.01 --learning-rate-scheduler none",
      "--beam-size 2 --nbest-size 2",
      False, 0, 0),
     # Basic transformer w/ prepared data & greedy decoding


### PR DESCRIPTION
This fixes the lookup for the current learning rate to support `--learning-rate-scheduler none`.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

