### PR TITLE
Refactor inference optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.36]
+
+### Changed
+
+- Make the `inference_only` mode switchable.
+- Simplify inference optimizations by
+  (1) using `eval()` to disable dropout instead of explicitly setting dropout modules to None;
+  (2) always using default value `inplace=False` for activation modules.
+
 ## [3.1.35]
 
 ### Fixed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017--2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017--2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.35'
+__version__ = '3.1.36'

--- a/sockeye/config.py
+++ b/sockeye/config.py
@@ -1,4 +1,4 @@
-# Copyright 2017--2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017--2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -83,15 +83,3 @@ class Config(yaml.YAMLObject, metaclass=TaggedYamlObjectMetaclass):
         for name, value in kwargs.items():
             object.__setattr__(copy_obj, name, value)
         return copy_obj
-
-    def disable_dropout(self):
-        """
-        Sets the value of all float-valued attributes in this config (or any of its children) that contain 'dropout'
-        in their name to 0.0.
-        """
-        for attr, val in self.__dict__.items():
-            if isinstance(val, Config):
-                val.disable_dropout()
-            elif 'dropout' in attr and isinstance(val, float):
-                logger.debug("Setting %s to 0.0", attr)
-                setattr(self, attr, 0.0)

--- a/sockeye/encoder.py
+++ b/sockeye/encoder.py
@@ -1,4 +1,4 @@
-# Copyright 2017--2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017--2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -116,7 +116,7 @@ class Embedding(Encoder):
                 self.factor_embeds.append(factor_embed)
                 self.factor_combinations.append(fc.combine)
 
-        self.dropout = pt.nn.Dropout(p=self.config.dropout) if self.config.dropout > 0.0 else None
+        self.dropout = pt.nn.Dropout(p=self.config.dropout)
 
     def forward(self, data: pt.Tensor) -> pt.Tensor:
         primary_data = data[:, :, 0]
@@ -177,7 +177,7 @@ class TransformerEncoder(Encoder):
         pt.nn.Module.__init__(self)
         self.config = config
 
-        self.dropout = pt.nn.Dropout(p=config.dropout_prepost) if config.dropout_prepost > 0.0 else None
+        self.dropout = pt.nn.Dropout(p=config.dropout_prepost)
 
         self.pos_embedding = layers.PositionalEmbeddings(weight_type=self.config.positional_embedding_type,
                                                          num_embed=self.config.model_size,

--- a/sockeye/transformer.py
+++ b/sockeye/transformer.py
@@ -1,4 +1,4 @@
-# Copyright 2017--2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017--2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -133,6 +133,7 @@ class TransformerDecoderBlock(pt.nn.Module):
                  clamp_to_dtype: bool = False) -> None:
         super().__init__()
         self.decoder_type = config.decoder_type
+        self.inference_only = inference_only
 
         self.autoregr_layer = None
         if self.decoder_type == C.TRANSFORMER_TYPE:
@@ -202,6 +203,14 @@ class TransformerDecoderBlock(pt.nn.Module):
         self.lhuc = None
         if config.use_lhuc:
             self.lhuc = sockeye.layers.LHUC(config.model_size, dtype=dtype)
+
+    def set_inference_only(self, inference_only: bool):
+        """
+        Set inference_only.
+        """
+        self.inference_only = inference_only
+        if self.decoder_type == C.SSRU_TRANSFORMER:
+            self.autoregr_layer.set_inference_only(inference_only)
 
     @property
     def num_state_tensors(self) -> int:
@@ -275,8 +284,7 @@ class TransformerProcessBlock(pt.nn.Module):
             # https://github.com/huggingface/transformers/issues/9377
             self.layer_norm = pt.nn.LayerNorm(num_hidden, eps=1e-06, dtype=dtype)
         self.dropout = dropout
-        if dropout > 0.0:
-            self.drop = pt.nn.Dropout(p=dropout)
+        self.drop = pt.nn.Dropout(p=dropout)
 
     def forward(self, data: pt.Tensor, prev: Optional[pt.Tensor] = None) -> pt.Tensor:
         """
@@ -301,8 +309,7 @@ class TransformerProcessBlock(pt.nn.Module):
                 data = self.layer_norm(data)
 
             elif step == "d":
-                if self.dropout > 0.0:
-                    data = self.drop(data)
+                data = self.drop(data)
             else:
                 raise ValueError("Unknown step in sequence: %s" % step)
 
@@ -324,15 +331,13 @@ class TransformerFeedForward(pt.nn.Module):
                  dtype: Optional[pt.dtype] = None,
                  clamp_to_dtype: bool = False) -> None:
         super().__init__()
-        self.dropout = dropout
         self.use_glu = use_glu
         self.clamp_to_dtype = clamp_to_dtype
         self.ff1 = pt.nn.Linear(in_features=num_model, out_features=num_hidden, dtype=dtype)
-        self.act = sockeye.layers.get_activation(act_type, inplace=inference_only)
+        self.act = sockeye.layers.get_activation(act_type)
         if self.use_glu:
             self.linear = pt.nn.Linear(in_features=num_model, out_features=num_hidden, dtype=dtype)
-        if self.dropout > 0.0:
-            self.drop = pt.nn.Dropout(p=self.dropout, inplace=inference_only)
+        self.drop = pt.nn.Dropout(p=dropout)
         self.ff2 = pt.nn.Linear(in_features=num_hidden, out_features=num_model, dtype=dtype)
 
     def forward(self, x):
@@ -340,8 +345,7 @@ class TransformerFeedForward(pt.nn.Module):
         h = self.act(h)
         if self.use_glu:
             h = h * self.linear(x)
-        if self.dropout > 0.0:
-            h = self.drop(h)
+        h = self.drop(h)
         y = self.ff2(h)
         if self.clamp_to_dtype:
             y = sockeye.layers.clamp_to_dtype_min_max(y)


### PR DESCRIPTION
This PR refactors inference optimizations:
- Make the `inference_only` mode switchable.
- Simplify inference optimizations by
  (1) using `eval()` to disable dropout instead of explicitly setting dropout modules to None;
  (2) always using default value `inplace=False` for activation modules.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [ ] ~~Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?~~
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [ ] ~~You have considered writing a test~~
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

