### PR TITLE
Moved offsetting of topk scores out of the (traced) TopK module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.6]
+
+### Changed
+
+- Moved offsetting of topk scores out of the (traced) TopK module. This allows sending requests of variable
+  batch size to the same Translator/Model/BeamSearch instance.
+
 ## [3.1.5]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.5'
+__version__ = '3.1.6'

--- a/test/unit/test_beam_search.py
+++ b/test/unit/test_beam_search.py
@@ -140,7 +140,10 @@ def test_topk_func(batch_size, beam_size, target_vocab_size):
     np_hyp, np_word, np_values = numpy_topk(scores, k=beam_size, offset=offset)
 
     topk = sockeye.beam_search.TopK(k=beam_size)
-    pt_hyp, pt_word, pt_values = topk(pt.tensor(scores), pt.tensor(offset))
+    pt_hyp, pt_word, pt_values = topk(pt.tensor(scores))
+    if batch_size > 1:
+        # Offsetting the indices to match the shape of the scores matrix
+        pt_hyp += pt.tensor(offset)
     assert onp.allclose(pt_hyp.detach().numpy(), np_hyp)
     assert onp.allclose(pt_word.detach().numpy(), np_word)
     assert onp.allclose(pt_values.detach().numpy(), np_values)


### PR DESCRIPTION
Moved offsetting of topk scores out of the (traced) TopK module. This allows sending requests of variable   batch size to the same Translator/Model/BeamSearch instance.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

