### PR TITLE
Update to sacrebleu 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.25]
+
+## Changed
+- Updated to sacrebleu==2.3.1. Changed default BLEU floor smoothing offset from 0.01 to 0.1.
+
 ## [3.1.24]
 
 ### Fixed

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 torch>=1.10.0,<1.12.0
 pyyaml>=5.1
 numpy>1.16.0,<2.0.0
-sacrebleu==1.4.14
+sacrebleu>=2.3.0

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.24'
+__version__ = '3.1.25'

--- a/sockeye/checkpoint_decoder.py
+++ b/sockeye/checkpoint_decoder.py
@@ -184,7 +184,7 @@ class CheckpointDecoder:
 
         metrics = {C.BLEU: evaluate.raw_corpus_bleu(hypotheses=translations[0],
                                                     references=self.targets_sentences[0],
-                                                    offset=0.01),
+                                                    offset=evaluate.DEFAULT_OFFSET),
                    C.CHRF: evaluate.raw_corpus_chrf(hypotheses=translations[0],
                                                     references=self.targets_sentences[0]),
                    C.ROUGE1: evaluate.raw_corpus_rouge1(hypotheses=translations[0],
@@ -206,7 +206,7 @@ class CheckpointDecoder:
                 metrics.update(
                     {'f%d-%s' % (i, C.BLEU): evaluate.raw_corpus_bleu(hypotheses=translations[i],
                                                                       references=self.targets_sentences[i],
-                                                                      offset=0.01)}
+                                                                      offset=evaluate.DEFAULT_OFFSET)}
                 )
         return metrics
 

--- a/sockeye/evaluate.py
+++ b/sockeye/evaluate.py
@@ -34,9 +34,13 @@ from .log import setup_main_logger, log_sockeye_version
 logger = logging.getLogger(__name__)
 
 
-def raw_corpus_bleu(hypotheses: Iterable[str], references: Iterable[str], offset: Optional[float] = 0.01) -> float:
+DEFAULT_OFFSET = sacrebleu.BLEU.SMOOTH_DEFAULTS['floor']  # 0.1
+
+
+def raw_corpus_bleu(hypotheses: Iterable[str], references: Iterable[str],
+                    offset: Optional[float] = DEFAULT_OFFSET) -> float:
     """
-    Simple wrapper around sacreBLEU's BLEU without tokenization and smoothing.
+    Simple wrapper around sacreBLEU's BLEU without tokenization and floor smoothing.
 
     :param hypotheses: Hypotheses stream.
     :param references: Reference stream.

--- a/sockeye/rerank.py
+++ b/sockeye/rerank.py
@@ -80,14 +80,15 @@ class Reranker:
                       hypothesis in hypotheses['translations']]
             # BLEU, CHRF - the higher, the better
             ranking = self.ranking_indices(scores)
-
-        if self.metric.startswith(C.RERANK_ISOMETRIC):
+        elif self.metric.startswith(C.RERANK_ISOMETRIC):
             source = hypotheses['text']
             # pylint: disable=redundant-keyword-arg
-            scores = [self.scoring_function(hypothesis, hypothesis_score[0], source) for
+            scores = [self.scoring_function(hypothesis, hypothesis_score[0], source) for  # type: ignore
                       hypothesis, hypothesis_score in zip(hypotheses['translations'], hypotheses['scores'])]
             # isometric-lc - the smaller, the better
             ranking = self.ranking_indices(scores)
+        else:
+            raise utils.SockeyeError("Scoring metric '%s' unknown. Choices are: %s" % (self.metric, C.RERANK_METRICS))
 
         reranked_hypotheses = self._sort_by_ranking(hypotheses, ranking)
         if self.return_score:

--- a/test/unit/test_chrf.py
+++ b/test/unit/test_chrf.py
@@ -41,7 +41,6 @@ test_cases_keep_whitespace = [
 @pytest.mark.parametrize("hypotheses, references, expected_score", test_cases)
 def test_chrf(hypotheses, references, expected_score):
     score = sacrebleu.corpus_chrf(hypotheses, [references], char_order=6, beta=3).score / 100.0
-    print(score, expected_score)
     assert abs(score - expected_score) < EPSILON
 
 

--- a/test/unit/test_chrf.py
+++ b/test/unit/test_chrf.py
@@ -40,11 +40,12 @@ test_cases_keep_whitespace = [
 
 @pytest.mark.parametrize("hypotheses, references, expected_score", test_cases)
 def test_chrf(hypotheses, references, expected_score):
-    score = sacrebleu.corpus_chrf(hypotheses, [references], 6, 3).score
+    score = sacrebleu.corpus_chrf(hypotheses, [references], char_order=6, beta=3).score / 100.0
+    print(score, expected_score)
     assert abs(score - expected_score) < EPSILON
 
 
 @pytest.mark.parametrize("hypotheses, references, expected_score", test_cases_keep_whitespace)
 def test_chrf_keep_whitespace(hypotheses, references, expected_score):
-    score = sacrebleu.corpus_chrf(hypotheses, [references], 6, 3, remove_whitespace=False).score
+    score = sacrebleu.corpus_chrf(hypotheses, [references], char_order=6, beta=3, remove_whitespace=False).score / 100.0
     assert abs(score - expected_score) < EPSILON


### PR DESCRIPTION
update default floor smoothing offset to 0.1 (which is the default in sacrebleu), removed a few unnecessary tests and adapted others.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

