### PR TITLE
Code formatting & cleanup for beam_search.py and inference.py

### DIFF
--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -18,7 +18,7 @@ from abc import abstractmethod, ABC
 from dataclasses import dataclass
 from typing import Optional, Tuple, List, Union
 
-import numpy as onp
+import numpy as np
 import torch as pt
 
 import sockeye.constants as C
@@ -96,7 +96,7 @@ class _SingleModelInference(_Inference):
                     tf_logits = pt.log_softmax(tf_logits, dim=-1)
                 tf_scores = -tf_logits
                 if target_prefix_factor_mask is not None:
-                    tf_scores += target_prefix_factor_mask[:,:,i-1].reshape(-1, factor_vocab_size)
+                    tf_scores += target_prefix_factor_mask[:, :, i-1].reshape(-1, factor_vocab_size)
                 # target factors are greedily chosen, and score and index are collected via torch.min.
                 # Shape per factor: (batch*beam, 1, 2), where last dimension holds values and indices.
                 tf_prediction = pt.cat(tf_scores.min(dim=-1, keepdim=True), dim=1).unsqueeze(1)
@@ -164,7 +164,7 @@ class _EnsembleInference(_Inference):
                 target_factor_probs = [tfo.softmax(dim=-1) for tfo in target_factor_outputs]
                 if target_prefix_factor_mask is not None:
                     for i in range(len(target_factor_probs)):
-                        target_factor_probs[i] += target_prefix_factor_mask[:,:,i].reshape(-1, factor_vocab_size)
+                        target_factor_probs[i] += target_prefix_factor_mask[:, :, i].reshape(-1, factor_vocab_size)
                 factor_outputs.append(target_factor_probs)
             new_states += model_states
         scores = self._interpolation(outputs)
@@ -195,6 +195,7 @@ class _EnsembleInference(_Inference):
     def model_output_factor_vocab_size(self):
         return self._models[0].factor_vocab_size
 
+
 @dataclass
 class SearchResult:
     """
@@ -223,7 +224,7 @@ class UpdateScores(pt.nn.Module):
     def forward(self, target_dists, finished, scores_accumulated, lengths, max_lengths, pad_dist, eos_dist):
 
         if self.prevent_unk:  # make sure to avoid generating <unk>
-            target_dists[:, C.UNK_ID] = onp.inf
+            target_dists[:, C.UNK_ID] = np.inf
 
         # broadcast hypothesis score to each prediction.
         # scores_accumulated. Shape: (batch*beam, 1)
@@ -538,23 +539,23 @@ def _get_vocab_slice_ids(restrict_lexicon: Optional[lexicon.TopKLexicon],
         # Ensuring that target prefix ids are part of vocab_slice_ids
          vocab_slice_ids = pt.concat([vocab_slice_ids, target_prefix.flatten().type(pt.int64)], -1).unique()
     # Pad to a multiple of 8.
-    vocab_slice_ids = pt.nn.functional.pad(vocab_slice_ids, \
-                                           pad=(0, 7 - ((vocab_slice_ids.size(-1) - 1) % 8)), \
+    vocab_slice_ids = pt.nn.functional.pad(vocab_slice_ids,
+                                           pad=(0, 7 - ((vocab_slice_ids.size(-1) - 1) % 8)),
                                            mode='constant', value=eos_id)
-    vocab_slice_ids_shape = vocab_slice_ids.size()[0]  # type: ignore
+    vocab_slice_ids_shape = vocab_slice_ids.size()[0]
     if vocab_slice_ids_shape < beam_size + 1:
         # This fixes an edge case for toy models, where the number of vocab ids from the lexicon is
         # smaller than the beam size.
         logger.warning("Padding vocab_slice_ids (%d) with EOS to have at least %d+1 elements to expand",
                        vocab_slice_ids_shape, beam_size)
         n = beam_size - vocab_slice_ids_shape + 1
-        vocab_slice_ids = pt.cat((vocab_slice_ids, pt.full((n,),  # type: ignore
+        vocab_slice_ids = pt.cat((vocab_slice_ids, pt.full((n,),
                                                            fill_value=eos_id,
                                                            device=device,
                                                            dtype=pt.int32)), dim=0)
 
     logger.debug(f'decoder softmax size: {vocab_slice_ids_shape}')
-    return vocab_slice_ids, vocab_slice_ids_shape  # type: ignore
+    return vocab_slice_ids, vocab_slice_ids_shape
 
 
 class GreedySearch(pt.nn.Module):
@@ -602,7 +603,8 @@ class GreedySearch(pt.nn.Module):
         :param max_output_lengths: ndarray of maximum output lengths per input in source.
                 Shape: (batch_size=1,). Dtype: int32.
         :param target_prefix: Target prefix ids. Shape: (batch_size=1, max target prefix length).
-        :param target_prefix_factors: Target prefix factor ids. Shape: (batch_size=1, max target prefix factors length, num_target_factors).
+        :param target_prefix_factors: Target prefix factor ids.
+                Shape: (batch_size=1, max target prefix factors length, num_target_factors).
         :return SearchResult.
         """
         batch_size = source.size()[0]
