### PR TITLE
Option to not reload the best training checkpoint when reducing the learning rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.13]
+
+### Added
+
+- Added `sockeye-train` argument `--no-reload-on-learning-rate-reduce` that disables reloading the best training checkpoint when reducing the learning rate. This currently only applies to the `plateau-reduce` learning rate scheduler since other schedulers do not reload checkpoints.
+
 ## [3.1.12]
 
 ### Fixed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.12'
+__version__ = '3.1.13'

--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -958,6 +958,12 @@ def add_training_args(params):
                               default=0,
                               help="Number of warmup steps. If set to x, linearly increases learning rate from 10%% "
                                    "to 100%% of the initial learning rate. Default: %(default)s.")
+    train_params.add_argument('--no-reload-on-learning-rate-reduce',
+                              action='store_true',
+                              default=False,
+                              help='Do not reload the best training checkpoint when reducing the learning rate. '
+                                   'Default: %(default)s.')
+
 
     train_params.add_argument('--fixed-param-strategy',
                               default=None,

--- a/sockeye/train.py
+++ b/sockeye/train.py
@@ -967,7 +967,8 @@ def train(args: argparse.Namespace, custom_metrics_logger: Optional[Callable] = 
                                             max_epochs=args.max_num_epochs,
                                             max_seconds=args.max_seconds,
                                             update_interval=args.update_interval,
-                                            stop_training_on_decoder_failure=args.stop_training_on_decoder_failure)
+                                            stop_training_on_decoder_failure=args.stop_training_on_decoder_failure,
+                                            no_reload_on_learning_rate_reduce=args.no_reload_on_learning_rate_reduce)
     if trainer_config.min_epochs is not None and trainer_config.max_epochs is not None:
         check_condition(trainer_config.min_epochs <= trainer_config.max_epochs,
                         "Minimum number of epochs must be smaller than maximum number of epochs")

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -73,6 +73,7 @@ class TrainerConfig(Config):
     max_seconds: Optional[int] = None
     update_interval: int = 1
     stop_training_on_decoder_failure: bool = False
+    no_reload_on_learning_rate_reduce: bool = False
 
 
 class TrainState:
@@ -549,7 +550,7 @@ class EarlyStoppingTrainer:
                 lr_adjusted = scheduler.new_evaluation_result(has_improved)  # type: ignore
             else:
                 lr_adjusted = False
-            if lr_adjusted and not has_improved:
+            if lr_adjusted and not has_improved and not self.config.no_reload_on_learning_rate_reduce:
                 logger.info("Loading model parameters and optimizer states from best checkpoint: %d",
                             self.state.best_checkpoint)
                 if os.path.exists(self.best_params_fname):

--- a/test/unit/test_arguments.py
+++ b/test/unit/test_arguments.py
@@ -207,6 +207,7 @@ def test_inference_args(test_params, expected_params):
               learning_rate_reduce_factor=0.9,
               learning_rate_reduce_num_not_improved=8,
               learning_rate_warmup=0,
+              no_reload_on_learning_rate_reduce=False,
               fixed_param_names=[],
               fixed_param_strategy=None,
               decode_and_evaluate=500,


### PR DESCRIPTION
This PR adds an option to disable reloading the best training checkpoint (model parameters and optimizer state) when reducing the learning rate. This currently only applies to the `plateau-reduce` scheduler since other schedulers do not trigger checkpoint reloading.

Disabling checkpoint reloading can help in cases where the noise between checkpoints can dominate the improvement between checkpoints and cause training to get stuck on a "lucky" checkpoint.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

