### PR TITLE
beam_search fix for running with torch.use_deterministic_algorithms(True)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.37]
+
+### Fixed
+
+- Fixed beam_search for running with torch.use_deterministic_algorithms(True)
+
 ## [3.1.36]
 
 ### Changed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.36'
+__version__ = '3.1.37'

--- a/sockeye/beam_search.py
+++ b/sockeye/beam_search.py
@@ -905,7 +905,7 @@ class BeamSearch(Search):
         # locations of each batch item when first dimension is (batch * beam)
         batch_indices = pt.arange(0, batch_size * self.beam_size, self.beam_size, dtype=pt.int64, device=self.device)
         first_step_mask = pt.full((batch_size * self.beam_size, 1), fill_value=np.inf, device=self.device, dtype=self.dtype)
-        first_step_mask[batch_indices] = 0.0
+        first_step_mask[batch_indices] = pt.full((batch_size, 1), fill_value=0.0, device=self.device, dtype=self.dtype)
         if target_prefix is not None:
             first_step_mask = utils.adjust_first_step_masking(target_prefix, first_step_mask)
 


### PR DESCRIPTION
Context:
Pytorch has some bugs related to setting values for tensors to scalars when using torch.use_deterministic_algorithms(True) that were only addressed in most recent Pytorch versions. See:
* https://github.com/pytorch/pytorch/commit/2d4b1ae434d28ed66b3c96cd47e21d648bd6a0b8
* https://github.com/pytorch/pytorch/issues/68525

The scalar attribution in beam_search.forward would throw:
```
    RuntimeError: linearIndex.numel()*sliceSize*nElemBefore == value.numel()INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/native/cuda/Indexing.cu":250, please report a bug to PyTorch. number of flattened indices did not match number of elements in the value tensor31
```
when running with torch.use_deterministic_algorithms(True).

The change in the PR did not have any changes in performance, but works around the 2 bugs mentioned above.

Testing done:
* Ran with a custom model, using `torch.use_deterministic_algorithms(True)`

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x]  Unit tests pass (`pytest`)
- [x] Were system tests modified? If so did you run these at least 5 times to account for the variation across runs?
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] You have considered writing a test
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

