### PR TITLE
Use fault tolerant symlink during training to handle temporary file system inconsistencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 ### Fixed
 
 - Use fault tolerant symlink wrapper function during training to handle cases of temporary inconsistency in distributed file systems.
-- Updated DeepSpeed requirement file to specify version (`deepspeed<0.9`).
+- Update DeepSpeed requirement file to specify version (`deepspeed<0.9`).
 
 ## [3.1.34]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 ### Fixed
 
 - Use fault tolerant symlink wrapper function during training to handle cases of temporary inconsistency in distributed file systems.
+- Updated DeepSpeed requirement file to specify version (`deepspeed<0.9`).
 
 ## [3.1.34]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 ### Fixed
 
 - Use fault tolerant symlink wrapper function during training to handle cases of temporary inconsistency in distributed file systems.
-- Update DeepSpeed requirement file to specify version (`deepspeed<0.9`).
+- Update DeepSpeed requirement file to specify version (`deepspeed==0.6.5`).
 
 ## [3.1.34]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.35]
+
+### Fixed
+
+- Use fault tolerant symlink wrapper function during training to handle cases of temporary inconsistency in distributed file systems.
+
 ## [3.1.34]
 
 ### Fixed
@@ -19,7 +25,7 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 
 ## [3.1.33]
 
-### Fixed 
+### Fixed
 - Two small fixes to SampleK. Before the device was not set correctly leading to issues when running sampling on GPUs. Furthermore, SampleK did not return the top-k values correctly.
 
 ## [3.1.32]

--- a/requirements/requirements.deepspeed.txt
+++ b/requirements/requirements.deepspeed.txt
@@ -1,1 +1,1 @@
-deepspeed
+deepspeed<0.9

--- a/requirements/requirements.deepspeed.txt
+++ b/requirements/requirements.deepspeed.txt
@@ -1,1 +1,1 @@
-deepspeed<0.9
+deepspeed==0.6.5

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.34'
+__version__ = '3.1.35'

--- a/sockeye/training.py
+++ b/sockeye/training.py
@@ -634,7 +634,7 @@ class EarlyStoppingTrainer:
         actual_best_params_fname = C.PARAMS_NAME % self.state.best_checkpoint
         if os.path.lexists(self.best_params_fname):
             os.remove(self.best_params_fname)
-        os.symlink(actual_best_params_fname, self.best_params_fname)
+        utils.fault_tolerant_symlink(actual_best_params_fname, self.best_params_fname)
         logger.info("'%s' now points to '%s'", self.best_params_fname, actual_best_params_fname)
 
     def _save_params(self, use_checkpoint: bool = False):
@@ -709,7 +709,7 @@ class EarlyStoppingTrainer:
             params_file = os.path.join(training_state_dirname, C.TRAINING_STATE_PARAMS_NAME)
             if os.path.exists(params_file):
                 os.unlink(params_file)
-            os.symlink(os.path.join("..", params_base_fname), params_file)
+            utils.fault_tolerant_symlink(os.path.join("..", params_base_fname), params_file)
 
             # (2) Optimizer state
             opt_state_fname = os.path.join(training_state_dirname, C.OPT_STATE_LAST)

--- a/sockeye/utils.py
+++ b/sockeye/utils.py
@@ -820,7 +820,7 @@ def init_device(args: argparse.Namespace) -> pt.device:
     return device
 
 
-def fault_tolerant_symlink(src: str, dst: str, max_retries: int = 5):
+def fault_tolerant_symlink(src: str, dst: str, max_retries: int = 6):
     """
     Attempt to create a symbolic link from source to destination. If a
     FileExistsError is raised, assume a distributed filesystem is currently

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -441,7 +441,7 @@ def test_fault_tolerant_symlink(mock_sleep):
         utils.fault_tolerant_symlink(src_fname, dst_fname)
         # Second symlink fails after retries (file exists)
         with pytest.raises(OSError):
-            utils.fault_tolerant_symlink(src_fname, dst_fname, max_retries=5)
+            utils.fault_tolerant_symlink(src_fname, dst_fname)
         assert mock_sleep.called
         # Same data read from source and destination
         with utils.smart_open(src_fname) as src_in, utils.smart_open(dst_fname) as dst_in:


### PR DESCRIPTION
Distributed file systems are not always synchronous. For example, a deleted file may still appear to be present until the file system synchronizes. This can cause `FileExistsError`s during training when updating symlinks to the best/current parameter files.

This pull request adds and applies a fault tolerant symlink wrapper that makes multiple attempts before raising an `OSError`. By default, 6 attempts are made over the course of 63 seconds. This should prevent brief file system inconsistencies from causing errors during parameter file symlink updates.

Unrelated: The latest version of `deepspeed` is not compatible with our current usage. The requirement is updated to `deepspeed==0.6.5`.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

