### PR TITLE
Optimized creation of repeated_state by using expand instead of repeat_interleave.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.8]
+
+### Changed
+
+- Optimized creation of repeated_state by using `expand` instead of `repeat_interleave`.
+
 ## [3.1.7]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.7'
+__version__ = '3.1.8'

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -493,7 +493,7 @@ class RepeatStates(pt.nn.Module):
                 repeat_axis = 1
             else:
                 raise ValueError("Provided state format %s not recognized." % state_format)
-            repeated_state = state.repeat_interleave(repeats=self.beam_size, dim=repeat_axis)
+            repeated_state = utils.repeat_interleave_with_expand(state, repeats=self.beam_size, dim=repeat_axis)
             repeated_states.append(repeated_state)
         return repeated_states
 

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -251,7 +251,7 @@ class TransformerDecoder(Decoder):
             autoregr_states = [list(islice(states_iter, 0, layer.num_state_tensors)) for layer in self.layers]  # type: ignore
 
         batch, heads, target_max_len, source_max_len = source_mask.size()
-        source_mask_view = source_mask.view(batch * heads, target_max_len, source_max_len)
+        source_mask_view = source_mask.reshape(batch * heads, target_max_len, source_max_len)
 
         # target: (batch_size, length, model_size)
         target = self.pos_embedding(step_input, steps)

--- a/sockeye/decoder.py
+++ b/sockeye/decoder.py
@@ -251,7 +251,7 @@ class TransformerDecoder(Decoder):
             autoregr_states = [list(islice(states_iter, 0, layer.num_state_tensors)) for layer in self.layers]  # type: ignore
 
         batch, heads, target_max_len, source_max_len = source_mask.size()
-        source_mask_view = source_mask.reshape(batch * heads, target_max_len, source_max_len)
+        source_mask_reshape = source_mask.reshape(batch * heads, target_max_len, source_max_len)
 
         # target: (batch_size, length, model_size)
         target = self.pos_embedding(step_input, steps)
@@ -266,7 +266,7 @@ class TransformerDecoder(Decoder):
             target, new_layer_autoregr_state = layer(target=target,
                                                      target_mask=target_mask,
                                                      source=source_encoded,
-                                                     source_mask=source_mask_view,
+                                                     source_mask=source_mask_reshape,
                                                      autoregr_states=layer_autoregr_state,
                                                      enc_att_kv=layer_enc_att_kv)
 

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -488,6 +488,21 @@ def grouper(iterable: Iterable, size: int) -> Iterable:
         yield chunk
 
 
+def repeat_interleave_with_expand(state: pt.Tensor, repeats: int, dim: int) -> pt.Tensor:
+    """
+    Replace repeat_interleave with expand for latency (i.e. equivalent to state.repeat_interleave(repeats=num_of_repeat, dim=dim))
+    :param state: a pt.Tensor
+    :param repeats: int
+    :param dim: int
+    :return repeat_state
+    """
+    repeat_state_size = list(state.size())
+    repeat_state_size[dim] = repeat_state_size[dim] * repeats  # type: List[int]
+    expand_size = [-1 for _ in range(len(repeat_state_size) + 1)]  # type: List[int]
+    expand_size[dim +1] = repeats
+    return state.unsqueeze(dim + 1).expand(expand_size).reshape(repeat_state_size)
+
+
 def metric_value_is_better(new: float, old: float, metric: str) -> bool:
     """
     Returns true if new value is strictly better than old for given metric.

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -496,10 +496,10 @@ def repeat_interleave_with_expand(state: pt.Tensor, repeats: int, dim: int) -> p
     :param dim: int
     :return repeat_state
     """
-    repeat_state_size = list(state.size())
-    repeat_state_size[dim] = repeat_state_size[dim] * repeats  # type: List[int]
+    repeat_state_size = list(state.size())  # type: List[int]
+    repeat_state_size[dim] = repeat_state_size[dim] * repeats
     expand_size = [-1 for _ in range(len(repeat_state_size) + 1)]  # type: List[int]
-    expand_size[dim +1] = repeats
+    expand_size[dim + 1] = repeats
     return state.unsqueeze(dim + 1).expand(expand_size).reshape(repeat_state_size)
 
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -252,6 +252,19 @@ def test_write_read_metric_file():
     assert expected_metrics == read_metrics
 
 
+def test_repeat_interleave_with_expand():
+    beam_size = 5
+    state = pt.rand(2, 1024)
+    assert pt.equal(state.repeat_interleave(beam_size, dim=0), utils.repeat_interleave_with_expand(state, beam_size, 0))
+    assert pt.equal(state.repeat_interleave(beam_size, dim=1), utils.repeat_interleave_with_expand(state, beam_size, 1))
+    state = pt.rand(2, 3, 1024)
+    assert pt.equal(state.repeat_interleave(beam_size, dim=0), utils.repeat_interleave_with_expand(state, beam_size, 0))
+    assert pt.equal(state.repeat_interleave(beam_size, dim=1), utils.repeat_interleave_with_expand(state, beam_size, 1))
+    state = pt.rand(2, 3, 4, 1024)
+    assert pt.equal(state.repeat_interleave(beam_size, dim=0), utils.repeat_interleave_with_expand(state, beam_size, 0))
+    assert pt.equal(state.repeat_interleave(beam_size, dim=1), utils.repeat_interleave_with_expand(state, beam_size, 1))
+
+
 def test_adjust_first_step_masking():
     first_step_mask = pt.tensor([[0.],
                                  [np.inf],


### PR DESCRIPTION
Replacing Pytorch's repeat_interleave function with a customized function repeat_interleave_with_expand reduces 48% latency on GPU (K80) and 41% latency on CPU on the creation of repeated_state. This could be worthy to consider given that `RepeatStates` is called numerous times during inference.

Comparison Code:
```
import timeit
set_up_line = """
import torch as pt
pt.manual_seed(1)
beam_size = 5
batch_size = 32
a = pt.rand(7, 2, 1024)
def repeat_interleave_with_expand(state, num_of_repeat, dim):
    state_size = list(state.size())
    expand_state_size = [-1 for _ in range(len(state_size) + 1)]
    state_size[dim] = state_size[dim] * num_of_repeat
    expand_state_size[dim +1] = num_of_repeat
    return state.unsqueeze(dim + 1).expand(expand_state_size).reshape(state_size)
"""
executive_line = """
a1 = repeat_interleave_with_expand(a, beam_size, 0)
a2 = repeat_interleave_with_expand(a, beam_size, 1)
"""
timeit.timeit(executive_line,setup=set_up_line, number=10000)
#gpu: 0.5507124290015781
#cpu: 0.5074962430226151

executive_line = """
a1 = a.repeat_interleave(beam_size, dim=0)
a2 = a.repeat_interleave(beam_size, dim=1)
"""
timeit.timeit(executive_line,setup=set_up_line, number=10000)
#gpu: 1.048011115999543
#cpu: 0.8592731970129535
```
<del>Side note: I still don't know yet why I have to change the code (decoder.py) from 
```source_mask_view = source_mask.view(batch * heads, target_max_len, source_max_len)```
to
```source_mask_view = source_mask.reshape(batch * heads, target_max_len, source_max_len)```
in order to pass `test/integration/test_backwards_compatibility.py` during running `pytest`.</del>


#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

