### PR TITLE
Update DeepSpeed checkpoint conversion to support newer DeepSpeed versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.24]
+
+### Fixed
+
+- Updated DeepSpeed checkpoint conversion to support newer versions of DeepSpeed.
+
 ## [3.1.23]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.23'
+__version__ = '3.1.24'

--- a/sockeye/constants.py
+++ b/sockeye/constants.py
@@ -157,6 +157,7 @@ DECODE_IN_NAME = "decode.source.{factor}"
 DECODE_REF_NAME = "decode.target.{factor}"
 METRICS_NAME = "metrics"
 TENSORBOARD_NAME = "tensorboard"
+DEEPSPEED_LATEST_NAME = "latest"
 
 # training resumption constants
 TRAINING_STATE_DIRNAME = "training_state"

--- a/sockeye/convert_deepspeed.py
+++ b/sockeye/convert_deepspeed.py
@@ -12,17 +12,23 @@
 # permissions and limitations under the License.
 
 import argparse
+import collections
 import gc
 import logging
 import os
 import shutil
 
+import torch
+
 from . import constants as C
+from . import log
 from . import model
+from . import utils
 
 try:
-    import deepspeed
-    import deepspeed.utils.zero_to_fp32
+    from deepspeed.checkpoint.constants import OPTIMIZER_STATE_DICT, PARTITION_COUNT, SINGLE_PARTITION_OF_FP32_GROUPS
+    from deepspeed.utils.zero_to_fp32 import (_get_fp32_state_dict_from_zero2_checkpoint, get_model_state_file,
+                                              get_optim_files, parse_model_state)
 except ImportError:
     pass
 
@@ -30,12 +36,38 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def get_fp32_state_dict_from_zero1_checkpoint(checkpoint_dir: str) -> collections.OrderedDict:
+    """
+    Simplified version of DeepSpeed's FP32 state dict reconstruction for ZeRO
+    stage 1.
+
+    :param checkpoint_dir: DeepSpeed checkpoint directory.
+    :return: FP32 model state dictionary.
+    """
+    # Find latest checkpoint
+    with utils.smart_open(os.path.join(checkpoint_dir, C.DEEPSPEED_LATEST_NAME)) as tag_in:
+        tag = tag_in.readline().strip()
+    checkpoint_dir = os.path.join(checkpoint_dir, tag)
+    # Load state dictionaries from all ranks (sockeye-train workers)
+    optim_files = get_optim_files(checkpoint_dir)
+    state_dicts = [torch.load(fname, map_location=torch.device('cpu')) for fname in optim_files]
+    # Collect data from state dicts
+    _world_size = state_dicts[0][OPTIMIZER_STATE_DICT][PARTITION_COUNT]
+    world_size = max(_world_size) if isinstance(_world_size, list) else world_size
+    fp32_flat_groups = [state_dict[OPTIMIZER_STATE_DICT][SINGLE_PARTITION_OF_FP32_GROUPS] for state_dict in state_dicts]
+    # Load model state. Stage 1 uses the same state file as stage 2.
+    model_state_file = get_model_state_file(checkpoint_dir, zero_stage=2)
+    buffers, param_shapes, _ = parse_model_state(file=model_state_file)
+    # Reconstruct FP32 state dict from all of the above
+    return _get_fp32_state_dict_from_zero2_checkpoint(world_size, param_shapes, fp32_flat_groups, buffers)
+
+
 def convert_checkpoint_to_params(model_config_fname: str, checkpoint_dirname: str, params_fname: str):
     # Create a temporary SockeyeModel
     model_config = model.SockeyeModel.load_config(model_config_fname)
     sockeye_model = model.SockeyeModel(model_config)
     # Gather the float32 params on CPU
-    state_dict = deepspeed.utils.zero_to_fp32.get_fp32_state_dict_from_zero_checkpoint(checkpoint_dirname)
+    state_dict = get_fp32_state_dict_from_zero1_checkpoint(checkpoint_dirname)
     # Strip the first prefix from each param name to match the SockeyeModel
     # Ex: 'model.encoder.layers...' -> 'encoder.layers...'
     state_dict = {name[name.find('.') + 1:]: param for (name, param) in state_dict.items()}
@@ -74,6 +106,7 @@ def convert_model_checkpoints(model_dirname: str, keep_deepspeed: bool = False):
 
 
 def main():
+    log.setup_main_logger(console=True, file_logging=False)
     params = argparse.ArgumentParser(
         description="Convert DeepSpeed checkpoints to regular parameter files in a Sockeye model directory.")
     params.add_argument('--model', '-m',

--- a/sockeye/convert_deepspeed.py
+++ b/sockeye/convert_deepspeed.py
@@ -53,7 +53,7 @@ def get_fp32_state_dict_from_zero1_checkpoint(checkpoint_dir: str) -> collection
     state_dicts = [torch.load(fname, map_location=torch.device('cpu')) for fname in optim_files]
     # Collect data from state dicts
     _world_size = state_dicts[0][OPTIMIZER_STATE_DICT][PARTITION_COUNT]
-    world_size = max(_world_size) if isinstance(_world_size, list) else world_size
+    world_size = max(_world_size) if isinstance(_world_size, list) else _world_size
     fp32_flat_groups = [state_dict[OPTIMIZER_STATE_DICT][SINGLE_PARTITION_OF_FP32_GROUPS] for state_dict in state_dicts]
     # Load model state. Stage 1 uses the same state file as stage 2.
     model_state_file = get_model_state_file(checkpoint_dir, zero_stage=2)


### PR DESCRIPTION
When training with DeepSpeed, model checkpoints are saved in DeepSpeed's sharded format. Our `convert_deepspeed` module converts these checkpoints to regular FP32 Sockeye parameter files automatically at the end of training or manually via the `sockeye-convert-deepspeed` CLI.

Newer versions of DeepSpeed change the way they track checkpoint formats. As a side effect, they do not correctly handle the format we use for Sockeye (ZeRO stage 1). This PR updates the `convert_deepspeed` module to convert checkpoints correctly without relying on DeepSpeed's automatic format detection.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