@@ -622,21 +624,24 @@ class GreedySearch(pt.nn.Module):
         # target vocab for this sentence.
         if restrict_lexicon:
             source_words = source[:, :, 0]
-            vocab_slice_ids, _ = _get_vocab_slice_ids(restrict_lexicon, source_words, self.eos_id, beam_size=1, target_prefix=target_prefix)
+            vocab_slice_ids, _ = _get_vocab_slice_ids(restrict_lexicon, source_words, self.eos_id,
+                                                      beam_size=1, target_prefix=target_prefix)
 
         # (0) encode source sentence, returns a list
         model_states, _ = self._inference.encode_and_initialize(source, source_length)
         # TODO: check for disabled predicted output length
 
         # Prefix masks, where scores are infinity for all other vocabulary items except target_prefix ids
-        prefix_masks, prefix_masks_length = (utils.gen_prefix_masking(target_prefix, self.output_vocab_size, self.dtype), target_prefix.size(1)) \
-                                            if target_prefix is not None else (None, None)  # type: ignore
-        if prefix_masks is not None and vocab_slice_ids is not None:
-            prefix_masks = pt.index_select(prefix_masks, -1, vocab_slice_ids)
+        prefix_masks, prefix_masks_length = None, 0
+        if prefix_masks is not None:
+            prefix_masks, prefix_masks_length = utils.gen_prefix_masking(target_prefix, self.output_vocab_size, self.dtype)
+            if vocab_slice_ids is not None:
+                prefix_masks = pt.index_select(prefix_masks, -1, vocab_slice_ids)
         # Prefix factor masks, where scores are also infinity for all other factor items except target_prefix_factor ids
-        target_prefix_factor_masks, target_prefix_factor_length = (utils.gen_prefix_masking(target_prefix_factors, self.output_factor_vocab_size, self.dtype), target_prefix_factors.size(1)) \
-                                                                  if self.num_target_factors > 1 and target_prefix_factors is not None \
-                                                                  else (None, None)  # type: ignore
+        target_prefix_factor_masks, target_prefix_factor_length = None, 0
+        if target_prefix_factors is not None:
+            target_prefix_factor_masks, target_prefix_factor_length = utils.gen_prefix_masking(
+                target_prefix_factors, self.output_factor_vocab_size, self.dtype)
 
         t = 1
         for t in range(1, max_iterations + 1):
@@ -648,7 +653,7 @@ class GreedySearch(pt.nn.Module):
                                                                                vocab_slice_ids,
                                                                                target_prefix_factor_mask,
                                                                                self.output_factor_vocab_size)
-            if target_prefix is not None and t <= prefix_masks_length:
+            if prefix_masks is not None and t <= prefix_masks_length:
                 # Make sure search selects the current prefix token
                 scores += prefix_masks[:, t-1]
 
@@ -774,7 +779,8 @@ class BeamSearch(pt.nn.Module):
         :param max_output_lengths: Tensor of maximum output lengths per input in source.
                 Shape: (batch_size,). Dtype: int32.
         :param target_prefix: Target prefix ids. Shape: (batch_size, max prefix length).
