### PR TITLE
Also trace SockeyeModel components when `inference_only == False` (includes CheckpointDecoder)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.7]
+
+### Changed
+
+- SockeyeModel components are now traced regardless of whether `inference_only` is set, including for the CheckpointDecoder during training.
+
 ## [3.1.6]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.6'
+__version__ = '3.1.7'

--- a/sockeye/checkpoint_decoder.py
+++ b/sockeye/checkpoint_decoder.py
@@ -151,7 +151,7 @@ class CheckpointDecoder:
 
         # Store original mode and set to eval mode in case the model is not yet
         # traced.
-        model_mode = self.model.training
+        original_mode = self.model.training
         self.model.eval()
 
         trans_wall_time = 0.0
@@ -178,7 +178,7 @@ class CheckpointDecoder:
         translations = list(zip(*translations))  # type: ignore
 
         # Restore original model mode
-        self.model.train(model_mode)
+        self.model.train(original_mode)
 
         # 2. Evaluate
 
@@ -216,11 +216,11 @@ class CheckpointDecoder:
         mode for tracing, translate the sentence, then set the model back to its
         original mode.
         """
-        model_mode = self.model.training
+        original_mode = self.model.training
         self.model.eval()
         one_sentence = [inference.make_input_from_multiple_strings(0, self.inputs_sentences[0])]
         _ = self.translator.translate(one_sentence)
-        self.model.train(model_mode)
+        self.model.train(original_mode)
 
 
 def parallel_subsample(parallel_sequences: List[List[Any]], sample_size: int, seed: int) -> List[Any]:

--- a/sockeye/checkpoint_decoder.py
+++ b/sockeye/checkpoint_decoder.py
@@ -85,7 +85,6 @@ class CheckpointDecoder:
         self.bucket_width_source = bucket_width_source
         self.length_penalty_alpha = length_penalty_alpha
         self.length_penalty_beta = length_penalty_beta
-        # TODO(mdenkows): Trace encoder/decoder even though inference_only=False
         self.model = model
 
         with ExitStack() as exit_stack:
@@ -149,6 +148,12 @@ class CheckpointDecoder:
         """
 
         # 1. Translate
+
+        # Store original mode and set to eval mode in case the model is not yet
+        # traced.
+        model_mode = self.model.training
+        self.model.eval()
+
         trans_wall_time = 0.0
         translations = []  # type: List[List[str]]
         with ExitStack() as exit_stack:
@@ -172,7 +177,11 @@ class CheckpointDecoder:
         avg_time = trans_wall_time / len(self.targets_sentences[0])
         translations = list(zip(*translations))  # type: ignore
 
+        # Restore original model mode
+        self.model.train(model_mode)
+
         # 2. Evaluate
+
         metrics = {C.BLEU: evaluate.raw_corpus_bleu(hypotheses=translations[0],
                                                     references=self.targets_sentences[0],
                                                     offset=0.01),
@@ -202,10 +211,16 @@ class CheckpointDecoder:
         return metrics
 
     def warmup(self):
-        """Translate a single sentence to warm up the model"""
+        """
+        Translate a single sentence to warm up the model. Set the model to eval
+        mode for tracing, translate the sentence, then set model back to its
+        original mode.
+        """
+        model_mode = self.model.training
+        self.model.eval()
         one_sentence = [inference.make_input_from_multiple_strings(0, self.inputs_sentences[0])]
         _ = self.translator.translate(one_sentence)
-
+        self.model.train(model_mode)
 
 def parallel_subsample(parallel_sequences: List[List[Any]], sample_size: int, seed: int) -> List[Any]:
     # custom random number generator to guarantee the same samples across runs in order to be able to

--- a/sockeye/checkpoint_decoder.py
+++ b/sockeye/checkpoint_decoder.py
@@ -222,6 +222,7 @@ class CheckpointDecoder:
         _ = self.translator.translate(one_sentence)
         self.model.train(model_mode)
 
+
 def parallel_subsample(parallel_sequences: List[List[Any]], sample_size: int, seed: int) -> List[Any]:
     # custom random number generator to guarantee the same samples across runs in order to be able to
     # compare metrics across independent runs

--- a/sockeye/checkpoint_decoder.py
+++ b/sockeye/checkpoint_decoder.py
@@ -213,7 +213,7 @@ class CheckpointDecoder:
     def warmup(self):
         """
         Translate a single sentence to warm up the model. Set the model to eval
-        mode for tracing, translate the sentence, then set model back to its
+        mode for tracing, translate the sentence, then set the model back to its
         original mode.
         """
         model_mode = self.model.training


### PR DESCRIPTION
This PR removes the `inference_only` branches from `SockeyeModel`'s `encode()` and `decode_step()` methods.  Behavior (including tracing submodules) is now the same whether or not `inference_only` is set.

When running the `CheckpointDecoder` during training, we make sure to set the model to eval mode.  This disables dropout when tracing components (desired behavior for decoding the validation data).

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

