### PR TITLE
Fixes to blocking cross-attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.34]
+
+### Fixed
+- Do not mask prepended tokens by default (for self-attention).
+- Do not require specifying `--end-of-prepending-tag` if it is already done when preparing the data.
+
 ## [3.1.33]
 
 ### Fixed 

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.33'
+__version__ = '3.1.34'

--- a/sockeye/layers.py
+++ b/sockeye/layers.py
@@ -321,7 +321,7 @@ class DotAttentionCell(pt.nn.Module):
 
 
 def prepare_source_length_mask(lengths: pt.Tensor, heads: int, max_length: int, expand: bool = True,
-                               mask_prepended_tokens: bool = True) -> pt.Tensor:
+                               mask_prepended_tokens: bool = False) -> pt.Tensor:
     """
     Prepare source length masks where positions of invalid tokens are marked as True.
 


### PR DESCRIPTION
Fixes to blocking cross-attention
- Do not mask prepended tokens by default (for self-attention).
- Do not require specifying `--end-of-prepending-tag` if it is already done when preparing the data.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] ~~Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?~~
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [ ] ~~You have considered writing a test~~
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

