### PR TITLE
Fix data type of valid_length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.15]
+
+### Fixed
+
+- Fix type of valid_length to be pt.Tensor instead of Optional[pt.Tensor] = None for jit tracing
+
 ## [3.1.14]
 
 ### Added

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.14'
+__version__ = '3.1.15'

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -39,7 +39,7 @@ class _Inference(ABC):
     @abstractmethod
     def encode_and_initialize(self,
                               inputs: pt.Tensor,
-                              valid_length: Optional[pt.Tensor] = None):
+                              valid_length: pt.Tensor):
         raise NotImplementedError()
 
     @abstractmethod
@@ -73,7 +73,7 @@ class _SingleModelInference(_Inference):
     def state_structure(self) -> List:
         return [self._model.state_structure()]
 
-    def encode_and_initialize(self, inputs: pt.Tensor, valid_length: Optional[pt.Tensor] = None):
+    def encode_and_initialize(self, inputs: pt.Tensor, valid_length: pt.Tensor):
         states, predicted_output_length, nvs_prediction = self._model.encode_and_initialize(inputs, valid_length, self._const_lr)
         return states, predicted_output_length, nvs_prediction
 
@@ -133,7 +133,7 @@ class _EnsembleInference(_Inference):
     def state_structure(self) -> List:
         return [model.state_structure() for model in self._models]
 
-    def encode_and_initialize(self, inputs: pt.Tensor, valid_length: Optional[pt.Tensor] = None):
+    def encode_and_initialize(self, inputs: pt.Tensor, valid_length: pt.Tensor):
         model_states = []  # type: List[pt.Tensor]
         predicted_output_lengths = []  # type: List[pt.Tensor]
         nvs_predictions = []

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -174,7 +174,7 @@ class SockeyeModel(pt.nn.Module):
     def state_structure(self):
         return self.decoder.state_structure()
 
-    def encode(self, inputs: pt.Tensor, valid_length: Optional[pt.Tensor] = None) -> Tuple[pt.Tensor, pt.Tensor, pt.Tensor]:
+    def encode(self, inputs: pt.Tensor, valid_length: pt.Tensor) -> Tuple[pt.Tensor, pt.Tensor, pt.Tensor]:
         """
         Encodes the input sequence.
 
@@ -192,7 +192,7 @@ class SockeyeModel(pt.nn.Module):
         source_encoded, source_encoded_length, att_mask = self.traced_encoder(source_embed, valid_length)
         return source_encoded, source_encoded_length, att_mask
 
-    def encode_and_initialize(self, inputs: pt.Tensor, valid_length: Optional[pt.Tensor] = None,
+    def encode_and_initialize(self, inputs: pt.Tensor, valid_length: pt.Tensor,
                               constant_length_ratio: float = 0.0) -> Tuple[List[pt.Tensor], pt.Tensor,
                                                                            Optional[pt.Tensor]]:
         """
@@ -200,7 +200,7 @@ class SockeyeModel(pt.nn.Module):
         Used for inference/decoding.
 
         :param inputs: Source input data. Shape: (batch_size, length, num_source_factors).
-        :param valid_length: Optional Tensor of sequence lengths within this batch. Shape: (batch_size,)
+        :param valid_length: Tensor of sequence lengths within this batch. Shape: (batch_size,)
         :param constant_length_ratio: Constant length ratio
         :return: Initial states for the decoder, predicted output length of shape (batch_size,), 0 if not available.
                  Returns the neural vocabulary selection model prediction if enabled, None otherwise.


### PR DESCRIPTION
(description of the change)

Fix type of `valid_length` to be pt.Tensor instead of Optional[pt.Tensor] = None for `jit tracing`.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

