### PR TITLE
Ignore false-positive missing keys for traced modules when loading model parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.10]
+
+### Fixed
+
+- When loading parameters, SockeyeModel now ignores false positive missing parameters for traced modules. These modules use the same parameters as their original non-traced versions.
+
 ## [3.1.9]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.9'
+__version__ = '3.1.10'

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -362,6 +362,11 @@ class SockeyeModel(pt.nn.Module):
         # Earlier versions of Sockeye may have saved parameters for traced
         # modules. These parameters can be safely ignored.
         unexpected = [key for key in unexpected if 'traced' not in key]
+        # We also ignore cases where traced modules exist and appear to be
+        # missing parameters. These modules actually use the same parameters as
+        # their original non-traced versions so there are no separate parameters
+        # to load.
+        missing = [key for key in missing if 'traced' not in key]
         if not allow_missing:
             utils.check_condition(not missing, f"missing keys: {missing}")
         if not ignore_extra:

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -231,7 +231,10 @@ def _test_parameter_averaging(model_path: str):
 
 def _test_checkpoint_decoder(dev_source_path: str, dev_target_path: str, model_path: str):
     """
-    Runs checkpoint decoder on 10% of the dev data and checks whether metric keys are present in the result dict.
+    Runs checkpoint decoder on 10% of the dev data and checks whether metric
+    keys are present in the result dict. Also checks that we can reload model
+    parameters after running the checkpoint decoder (case when using the
+    plateau-reduce scheduler).
     """
     with open(dev_source_path) as dev_fd:
         num_dev_sent = sum(1 for _ in dev_fd)
@@ -254,3 +257,5 @@ def _test_checkpoint_decoder(dev_source_path: str, dev_target_path: str, model_p
     assert 'bleu' in cp_metrics
     assert 'chrf' in cp_metrics
     assert 'decode-walltime' in cp_metrics
+
+    model.load_parameters(os.path.join(model_path, C.PARAMS_BEST_NAME), device=pt.device('cpu'))


### PR DESCRIPTION
This is the sequel to #1036.

When we load model parameters, any traced modules that exist appear to be missing their parameters.  Traced modules actually use the same parameters as their original non-traced versions, so no separate parameters exist and there's nothing extra to load.

This PR adds logic for filtering out false positive "missing" keys for traced modules and adds an integration test for reloading model parameters after running a checkpoint decoder (case where the incorrect loading behavior was first observed).

Thanks to @SamuelLarkin for reporting this issue (#1040).



#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

