### PR TITLE
Fix scoring with batches of size 1 by avoid squeezing the batch dim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.12]
+
+### Fixed
+
+- Fix scoring with batches of size 1 (whic may occur when `|data| % batch_size == 1`.
+
 ## [3.1.11]
 
 ### Fixed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.11'
+__version__ = '3.1.12'

--- a/sockeye/scoring.py
+++ b/sockeye/scoring.py
@@ -64,7 +64,7 @@ class BatchScorer(pt.nn.Module):
 
         # Select the label log probability
         # logprobs and scores: (batch_size, target_seq_len)
-        token_scores = logprobs.gather(dim=-1, index=labels.unsqueeze(-1)).squeeze()
+        token_scores = logprobs.gather(dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
         if self.score_type == C.SCORING_TYPE_NEGLOGPROB:
             token_scores = -token_scores
 
@@ -80,7 +80,7 @@ class BatchScorer(pt.nn.Module):
             factor_scores = []  # type: List[pt.Tensor]
             for factor_logit, factor_label in factor_logits_and_labels:
                 factor_logprobs = factor_logit.log_softmax(dim=-1)
-                factor_token_scores = factor_logprobs.gather(dim=-1, index=factor_label.unsqueeze(-1)).squeeze()
+                factor_token_scores = factor_logprobs.gather(dim=-1, index=factor_label.unsqueeze(-1)).squeeze(-1)
                 if self.score_type == C.SCORING_TYPE_NEGLOGPROB:
                     factor_token_scores = -factor_token_scores
                 fs = factor_token_scores.masked_fill_(factor_label == C.PAD_ID, .0).sum(dim=-1, keepdims=True)  # type: ignore


### PR DESCRIPTION
Makes sure that batches of size 1 in scoring are handled properly and the call to `squeeze` does not accidentally remove the batch dim of size 1. Change: `squeeze()` -> `squeeze(-1)`.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [ ] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

