### PR TITLE
support JSON source prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.3]
+
+### Added
+- Added support for the use of adding source prefixes to the input in JSON format during inference.
+
 ## [3.1.2]
 
 ### Changed

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -84,6 +84,18 @@ The output may be:
 { "sentence_id": 1, "sentiment_id": "positive", "text": "The boy ate the waff@@ le .", "translation": "Der Junge aß die Waffel." }
 ```
 
+Sockeye also supports the use of adding source prefixes to the input during inference. For instance let us assume a multilingual translation model is trained with a source prefix (e.g. 2XX where XX is the target language code) as the translation direction signal. During inference this source prefix can be added with JSON format as follows:
+
+```json
+{ "text": "The boy ate the waff@@ le .", "source_prefix": "2XX"}
+```
+
+Similar to source factors, source prefix factors can be also specified with JSON format, e.g.,
+
+```json
+{ "text": "The boy ate the waff@@ le .", "source_prefix": "2XX", "source_prefix_factors": ["O"]}
+```
+
 ## N-best translations
 
 Sockeye can return the n best hypotheses per input (*nbest lists*).

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.2'
+__version__ = '3.1.3'

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -122,6 +122,8 @@ DECODER_STATE = 'd'
 # Inference Input JSON constants
 JSON_TEXT_KEY = "text"
 JSON_FACTORS_KEY = "factors"
+JSON_SOURCE_PREFIX_KEY = "source_prefix"
+JSON_SOURCE_PREFIX_FACTORS_KEY = "source_prefix_factors"
 JSON_RESTRICT_LEXICON_KEY = "restrict_lexicon"
 JSON_CONSTRAINTS_KEY = "constraints"
 JSON_AVOID_KEY = "avoid"

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -130,14 +130,16 @@ class TranslatorInput:
     sentence_id: SentenceId
     tokens: Tokens
     factors: Optional[List[Tokens]] = None
+    source_prefix: Optional[Tokens] = None
+    source_prefix_factors: Optional[List[Tokens]] = None
     restrict_lexicon: Optional[lexicon.TopKLexicon] = None
     constraints: Optional[List[Tokens]] = None
     avoid_list: Optional[List[Tokens]] = None
     pass_through_dict: Optional[Dict] = None
 
     def __str__(self):
-        return 'TranslatorInput(%s, %s, factors=%s, constraints=%s, avoid=%s)' \
-            % (self.sentence_id, self.tokens, self.factors, self.constraints, self.avoid_list)
+        return 'TranslatorInput(%s, %s, factors=%s, source_prefix=%s, source_prefix_factors=%s, constraints=%s, avoid=%s)' \
+            % (self.sentence_id, self.tokens, self.factors, self.source_prefix, self.source_prefix_factors, self.constraints, self.avoid_list)
 
     def __len__(self):
         return len(self.tokens)
@@ -174,6 +176,8 @@ class TranslatorInput:
             yield TranslatorInput(sentence_id=self.sentence_id,
                                   tokens=self.tokens[i:i + chunk_size],
                                   factors=factors,
+                                  source_prefix=self.source_prefix,
+                                  source_prefix_factors=self.source_prefix_factors,
                                   restrict_lexicon=self.restrict_lexicon,
                                   constraints=constraints,
                                   avoid_list=self.avoid_list,
@@ -187,6 +191,8 @@ class TranslatorInput:
                                tokens=self.tokens + [C.EOS_SYMBOL],
                                factors=[factor + [C.EOS_SYMBOL] for factor in
                                         self.factors] if self.factors is not None else None,
+                               source_prefix=self.source_prefix,
+                               source_prefix_factors=self.source_prefix_factors,
                                restrict_lexicon=self.restrict_lexicon,
                                constraints=self.constraints,
                                avoid_list=self.avoid_list,
@@ -255,12 +261,36 @@ def make_input_from_dict(sentence_id: SentenceId,
         tokens = input_dict[C.JSON_TEXT_KEY]
         tokens = list(utils.get_tokens(tokens))
         factors = input_dict.get(C.JSON_FACTORS_KEY)
+        source_prefix = input_dict.get(C.JSON_SOURCE_PREFIX_KEY)
+        source_prefix_factors = input_dict.get(C.JSON_SOURCE_PREFIX_FACTORS_KEY)
+        source_prefix = source_prefix.strip() if source_prefix else None
         if isinstance(factors, list):
             factors = [list(utils.get_tokens(factor)) for factor in factors]
             lengths = [len(f) for f in factors]
             if not all(length == len(tokens) for length in lengths):
                 logger.error("Factors have different length than input text: %d vs. %s", len(tokens), str(lengths))
                 return _bad_input(sentence_id, reason=str(input_dict))
+
+        if isinstance(source_prefix_factors, list):
+            source_prefix_factors = [list(utils.get_tokens(source_prefix_factor)) for source_prefix_factor in source_prefix_factors]
+
+        if source_prefix is not None and \
+            (factors is not None and not source_prefix_factors):
+                logger.error("Source prefix factors need to be also specified together with source factors")
+                return _bad_input(sentence_id, reason=str(input_dict))
+        if source_prefix is not None and source_prefix_factors is not None:
+            if not factors:
+                logger.error("Source prefix factors cannot be specified when source factors are not specified")
+                return _bad_input(sentence_id, reason=str(input_dict))
+            else:
+                if len(factors) != len(source_prefix_factors):
+                    logger.error("There is mismatch in source factors %d and prefix factors %d", len(factors), len(source_prefix_factors))
+                    return _bad_input(sentence_id, reason=str(input_dict))
+            lengths = [len(source_prefix_factors[i]) for i in range(len(source_prefix_factors))]
+            if not all(len(source_prefix.split()) == length for length in lengths):
+                logger.error("Source prefix has %d tokens but there are %s prefix factors", len(source_prefix.split()), str(lengths))
+                return _bad_input(sentence_id, reason=str(input_dict))
+
 
         # Lexicon for vocabulary selection/restriction:
         # This is only populated when using multiple lexicons, in which case the
@@ -301,6 +331,8 @@ def make_input_from_dict(sentence_id: SentenceId,
             constraints = [list(utils.get_tokens(constraint)) for constraint in constraints]
 
         return TranslatorInput(sentence_id=sentence_id, tokens=tokens, factors=factors,
+                               source_prefix=source_prefix,
+                               source_prefix_factors=source_prefix_factors,
                                restrict_lexicon=restrict_lexicon, constraints=constraints,
                                avoid_list=avoid_list, pass_through_dict=input_dict)
 
@@ -759,16 +791,19 @@ class Translator:
                 translated_chunks.append(IndexedTranslation(input_idx=trans_input_idx, chunk_idx=0,
                                                             translation=empty_translation(add_nbest=(self.nbest_size > 1))))
             else:
-                if len(trans_input.tokens) > self.max_input_length:
+                max_input_length = self.max_input_length
+                #take length of source prefix into account while chunking
+                max_input_length = max_input_length if not trans_input.source_prefix else max_input_length - len(trans_input.source_prefix.split())
+                if len(trans_input.tokens) > max_input_length:
                     # oversized input
                     logger.debug(
                         "Input %s has length (%d) that exceeds max input length (%d). "
                         "Splitting into chunks of size %d.",
                         trans_input.sentence_id, len(trans_input.tokens),
-                        self.max_input_length, self.max_input_length)
+                        max_input_length, max_input_length)
                     chunks = [trans_input_chunk.with_eos()
                               for trans_input_chunk in
-                              trans_input.chunks(self.max_input_length)]
+                              trans_input.chunks(max_input_length)]
                     input_chunks.extend([IndexedTranslatorInput(trans_input_idx, chunk_idx, chunk_input)
                                          for chunk_idx, chunk_input in enumerate(chunks)])
                 else:
@@ -852,7 +887,7 @@ class Translator:
         batch_size = len(trans_inputs)
         lengths = [len(inp) for inp in trans_inputs]
 
-        max_length = max(len(inp) for inp in trans_inputs)
+        max_length = max(len(inp) for inp in trans_inputs) if not trans_inputs[0].source_prefix else max(len(inp) + len(inp.source_prefix.split()) for inp in trans_inputs)
         # assembling source ids on cpu array (faster) and copy to Translator.device (potentially GPU) in one go below.
         source = onp.zeros((batch_size, max_length, self.num_source_factors), dtype='int32')
 
@@ -862,17 +897,27 @@ class Translator:
         for j, trans_input in enumerate(trans_inputs):
             num_tokens = len(trans_input)  # includes eos
             max_output_lengths.append(self._get_max_output_length(num_tokens))
-            source[j, :num_tokens, 0] = tokens2ids(trans_input.tokens, self.source_vocabs[0])
+            num_tokens = num_tokens if not trans_input.source_prefix else num_tokens + len(trans_input.source_prefix.split())
+            if not trans_input.source_prefix:
+                source[j, :num_tokens, 0] = tokens2ids(trans_input.tokens, self.source_vocabs[0])
+            else:
+                #adding source prefix to every chunk
+                source[j, :num_tokens, 0] = tokens2ids(trans_input.source_prefix.split() + \
+                    trans_input.tokens, self.source_vocabs[0])
 
             factors = trans_input.factors if trans_input.factors is not None else []
             num_factors = 1 + len(factors)
             if num_factors != self.num_source_factors:
                 logger.warning("Input %d factors, but model(s) expect %d", num_factors,
                                self.num_source_factors)
-            for i, factor in enumerate(factors[:self.num_source_factors - 1], start=1):
-                # fill in as many factors as there are tokens
-
-                source[j, :num_tokens, i] = tokens2ids(factor, self.source_vocabs[i])[:num_tokens]
+            if not trans_input.source_prefix or not trans_input.source_prefix_factors: #no source prefix during inference
+                for i, factor in enumerate(factors[:self.num_source_factors - 1], start=1):
+                    # fill in as many factors as there are tokens
+                    source[j, :num_tokens, i] = tokens2ids(factor, self.source_vocabs[i])[:num_tokens]
+            else:
+                for i, zip_of_factor_and_prefix_factor in enumerate(zip(factors[:self.num_source_factors - 1], trans_input.source_prefix_factors[:self.num_source_factors - 1]), start=1):
+                    factor, source_prefix_factor = zip_of_factor_and_prefix_factor
+                    source[j, :num_tokens, i] = tokens2ids(source_prefix_factor + factor, self.source_vocabs[i])[:num_tokens]
 
             # Check if vocabulary selection/restriction is enabled:
             # - First, see if the translator input provides a lexicon (used for multiple lexicons)

--- a/test/unit/test_inference.py
+++ b/test/unit/test_inference.py
@@ -137,6 +137,44 @@ def test_translator_input(sentence_id, sentence, factors, chunk_size):
                 assert factor == expected_factor[chunk_id * chunk_size: (chunk_id + 1) * chunk_size]
 
 
+@pytest.mark.parametrize("sentence_id, sentence, factors, chunk_size, source_prefix, source_prefix_factors",
+                         [(1, "a test", None, 4, "prefix test", None),
+                          (1, "a test", None, 2, "prefix test", None),
+                          (1, "a test", None, 1, "prefix test", None),
+                          (0, "", None, 1, "", None),
+                          (1, "a test", [['h', 'l']], 4, "prefix test", [['h', 'l']]),
+                          (1, "a test", [['h', 'h'], ['x', 'y']], 1, "prefix test", [['h', 'h'], ['x', 'y']])])
+def test_translator_input_with_source_prefix(sentence_id, sentence, factors, chunk_size, source_prefix, source_prefix_factors):
+    tokens = sentence.split()
+    source_prefix_tokens = source_prefix.split()
+    trans_input = sockeye.inference.TranslatorInput(sentence_id=sentence_id, tokens=tokens, factors=factors, \
+        source_prefix_tokens=source_prefix_tokens, source_prefix_factors=source_prefix_factors)
+
+    assert trans_input.sentence_id == sentence_id
+    assert trans_input.tokens == tokens
+    assert len(trans_input) == len(tokens)
+    assert trans_input.factors == factors
+    assert trans_input.source_prefix_tokens == source_prefix_tokens
+    assert trans_input.source_prefix_factors == source_prefix_factors
+    if factors is not None:
+        for factor in trans_input.factors:
+            assert len(factor) == len(tokens)
+        if trans_input.source_prefix_factors is not None:
+            assert len(factors) == len(trans_input.source_prefix_factors)
+
+    chunked_inputs = list(trans_input.chunks(chunk_size))
+    assert len(chunked_inputs) == ceil(len(tokens) / chunk_size)
+    for chunk_id, chunk_input in enumerate(chunked_inputs):
+        assert chunk_input.sentence_id == sentence_id
+        assert chunk_input.tokens == trans_input.tokens[chunk_id * chunk_size: (chunk_id + 1) * chunk_size]
+        assert chunk_input.source_prefix_tokens == trans_input.source_prefix_tokens
+        assert chunk_input.num_source_prefix_tokens() == trans_input.num_source_prefix_tokens()
+        if source_prefix_factors is not None:
+            assert len(chunk_input.source_prefix_factors) == len(source_prefix_factors)
+            for chunk_input_source_prefix_factor, source_prefix_factor in zip(chunk_input.source_prefix_factors, trans_input.source_prefix_factors):
+                assert len(chunk_input_source_prefix_factor) == len(source_prefix_factor)
+
+
 @pytest.mark.parametrize("supported_max_seq_len_source, supported_max_seq_len_target, "
                          "forced_max_input_len, forced_max_output_len, length_ratio_mean, length_ratio_std, "
                          "expected_max_input_len, expected_max_output_len",

--- a/test/unit/test_inference.py
+++ b/test/unit/test_inference.py
@@ -152,7 +152,7 @@ def test_translator_input_with_source_prefix(sentence_id, sentence, factors, chu
 
     assert trans_input.sentence_id == sentence_id
     assert trans_input.tokens == tokens
-    assert len(trans_input) == len(tokens)
+    assert len(trans_input) == len(tokens) + len(source_prefix_tokens)
     assert trans_input.factors == factors
     assert trans_input.source_prefix_tokens == source_prefix_tokens
     assert trans_input.source_prefix_factors == source_prefix_factors


### PR DESCRIPTION
This version makes Sockeye able to support JSON input format with special source tokens as follows: 

  1. Special source tokens can be added (e.g. verbosity token, formality token, multilingual token) in Sockeye's JSON input format
  2. Long input sequence is chunked in the way that the special source tokens are added to each chunk.

Examples of JSON input object that can be used during inference are as below (noticed of the keyword: `source_prefix` and `source_prefix_factors`):
```
{ "text": "(@@ A@@", "source_prefix": "a@@"}
{ "text": "(@@ A@@", "source_prefix": "a@@ a@@"} 
{ "text": "(@@ A@@", "factors": ["(@@ A@@"], "source_prefix": "a@@ a@@", "source_prefix_factors": ["(@@ A@@"]}

```
#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`) 
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
