### PR TITLE
BFloat16 Integration/System Test Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 ### Fixed
 
 - Fixed sequence copying integration tests to correctly specify that scoring/translation outputs should not be checked.
-- The above fix enables `bfloat32` testing on all platforms.
+- Enabled `bfloat16` integration and system testing on all platforms.
 
 ## [3.1.30]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.31]
+
+### Fixed
+
+- Fixed sequence copying integration tests to correctly specify that scoring/translation outputs should not be checked.
+- The above fix enables `bfloat32` testing on all platforms.
+
 ## [3.1.30]
 
 ### Added

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.30'
+__version__ = '3.1.31'

--- a/test/common.py
+++ b/test/common.py
@@ -53,13 +53,13 @@ def check_train_translate(train_params: str,
     # may differ.
     if 'greedy' not in translate_params and 'neural-vocab-selection' not in train_params:
         translate_params_batch = translate_params + " --batch-size 2"
-        test_translate_equivalence(data, translate_params_batch, compare_output=True)
+        test_translate_equivalence(data, translate_params_batch, compare_output=compare_output)
 
     # Run translate with restrict-lexicon
     if 'neural-vocab-selection ' not in train_params:
         data = run_translate_restrict(data, translate_params)
 
-    test_translate_equivalence(data, translate_params, compare_output=True)
+    test_translate_equivalence(data, translate_params, compare_output=compare_output)
 
     # Test scoring by ensuring that the sockeye.scoring module produces the same scores when scoring the output
     # of sockeye.translate. However, since this training is on very small datasets, the output of sockeye.translate

--- a/test/integration/test_seq_copy_int.py
+++ b/test/integration/test_seq_copy_int.py
@@ -133,8 +133,7 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --checkpoint-interval 2 --optimizer adam --initial-learning-rate 0.01 --clamp-to-dtype",
      "--beam-size 2 --clamp-to-dtype",
      False, 0, 0),
-    # Basic transformer, training only the decoder with bfloat16 inference when
-    # running on Linux
+    # Basic transformer, training only the decoder with bfloat16 inference
     ("--encoder transformer --decoder {decoder}"
      " --num-layers 2 --transformer-attention-heads 2 --transformer-model-size 8 --num-embed 8"
      " --transformer-feed-forward-num-hidden 16"
@@ -143,7 +142,7 @@ ENCODER_DECODER_SETTINGS_TEMPLATE = [
      " --batch-size 2 --max-updates 2 --batch-type sentence --decode-and-evaluate 2"
      " --checkpoint-interval 2 --optimizer adam --initial-learning-rate 0.01"
      " --fixed-param-strategy " + C.FIXED_PARAM_STRATEGY_ALL_EXCEPT_DECODER,
-     "--beam-size 2" + (" --dtype bfloat16" if platform.system() == "Linux" else ""),
+     "--beam-size 2 --dtype bfloat16",
      False, 0, 0),
 ]
 

