### PR TITLE
Do not create incorrect checkpoints when resuming training with a fully trained model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.11]
+
+### Fixed
+
+- When resuming training with a fully trained model, `sockeye-train` will correctly exit without creating a duplicate (but separately numbered) checkpoint.
+
 ## [3.1.10]
 
 ### Fixed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.10'
+__version__ = '3.1.11'

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -209,7 +209,9 @@ class EarlyStoppingTrainer:
                         self.config.max_updates,
                         self.config.max_checkpoints)
 
-        checkpoint_up_to_date = False
+        # At the start of training, the checkpoint is only up to date if it has
+        # just been loaded (resuming training with an existing model directory).
+        checkpoint_up_to_date = resume_training
         while True:
             if self.config.max_epochs is not None and self.state.epoch == self.config.max_epochs:
                 logger.info("Maximum # of epochs (%s) reached.", self.config.max_epochs)


### PR DESCRIPTION
This PR updates `sockeye-train` to consider the current (just loaded) checkpoint up-to-date when resuming training.

When running the same `sockeye-train` command multiple times, runs after the first detect that a model exists, load the last checkpoint, and exit without running any updates because the stopping conditions are already met.

Before this change, Sockeye also thought it needed to create a final checkpoint because the current (loaded) checkpoint was not up-to-date. This led to additional checkpoints with increasing numbers but the same parameters. These incorrect checkpoints disrupt parameter averaging and other post-training steps.

After this change, Sockeye exits as expected without producing an incorrect checkpoint.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

