### PR TITLE
fix typos in testset names, allow symlinked datadir

### DIFF
--- a/wmt23_data_task_scripts/get_data.sh
+++ b/wmt23_data_task_scripts/get_data.sh
@@ -3,14 +3,15 @@
 set -e
 
 DATA_FOLDER=wmt23_data_task_data
-mkdir -p ${DATA_FOLDER}
+# if no dir or symlinked dir exists -- mkdir one
+[[ -d $DATA_FOLDER || -L $DATA_FOLDER ]] || mkdir -p ${DATA_FOLDER}
 mkdir -p ${DATA_FOLDER}/testsets_v2
 for data_set in dev test
 do
     for test_set in EMEA EUBookshop Europarl JRC-Acquis
     do
         wget -O ${DATA_FOLDER}/testsets_v2/${test_set}.${data_set}.et-lt.lt https://mtdataexternalpublic.blob.core.windows.net/2023datatask/${data_set}/${test_set}.${data_set}.et-lt.lt
-        wget -O ${DATA_FOLDER}/testsets_v2/${test_set}.${data_set}.et-lt.lt https://mtdataexternalpublic.blob.core.windows.net/2023datatask/${data_set}/${test_set}.${data_set}.et-lt.et
+        wget -O ${DATA_FOLDER}/testsets_v2/${test_set}.${data_set}.et-lt.et https://mtdataexternalpublic.blob.core.windows.net/2023datatask/${data_set}/${test_set}.${data_set}.et-lt.et
     done
 done
 

--- a/wmt23_data_task_scripts/run_eval.py
+++ b/wmt23_data_task_scripts/run_eval.py
@@ -1,3 +1,4 @@
+#!/usr//bin/env python3
 import subprocess
 import os
 import sys
@@ -15,10 +16,12 @@ from contextlib import ExitStack
 import math
 import sacrebleu
 
-TEST_SETS = ["EMEA", "EUbookshop", "Europarl", "JRC-Acquis"]
+TEST_SETS = ["EMEA", "EUBookshop", "Europarl", "JRC-Acquis"]
 
 # Create a logger with basic logging
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s,%(msecs)03d %(levelname)s [%(filename)s:%(lineno)d] %(message)s',
+                    datefmt='%Y-%m-%d:%H:%M:%S',)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
* Fix minor typos in testset names for wmt23_data_task scripts
* $DATA_FOLDER can be a symlink (e.g., to a shared filesystem), in that case it won't try to mkdir $DATA_FOLDER

#### Pull Request Checklist ##
- [x] Changes are complete


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