--- a/test/system/test_seq_copy_sys.py
+++ b/test/system/test_seq_copy_sys.py
@@ -195,7 +195,7 @@ SORT_CASES = [
      0.97,
      True),
     ("Sort:transformer:batch_word:bfloat16",
-     "--encoder transformer --decoder ssru_transformer"
+     "--encoder transformer --decoder transformer"
      " --max-seq-len 10 --batch-size 90 --update-interval 1 --batch-type word --batch-sentences-multiple-of 1"
      " --max-updates 6000"
      " --num-layers 2 --transformer-attention-heads 2 --transformer-model-size 32 --num-embed 32"

--- a/test/system/test_seq_copy_sys.py
+++ b/test/system/test_seq_copy_sys.py
@@ -166,7 +166,8 @@ SORT_CASES = [
      "--beam-size 1 --prevent-unk",
      True, 0, 0,
      1.03,
-     0.97),
+     0.97,
+     True),
     ("Sort:transformer:transformer:source_factors:target_factors:batch_max_word",
      "--encoder transformer --decoder transformer"
      " --max-seq-len 10 --batch-size 70 --update-interval 2 --batch-type max-word --batch-sentences-multiple-of 1"
@@ -179,7 +180,8 @@ SORT_CASES = [
      "--beam-size 1",
      True, 3, 1,
      1.03,
-     0.96),
+     0.96,
+     True),
     ("Sort:transformer:ssru_transformer:batch_word",
      "--encoder transformer --decoder ssru_transformer"
      " --max-seq-len 10 --batch-size 90 --update-interval 1 --batch-type word --batch-sentences-multiple-of 1"
@@ -190,14 +192,27 @@ SORT_CASES = [
      "--beam-size 1",
      True, 0, 0,
      1.03,
-     0.97)
+     0.97,
+     True),
+    ("Sort:transformer:batch_word:bfloat16",
+     "--encoder transformer --decoder ssru_transformer"
+     " --max-seq-len 10 --batch-size 90 --update-interval 1 --batch-type word --batch-sentences-multiple-of 1"
+     " --max-updates 6000"
+     " --num-layers 2 --transformer-attention-heads 2 --transformer-model-size 32 --num-embed 32"
+     " --transformer-dropout-attention 0.0 --transformer-dropout-act 0.0 --transformer-dropout-prepost 0.0"
+     " --transformer-feed-forward-num-hidden 64" + COMMON_TRAINING_PARAMS,
+     "--beam-size 1 --dtype bfloat16",
+     True, 0, 0,
+     1.03,
+     0.97,
+     False)
 ]
 
 
 @pytest.mark.parametrize("name, train_params, translate_params, use_prepared_data, n_source_factors, "
-                         "n_target_factors, perplexity_thresh, bleu_thresh", SORT_CASES)
+                         "n_target_factors, perplexity_thresh, bleu_thresh, compare_output", SORT_CASES)
 def test_seq_sort(name, train_params, translate_params, use_prepared_data,
-                  n_source_factors, n_target_factors, perplexity_thresh, bleu_thresh):
+                  n_source_factors, n_target_factors, perplexity_thresh, bleu_thresh, compare_output):
     """Task: sort short sequences of digits"""
     with tmp_digits_dataset("test_seq_sort.",
                             _TRAIN_LINE_COUNT, _TRAIN_LINE_COUNT_EMPTY, _LINE_MAX_LENGTH,
@@ -211,7 +226,7 @@ def test_seq_sort(name, train_params, translate_params, use_prepared_data,
                                      data=data,
                                      use_prepared_data=use_prepared_data,
                                      max_seq_len=_LINE_MAX_LENGTH,
-                                     compare_output=True,
+                                     compare_output=compare_output,
                                      seed=seed)
 
         # get best validation perplexity


### PR DESCRIPTION
#### Changes

This PR brings bfloat16 integration and system testing to all platforms with the following changes:
- The `check_train_translate` test function now correctly passes `compare_output` to `test_translate_equivalence` instead of always passing `True`.
- Integration tests do not compare scoring and translation outputs (original intention).
- System tests optionally compare outputs. All existing system tests compare outputs (default behavior unchanged).
- A new bfloat16 system test does not compare scoring and translation outputs. BLEU score is still checked.

#### Investigation

Integration tests that use `--dtype bfloat16` were failing the score/translate output comparison. This appears to be caused by bfloat16 rounding: different orders of calculations plus reduced precision. For a small digits sorting model:
- Float32 inference with `--batch-size 8` and `--batch-size 1` produce the same scores and translations.
- Bfloat16 inference with `--batch-size 8` and `--batch-size 1` produce different scores (average change of 1.5% with outliers up to 16%) but the same translations.
- This appears to be working as intended: bfloat16 is faster with lower precision that should not significantly change the final outputs. PyTorch has [inherent nondeterminism](https://pytorch.org/docs/stable/notes/randomness.html) that generally does not appear to impact float32 calculations, but does appear to impact some bfloat16 calculations.

This issue was identified when tests using nightly builds of PyTorch 2.0 [failed](https://github.com/awslabs/sockeye/actions/runs/3825897790/jobs/6509235124#step:6:567). It appears that a change in either bfloat16 handling or general algorithms (order of calculations) causes bfloat16 scores to differ between scoring and translation on "Linux" platforms where they were previously identical.

To resolve this, we turn off the scoring/translation comparison for bfloat16 cases. This enables running bfloat16 integration and system tests on both "Linux" and "Darwin".

Thanks @fhieber for reporting this issue!

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