-        :param target_prefix_factors: Target prefix factors ids. Shape: (batch_size, max prefix factors length, num_target_factors).
+        :param target_prefix_factors: Target prefix factors ids.
+                Shape: (batch_size, max prefix factors length, num_target_factors).
         :return SearchResult.
         """
         batch_size = source.size()[0]
@@ -800,7 +806,7 @@ class BeamSearch(pt.nn.Module):
 
         # locations of each batch item when first dimension is (batch * beam)
         batch_indices = pt.arange(0, batch_size * self.beam_size, self.beam_size, dtype=pt.int64, device=self.device)
-        first_step_mask = pt.full((batch_size * self.beam_size, 1), fill_value=onp.inf, device=self.device, dtype=self.dtype)
+        first_step_mask = pt.full((batch_size * self.beam_size, 1), fill_value=np.inf, device=self.device, dtype=self.dtype)
         first_step_mask[batch_indices] = 0.0
         if target_prefix is not None:
             first_step_mask = utils.adjust_first_step_masking(target_prefix, first_step_mask)
@@ -833,10 +839,10 @@ class BeamSearch(pt.nn.Module):
             vocab_slice_ids, output_vocab_size = _get_vocab_slice_ids(restrict_lexicon, source_words, self.eos_id,
                                                                       beam_size=1, target_prefix=target_prefix)
 
-        pad_dist = pt.full((1, output_vocab_size), fill_value=onp.inf, device=self.device, dtype=self.dtype)
+        pad_dist = pt.full((1, output_vocab_size), fill_value=np.inf, device=self.device, dtype=self.dtype)
         pad_dist[0, 0] = 0  # [0, inf, inf, ...]
         eos_dist = pt.full((1, output_vocab_size),
-                           fill_value=onp.inf, device=self.device, dtype=self.dtype)
+                           fill_value=np.inf, device=self.device, dtype=self.dtype)
         eos_dist[:, C.EOS_ID] = 0
 
         # (0) encode source sentence, returns a list
@@ -850,16 +856,19 @@ class BeamSearch(pt.nn.Module):
         estimated_reference_lengths = estimated_reference_lengths.repeat_interleave(self.beam_size, dim=0)
 
         # Prefix token masks, where scores are infinity for all other vocabulary items except target_prefix ids
-        prefix_masks, prefix_masks_length = (utils.gen_prefix_masking(target_prefix, self.output_vocab_size, self.dtype), target_prefix.size(1)) \
-                                            if target_prefix is not None else (None, None) # type: ignore
-        prefix_masks = prefix_masks.unsqueeze(2).expand(-1, -1, self.beam_size, -1) if target_prefix is not None else None #  type: ignore
-        if prefix_masks is not None and vocab_slice_ids is not None:
-            prefix_masks = pt.index_select(prefix_masks, -1, vocab_slice_ids)
+        prefix_masks, prefix_masks_length = None, 0
+        if target_prefix is not None:
+            prefix_masks, prefix_masks_length = utils.gen_prefix_masking(target_prefix, self.output_vocab_size, self.dtype)
+            prefix_masks = prefix_masks.unsqueeze(2).expand(-1, -1, self.beam_size, -1)
+            if vocab_slice_ids is not None:
+                prefix_masks = pt.index_select(prefix_masks, -1, vocab_slice_ids)
         # Prefix factor masks, where scores are also infinity for all other factor items except target_prefix_factor ids
-        target_prefix_factor_masks, target_prefix_factor_length = (utils.gen_prefix_masking(target_prefix_factors, self.output_factor_vocab_size, self.dtype), target_prefix_factors.size(1)) \
-                                                                  if self.num_target_factors > 1 and target_prefix_factors is not None \
-                                                                  else (None, None)  # type: ignore
-        target_prefix_factor_masks = target_prefix_factor_masks.unsqueeze(2).expand(-1, -1, self.beam_size, -1, -1) if target_prefix_factor_masks is not None else None #  type: ignore
+        target_prefix_factor_masks, target_prefix_factor_length = None, 0
+        if target_prefix_factors is not None:
+            target_prefix_factor_masks, target_prefix_factor_length = utils.gen_prefix_masking(
+                target_prefix_factors, self.output_factor_vocab_size, self.dtype)
+            target_prefix_factor_masks = target_prefix_factor_masks.unsqueeze(2).expand(-1, -1, self.beam_size, -1, -1)
+
         t = 1
         for t in range(1, max_iterations + 1):  # max_iterations + 1 required to get correct results
             # (1) obtain next predictions and advance models' state
@@ -881,7 +890,7 @@ class BeamSearch(pt.nn.Module):
             scores, lengths = self._update_scores(target_dists, finished, scores_accumulated,
                                                   lengths, max_output_lengths, pad_dist, eos_dist)
 
-            if target_prefix is not None and t <= prefix_masks_length:
+            if prefix_masks is not None and t <= prefix_masks_length:
                 # Make sure search selects the current prefix token
                 scores += prefix_masks[:, t-1].reshape(-1, output_vocab_size)
 

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -633,7 +633,7 @@ class GreedySearch(pt.nn.Module):
 
         # Prefix masks, where scores are infinity for all other vocabulary items except target_prefix ids
         prefix_masks, prefix_masks_length = None, 0
-        if prefix_masks is not None:
+        if target_prefix is not None:
             prefix_masks, prefix_masks_length = utils.gen_prefix_masking(target_prefix, self.output_vocab_size, self.dtype)
             if vocab_slice_ids is not None:
                 prefix_masks = pt.index_select(prefix_masks, -1, vocab_slice_ids)

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -361,10 +361,10 @@ def make_input_from_dict(sentence_id: SentenceId,
         target_prefix_factors = input_dict.get(C.JSON_TARGET_PREFIX_FACTORS_KEY)
         if isinstance(target_prefix_factors, list):
             target_prefix_factors = [list(utils.get_tokens(tpf)) for tpf in target_prefix_factors]
-            for target_prefix_factor in target_prefix_factors:
-                if not target_prefix_factor:
-                    logger.warning(f"Empty list is specified as target prefix factors for input '%s'.",
-                                   input_dict[C.JSON_TEXT_KEY])
+            if len(target_prefix_factors) != translator.num_target_factors - 1:
+                logger.error("Must provide target prefix for each target factor. Given: %s required: %s",
+                             len(target_prefix_factors), translator.num_target_factors - 1)
+                return _bad_input(sentence_id, reason=str(input_dict))
 
         use_target_prefix_all_chunks = input_dict.get(C.JSON_USE_TARGET_PREFIX_ALL_CHUNKS_KEY, True)
         keep_target_prefix_key = input_dict.get(C.JSON_KEEP_TARGET_PREFIX_KEY, True)

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Union
 
-import numpy as onp
+import numpy as np
 import torch as pt
 
 from . import constants as C
@@ -105,7 +105,7 @@ def get_max_input_output_length(supported_max_seq_len_source: int,
         """
         if forced_max_output_len is not None:
             return forced_max_output_len + C.SPACE_FOR_XOS
