### PR TITLE
Do not save parameters for traced modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.8]
+
+### Fixed
+
+- When saving parameters, SockeyeModel now skips parameters for traced modules because these modules are created at runtime and use the same parameters as non-traced versions. When loading parameters, SockeyeModel ignores parameters for traced modules that may have been saved by earlier versions.
+
 ## [3.1.7]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.7'
+__version__ = '3.1.8'

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -47,7 +47,7 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --transformer-feed-forward-num-hidden 16"
      " --transformer-dropout-prepost 0.1 --transformer-preprocess n --transformer-postprocess dr"
      " --weight-tying-type src_trg_softmax"
-     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
+     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 2"
      # Note: We set the checkpoint interval > max updates in order to make sure we create a checkpoint when reaching
      # max updates independent of the checkpoint interval
      " --checkpoint-interval 20 --optimizer adam --initial-learning-rate 0.01 --learning-rate-scheduler none",
@@ -59,7 +59,7 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --transformer-feed-forward-num-hidden 16"
      " --transformer-dropout-prepost 0.1 --transformer-preprocess n --transformer-postprocess dr"
      " --weight-tying-type src_trg"
-     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
+     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 2"
      " --checkpoint-interval 2 --optimizer adam --initial-learning-rate 0.01",
      "--beam-size 1 --greedy",
      True, 0, 0),
@@ -69,7 +69,7 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --transformer-feed-forward-num-hidden 16"
      " --transformer-dropout-prepost 0.1 --transformer-preprocess n --transformer-postprocess dr"
      " --weight-tying-type trg_softmax"
-     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
+     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 2"
      " --checkpoint-interval 2 --optimizer adam --initial-learning-rate 0.01"
      " --source-factors-combine sum concat average --source-factors-share-embedding true false true"
      " --source-factors-num-embed 8 2 8"
@@ -83,7 +83,7 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --transformer-feed-forward-num-hidden 16"
      " --transformer-dropout-prepost 0.1 --transformer-preprocess n --transformer-postprocess dr"
      " --weight-tying-type src_trg_softmax"
-     " --batch-size 2 --max-updates 2 --batch-type sentence  --decode-and-evaluate 0"
+     " --batch-size 2 --max-updates 2 --batch-type sentence  --decode-and-evaluate 2"
      " --checkpoint-interval 2 --optimizer adam --initial-learning-rate 0.01 --lhuc all",
      "--beam-size 2",
      False, 0, 0),
@@ -93,7 +93,7 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --transformer-feed-forward-num-hidden 16"
      " --transformer-dropout-prepost 0.1 --transformer-preprocess n --transformer-postprocess dr"
      " --weight-tying-type src_trg_softmax"
-     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
+     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 2"
      " --checkpoint-interval 2 --optimizer adam --initial-learning-rate 0.01"
      " --length-task ratio --length-task-weight 1.0 --length-task-layers 1",
      "--beam-size 2"
@@ -105,7 +105,7 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --transformer-feed-forward-num-hidden 16"
      " --transformer-dropout-prepost 0.1 --transformer-preprocess n --transformer-postprocess dr"
      " --weight-tying-type src_trg_softmax"
-     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
+     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 2"
      " --checkpoint-interval 2 --optimizer adam --initial-learning-rate 0.01"
      " --length-task length --length-task-weight 1.0 --length-task-layers 1",
      "--beam-size 2"
@@ -117,7 +117,7 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --transformer-feed-forward-num-hidden 16"
      " --transformer-dropout-prepost 0.1 --transformer-preprocess n --transformer-postprocess dr"
      " --weight-tying-type src_trg_softmax"
-     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 0"
+     " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 2"
      " --checkpoint-interval 2 --optimizer adam --initial-learning-rate 0.01"
      " --fixed-param-strategy " + C.FIXED_PARAM_STRATEGY_ALL_EXCEPT_DECODER,
      "--beam-size 2",
@@ -165,7 +165,7 @@ def test_seq_copy(train_params: str,
 
 TINY_TEST_MODEL = [(" --num-layers 2 --transformer-attention-heads 2 --transformer-model-size 4 --num-embed 4"
                     " --transformer-feed-forward-num-hidden 4 --weight-tying-type src_trg_softmax"
-                    " --batch-size 2 --batch-type sentence --max-updates 4 --decode-and-evaluate 0"
+                    " --batch-size 2 --batch-type sentence --max-updates 4 --decode-and-evaluate 2"
                     " --checkpoint-interval 4",
                     "--beam-size 1")]
 

--- a/test/system/test_seq_copy_sys.py
+++ b/test/system/test_seq_copy_sys.py
@@ -43,7 +43,7 @@ seed = random.randint(0, 1000)
 
 
 COMMON_TRAINING_PARAMS = " --checkpoint-interval 1000 --optimizer adam --initial-learning-rate 0.001" \
-                         " --decode-and-evaluate 0 --label-smoothing 0.0" \
+                         " --decode-and-evaluate 2 --label-smoothing 0.0" \
                          " --optimized-metric perplexity --weight-tying-type src_trg_softmax"
 
 


### PR DESCRIPTION
At runtime, `SockeyeModel` traces several modules with PyTorch's JIT compiler.  The traced modules use the same parameters as the non-traced versions, but PyTorch considers them to be separate modules when creating state dictionaries.  This means that saving the model with `save_parameters()` includes parameters for traced as well as non-traced modules.  In addition to being redundant, parameters for traced modules cause errors at load time if the traced modules do not yet exist (original modules haven't been traced yet).

In this commit, `save_parameters()` filters out keys for traced module parameters and `load_parameters()` ignores keys for traced module parameters that may have been saved by earlier versions of Sockeye.  The commit also turns on checkpoint decoding for integration and system tests as this was one of the cases that caused traced parameters to be saved.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

