### PR TITLE
Change decoder softmax size logging level from info to debug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.23]
+
+### Changed
+
+- Change decoder softmax size logging level from info to debug.
+
 ## [3.1.22]
 
 ### Added

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.22'
+__version__ = '3.1.23'

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -640,7 +640,7 @@ class Search(pt.nn.Module):
         self.output_vocab_sizes.update(size)
 
     def log_search_stats(self):
-        logger.info(f'decoder softmax size: {self.output_vocab_sizes.mean:.1f} (avg)')
+        logger.debug(f'decoder softmax size: {self.output_vocab_sizes.mean:.1f} (avg)')
 
 
 class GreedySearch(Search):


### PR DESCRIPTION
This PR changes the logging level for decoder softmax size messages to `debug` to avoid printing log lines for each input.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