-        return int(onp.ceil(factor * input_length))
+        return int(np.ceil(factor * input_length))
 
     return max_input_len, get_max_output_length
 
@@ -338,16 +338,19 @@ def make_input_from_dict(sentence_id: SentenceId,
                 return _bad_input(sentence_id, reason=str(input_dict))
 
         if isinstance(source_prefix_factors, list):
-            source_prefix_factors = [list(utils.get_tokens(source_prefix_factor)) for source_prefix_factor in source_prefix_factors]
+            source_prefix_factors = [list(utils.get_tokens(spf)) for spf in source_prefix_factors]
             for source_prefix_factor in source_prefix_factors:
                 if not source_prefix_factor:
-                    logger.warning(f"Empty list is specified as source prefix factors for input '{input_dict[C.JSON_TEXT_KEY]}'.")
+                    logger.warning(f"Empty list is specified as source prefix factors for input '%s'.",
+                                   input_dict[C.JSON_TEXT_KEY])
             lengths = [len(source_prefix_factor) for source_prefix_factor in source_prefix_factors]
             if not all(len(source_prefix_tokens) == length for length in lengths):
-                logger.error("Source prefix has %d tokens but there are %s prefix factors", len(source_prefix_tokens), str(lengths))
+                logger.error("Source prefix has %d tokens but there are %s prefix factors",
+                             len(source_prefix_tokens), str(lengths))
                 return _bad_input(sentence_id, reason=str(input_dict))
             if len(source_prefix_factors) != len(factors):
-                logger.error("There is mismatch in source factors %d and prefix factors %d", len(factors), len(source_prefix_factors))
+                logger.error("There is mismatch in source factors %d and prefix factors %d",
+                             len(factors), len(source_prefix_factors))
                 return _bad_input(sentence_id, reason=str(input_dict))
 
         target_prefix_tokens = input_dict.get(C.JSON_TARGET_PREFIX_KEY)
@@ -357,10 +360,11 @@ def make_input_from_dict(sentence_id: SentenceId,
 
         target_prefix_factors = input_dict.get(C.JSON_TARGET_PREFIX_FACTORS_KEY)
         if isinstance(target_prefix_factors, list):
-            target_prefix_factors = [list(utils.get_tokens(target_prefix_factor)) for target_prefix_factor in target_prefix_factors]
+            target_prefix_factors = [list(utils.get_tokens(tpf)) for tpf in target_prefix_factors]
             for target_prefix_factor in target_prefix_factors:
                 if not target_prefix_factor:
-                    logger.warning(f"Empty list is specified as target prefix factors for input '{input_dict[C.JSON_TEXT_KEY]}'.")
+                    logger.warning(f"Empty list is specified as target prefix factors for input '%s'.",
+                                   input_dict[C.JSON_TEXT_KEY])
 
         use_target_prefix_all_chunks = input_dict.get(C.JSON_USE_TARGET_PREFIX_ALL_CHUNKS_KEY, True)
         keep_target_prefix_key = input_dict.get(C.JSON_KEEP_TARGET_PREFIX_KEY, True)
@@ -381,7 +385,7 @@ def make_input_from_dict(sentence_id: SentenceId,
                              % (restrict_lexicon_name, ' '.join(sorted(translator.restrict_lexicon))))
                 return _bad_input(sentence_id, reason=str(input_dict))
 
-        # List of phrases to prevent from occuring in the output
+        # List of phrases to prevent from occurring in the output
         avoid_list = input_dict.get(C.JSON_AVOID_KEY)
 
         # List of phrases that must appear in the output
@@ -565,7 +569,7 @@ def empty_translation(add_nbest: bool = False) -> Translation:
     :param add_nbest: Include (empty) nbest_translations in the translation object.
     """
     return Translation(target_ids=[],
-                       scores=[-onp.inf],
+                       scores=[-np.inf],
                        nbest_translations=NBestTranslations([], []) if add_nbest else None)
 
 
@@ -655,6 +659,7 @@ def _expand_nbest_translation(translation: Translation) -> List[Translation]:
                                       estimated_reference_length=translation.estimated_reference_length))
     return nbest_list
 
+
 def _remove_target_prefix_tokens(target_ids: TokenIds, num_target_prefix_tokens: int) -> TokenIds:
     """
     Remove target prefix tokens from target token Ids
@@ -665,6 +670,7 @@ def _remove_target_prefix_tokens(target_ids: TokenIds, num_target_prefix_tokens:
     """
     starting_idx = min(len(target_ids), num_target_prefix_tokens)
     return target_ids[starting_idx:]
+
 
 def _concat_translations(translations: List[Translation],
                          stop_ids: Set[int],
@@ -683,7 +689,7 @@ def _concat_translations(translations: List[Translation],
     # Concatenation of all target ids without BOS and EOS
     target_ids = []
     estimated_reference_length = None  # type: Optional[float]
-    scores = onp.zeros_like(translations[0].scores)
+    scores = np.zeros_like(translations[0].scores)
 
     for idx, translation in enumerate(translations):
         if idx == len(translations) - 1:
@@ -703,10 +709,10 @@ def _concat_translations(translations: List[Translation],
         # Unnormalize the primary score:
         raw_score = scorer.unnormalize(score, len(translation.target_ids), translation.estimated_reference_length)
         # Accumulate scores element-wise
-        scores = onp.add(scores, [raw_score, *factor_scores])
+        scores = np.add(scores, [raw_score, *factor_scores])
 
     # Re-normalize the primary score
-    scores[0] = scorer(scores[0], len(target_ids), estimated_reference_length)
+    scores = scorer(scores[0], len(target_ids), estimated_reference_length)
 
     return Translation(target_ids, scores.tolist(), estimated_reference_length=estimated_reference_length)
 
@@ -870,19 +876,23 @@ class Translator:
             # bad input
             if isinstance(trans_input, BadTranslatorInput):
                 translated_chunks.append(IndexedTranslation(input_idx=trans_input_idx, chunk_idx=0,
-                                                            translation=empty_translation(add_nbest=(self.nbest_size > 1))))
+                                                            translation=empty_translation(add_nbest=(
+                                                                    self.nbest_size > 1))))
             # empty input
             elif len(trans_input.tokens) == 0:
                 translated_chunks.append(IndexedTranslation(input_idx=trans_input_idx, chunk_idx=0,
-                                                            translation=empty_translation(add_nbest=(self.nbest_size > 1))))
+                                                            translation=empty_translation(add_nbest=(
+                                                                    self.nbest_size > 1))))
             else:
-                max_input_length_for_chunking = self.max_input_length - trans_input.num_source_prefix_tokens # take length of source prefix, if used, into account while chunking
+                # take length of source prefix, if used, into account while chunking
+                max_input_length_for_chunking = self.max_input_length - trans_input.num_source_prefix_tokens
                 if max_input_length_for_chunking <= 0:
-                    logger.warning(
-                        "Input %s has a source prefix with length (%d) that already equals or exceeds max input length (%d). Return an empty translation instead.", \
-                        trans_input.sentence_id, trans_input.num_source_prefix_tokens, self.max_input_length)
+                    logger.warning("Input %s has a source prefix with length (%d) that already equals or exceeds "
+                                   "max input length (%d). Return an empty translation instead.",
+                                   trans_input.sentence_id, trans_input.num_source_prefix_tokens, self.max_input_length)
                     translated_chunks.append(IndexedTranslation(input_idx=trans_input_idx, chunk_idx=0,
-                                                                translation=empty_translation(add_nbest=(self.nbest_size > 1))))
+                                                                translation=empty_translation(
+                                                                    add_nbest=(self.nbest_size > 1))))
                 elif len(trans_input.tokens) > max_input_length_for_chunking:
                     # oversized input
                     logger.debug(
@@ -925,7 +935,7 @@ class Translator:
 
             translator_inputs = [indexed_translator_input.translator_input for indexed_translator_input in batch]
             with pt.inference_mode():
-                batch_translations = self._translate_np(*self._get_inference_input(translator_inputs))  # type: ignore
+                batch_translations = self._translate_np(*self._get_inference_input(translator_inputs))
 
             # truncate to remove filler translations
             if fill_up_batches and rest > 0:
@@ -970,19 +980,19 @@ class Translator:
 
     def _get_inference_input(self,
                              trans_inputs: List[TranslatorInput]) -> Tuple[pt.Tensor,
-                                                                           int,
-                                                                           Optional[pt.Tensor],
+                                                                           pt.Tensor,
                                                                            Optional[lexicon.TopKLexicon],
                                                                            pt.Tensor,
-                                                                           pt.Tensor]:
+                                                                           Optional[pt.Tensor],
+                                                                           Optional[pt.Tensor]]:
         """
         Assembles the numerical data for the batch. This comprises a tensor for the source sentences,
         the bucket key (padded source length), a tensor of maximum output lengths for each sentence in the batch.
 
         :param trans_inputs: List of TranslatorInputs.
         :return tensor of source ids (shape=(batch_size, bucket_key, num_factors)),
-                tensor of valid source lengths, target prefix, lexicon for vocabulary restriction, and a tensor of maximum output
-                lengths.
+                tensor of valid source lengths, lexicon for vocabulary restriction, tensor of maximum output lengths,
+                optional target prefix, and optional target prefix factors.
         """
         batch_size = len(trans_inputs)
         lengths = [len(inp) for inp in trans_inputs]
@@ -991,23 +1001,29 @@ class Translator:
         max_target_prefix_factors_length = max(inp.num_target_prefix_factors for inp in trans_inputs)
         max_length = max(len(inp) for inp in trans_inputs)
         # assembling source ids on cpu array (faster) and copy to Translator.device (potentially GPU) in one go below.
-        source = onp.zeros((batch_size, max_length, self.num_source_factors), dtype='int32')
+        source_np = np.zeros((batch_size, max_length, self.num_source_factors), dtype='int32')
 
-        target_prefix = onp.zeros((batch_size, max_target_prefix_length), dtype='int32') if max_target_prefix_length > 0 else None
-        target_prefix_factors = onp.zeros((batch_size, max_target_prefix_factors_length, self.num_target_factors - 1), dtype='int32') if self.num_target_factors > 1 and max_target_prefix_factors_length > 0 else None
+        target_prefix_np = np.zeros((batch_size, max_target_prefix_length), dtype='int32') \
+            if max_target_prefix_length > 0 else None
+        target_prefix_factors_np = np.zeros((batch_size, max_target_prefix_factors_length,
+                                             self.num_target_factors - 1), dtype='int32') \
+            if self.num_target_factors > 1 and max_target_prefix_factors_length > 0 else None
         restrict_lexicon = None  # type: Optional[lexicon.TopKLexicon]
 
         max_output_lengths = []  # type: List[int]
         for j, trans_input in enumerate(trans_inputs):
             num_tokens = len(trans_input)  # includes eos
             max_output_lengths.append(self._get_max_output_length(num_tokens))
-            source[j, :num_tokens, 0] = tokens2ids(itertools.chain(trans_input.get_source_prefix_tokens(), \
-                trans_input.tokens), self.source_vocabs[0])
-            if target_prefix is not None and trans_input.num_target_prefix_tokens > 0:
-                target_prefix[j, :trans_input.num_target_prefix_tokens] = tokens2ids(trans_input.get_target_prefix_tokens(), self.vocab_targets[0])
-            if target_prefix_factors is not None and self.num_target_factors > 1 and trans_input.num_target_prefix_factors > 0:
+            source_np[j, :num_tokens, 0] = tokens2ids(itertools.chain(trans_input.get_source_prefix_tokens(),
+                                                                      trans_input.tokens), self.source_vocabs[0])
+            if target_prefix_np is not None and trans_input.num_target_prefix_tokens > 0:
+                target_prefix_np[j, :trans_input.num_target_prefix_tokens] = \
+                    tokens2ids(trans_input.get_target_prefix_tokens(), self.vocab_targets[0])
+            if target_prefix_factors_np is not None \
+                    and self.num_target_factors > 1 and trans_input.num_target_prefix_factors > 0:
                 for i in range(1, self.num_target_factors):
-                    target_prefix_factors[j, :trans_input.num_target_prefix_factors, i - 1] = tokens2ids(trans_input.get_target_prefix_factors()[i - 1], self.vocab_targets[i])
+                    target_prefix_factors_np[j, :trans_input.num_target_prefix_factors, i - 1] = \
+                        tokens2ids(trans_input.get_target_prefix_factors()[i - 1], self.vocab_targets[i])
             factors = trans_input.factors if trans_input.factors is not None else []
             num_factors = 1 + len(factors)
             if num_factors != self.num_source_factors:
@@ -1016,11 +1032,15 @@ class Translator:
             if not trans_input.source_prefix_factors: # no source prefix during inference
                 for i, factor in enumerate(factors[:self.num_source_factors - 1], start=1):
                     # fill in as many factors as there are tokens
-                    source[j, :num_tokens, i] = tokens2ids(factor, self.source_vocabs[i])[:num_tokens]
+                    source_np[j, :num_tokens, i] = tokens2ids(factor, self.source_vocabs[i])[:num_tokens]
             else:
-                for i, zip_of_factor_and_prefix_factor in enumerate(zip(factors[:self.num_source_factors - 1], trans_input.source_prefix_factors[:self.num_source_factors - 1]), start=1):
+                for i, zip_of_factor_and_prefix_factor in enumerate(
+                        zip(factors[:self.num_source_factors - 1],
+                            trans_input.source_prefix_factors[:self.num_source_factors - 1]),
+                        start=1):
                     factor, source_prefix_factor = zip_of_factor_and_prefix_factor
-                    source[j, :num_tokens, i] = tokens2ids(itertools.chain(source_prefix_factor, factor), self.source_vocabs[i])[:num_tokens]
+                    source_np[j, :num_tokens, i] = tokens2ids(itertools.chain(source_prefix_factor, factor),
+                                                              self.source_vocabs[i])[:num_tokens]
 
             # Check if vocabulary selection/restriction is enabled:
             # - First, see if the translator input provides a lexicon (used for multiple lexicons)
@@ -1042,18 +1062,23 @@ class Translator:
                 else:
                     restrict_lexicon = self.restrict_lexicon
 
-        source = pt.tensor(source, device=self.device, dtype=pt.int32)  # type: ignore
+        source = pt.tensor(source_np, device=self.device, dtype=pt.int32)
         source_length = pt.tensor(lengths, device=self.device, dtype=pt.int32)  # shape: (batch_size,)
-        max_output_lengths = pt.tensor(max_output_lengths, device=self.device, dtype=pt.int32)  # type: ignore
-        target_prefix = pt.tensor(target_prefix, device=self.device, dtype=pt.int32) if target_prefix is not None else None  # type: ignore
-        target_prefix_factors_tensor = pt.tensor(target_prefix_factors, device=self.device, dtype=pt.int32) if target_prefix_factors is not None else None  # type: ignore
+        max_out_lengths = pt.tensor(max_output_lengths, device=self.device, dtype=pt.int32)
+        target_prefix = pt.tensor(target_prefix_np, device=self.device, dtype=pt.int32) \
+            if target_prefix_np is not None else None
+        target_prefix_factors = pt.tensor(target_prefix_factors_np, device=self.device, dtype=pt.int32) \
+            if target_prefix_factors_np is not None else None
 
-        # During inference, if C.TARGET_FACTOR_SHIFT is True, predicted target_factors are left-shifted (see _unshift_target_factors function()) so that \
-        # they re-align with the words. With that, target_prefix_factors need to be also right-shifted here if C.TARGET_FACTOR_SHIFT is True so that when \
-        # they are shifted back later they would align with words.
-        target_prefix_factors_tensor = utils.shift_prefix_factors(target_prefix_factors_tensor) if target_prefix_factors_tensor is not None and C.TARGET_FACTOR_SHIFT else target_prefix_factors_tensor # type: ignore
+        # During inference, if C.TARGET_FACTOR_SHIFT is True, predicted target_factors are left-shifted
+        # (see _unshift_target_factors function()) so that they re-align with the words.
+        # With that, target_prefix_factors need to be also right-shifted here if C.TARGET_FACTOR_SHIFT is True so
+        # that when they are shifted back later they would align with words.
+        target_prefix_factors = utils.shift_prefix_factors(target_prefix_factors) \
+            if target_prefix_factors is not None and \
+               C.TARGET_FACTOR_SHIFT else target_prefix_factors
 
-        return source, source_length, restrict_lexicon, max_output_lengths, target_prefix, target_prefix_factors_tensor  # type: ignore
+        return source, source_length, restrict_lexicon, max_out_lengths, target_prefix, target_prefix_factors
 
     def _get_translation_tokens_and_factors(self, target_ids: List[List[int]]) -> Tuple[List[str],
                                                                                         str,
@@ -1174,12 +1199,12 @@ class Translator:
             estimated_reference_lengths = result.estimated_reference_lengths.cpu().numpy()
         batch_size = best_hyp_indices.shape[0] // self.beam_size
         nbest_translations = []  # type: List[List[Translation]]
-        reference_lengths = estimated_reference_lengths if estimated_reference_lengths is not None \
-                                                        else onp.zeros((self.batch_size * self.beam_size, 1))
+        reference_lengths = estimated_reference_lengths \
+            if estimated_reference_lengths is not None else np.zeros((self.batch_size * self.beam_size, 1))
         for n in range(0, self.nbest_size):
 
             # Initialize the best_ids to the first item in each batch, plus current nbest index
-            best_ids = onp.arange(n, batch_size * self.beam_size, self.beam_size, dtype='int32')
+            best_ids = np.arange(n, batch_size * self.beam_size, self.beam_size, dtype='int32')
             # Obtain sequences for all best hypotheses in the batch. Shape: (batch, length)
             indices = self._get_best_word_indices_for_kth_hypotheses(best_ids, best_hyp_indices)  # type: ignore
             indices_shape_1 = indices.shape[1]  # pylint: disable=unsubscriptable-object
@@ -1187,7 +1212,7 @@ class Translator:
                     [self._assemble_translation(*x, unshift_target_factors=C.TARGET_FACTOR_SHIFT) for x in
                      zip(best_word_indices[indices,
                                            :,  # get all factors
-                                           onp.arange(indices_shape_1)],
+                                           np.arange(indices_shape_1)],
                          lengths[best_ids],
                          accumulated_scores[best_ids],
                          reference_lengths[best_ids])])  # type: ignore
@@ -1197,7 +1222,7 @@ class Translator:
         return reduced_translations
 
     @staticmethod
-    def _get_best_word_indices_for_kth_hypotheses(ks: onp.ndarray, all_hyp_indices: onp.ndarray) -> onp.ndarray:
+    def _get_best_word_indices_for_kth_hypotheses(ks: np.ndarray, all_hyp_indices: np.ndarray) -> np.ndarray:
         """
         Traverses the matrix of best hypotheses indices collected during beam search in reversed order by
         using the kth hypotheses index as a backpointer.
@@ -1211,7 +1236,7 @@ class Translator:
         """
         batch_size = ks.shape[0]
         num_steps = all_hyp_indices.shape[1]
-        result = onp.zeros((batch_size, num_steps - 1), dtype=all_hyp_indices.dtype)
+        result = np.zeros((batch_size, num_steps - 1), dtype=all_hyp_indices.dtype)
         # first index into the history of the desired hypotheses.
         pointer = all_hyp_indices[ks, -1]
         # for each column/step follow the pointer, starting from the penultimate column/step
@@ -1221,9 +1246,9 @@ class Translator:
         return result
 
     @staticmethod
-    def _assemble_translation(sequence: onp.ndarray,
-                              length: onp.ndarray,
-                              seq_scores: onp.ndarray,
+    def _assemble_translation(sequence: np.ndarray,
+                              length: np.ndarray,
+                              seq_scores: np.ndarray,
                               estimated_reference_length: Optional[float],
                               unshift_target_factors: bool = False) -> Translation:
         """
@@ -1248,7 +1273,7 @@ class Translator:
                            estimated_reference_length=estimated_reference_length)
 
 
-def _unshift_target_factors(sequence: onp.ndarray, fill_last_with: int = C.EOS_ID):
+def _unshift_target_factors(sequence: np.ndarray, fill_last_with: int = C.EOS_ID):
     """
     Shifts back target factors so that they re-align with the words.
 

--- a/sockeye/inference.py
+++ b/sockeye/inference.py
@@ -712,7 +712,7 @@ def _concat_translations(translations: List[Translation],
         scores = np.add(scores, [raw_score, *factor_scores])
 
     # Re-normalize the primary score
-    scores = scorer(scores[0], len(target_ids), estimated_reference_length)
+    scores[0] = scorer(scores[0], len(target_ids), estimated_reference_length)
 
     return Translation(target_ids, scores.tolist(), estimated_reference_length=estimated_reference_length)
 

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -264,7 +264,7 @@ def average_tensors(tensors: List[pt.Tensor]) -> pt.Tensor:
     return sum(tensors) / len(tensors)  # type: ignore
 
 
-def gen_prefix_masking(prefix: pt.Tensor, vocab_size: int, dtype: pt.dtype) -> pt.Tensor:
+def gen_prefix_masking(prefix: pt.Tensor, vocab_size: int, dtype: pt.dtype) -> Tuple[pt.Tensor, int]:
     """
     Generate prefix masks from prefix ids, which are inf everywhere except zero for prefix ids.
 
@@ -274,7 +274,8 @@ def gen_prefix_masking(prefix: pt.Tensor, vocab_size: int, dtype: pt.dtype) -> p
     :return prefix_masks (batch size, max length of prefix, vocab_size), with type as dtype
 
     """
-    prefix_masks_sizes = [s for s in prefix.size()]
+    prefix_masks_sizes = list(prefix.size())  # type: List[int]
+    max_length = prefix_masks_sizes[1]
     prefix_masks_sizes.append(vocab_size)
 
     # prefix_masks are inf everywhere except zero for indices of prefix ids.
@@ -304,7 +305,7 @@ def gen_prefix_masking(prefix: pt.Tensor, vocab_size: int, dtype: pt.dtype) -> p
     # selecting any specific target token for the translation in that case.
 
     prefix_masks.masked_fill_(prefix.unsqueeze(-1) == 0, 0)
-    return prefix_masks
+    return prefix_masks, max_length
 
 
 def shift_prefix_factors(prefix_factors: pt.Tensor) -> pt.Tensor:


### PR DESCRIPTION
- reformatted a few lines to better adhere to max line length
- refactored `utils.gen_prefix_masking` to simplify logic in beam search
- rename numpy import from `onp` to `np`.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Passed code style checking (`./style-check.sh`)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

