### PR TITLE
Allow easier programmatic use by extracting code from `translate.py`

### DIFF
--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -24,10 +24,10 @@ from typing import Dict, Generator, List, Optional, Union
 
 from sockeye.lexicon import load_restrict_lexicon, RestrictLexicon
 from sockeye.log import setup_main_logger
-from sockeye.model import load_models
+from sockeye.model import load_models, SockeyeModel
 from sockeye.output_handler import get_output_handler, OutputHandler
 from sockeye.utils import log_basic_info, check_condition, grouper, smart_open, seed_rngs
-from . import arguments
+from . import arguments, vocab
 from . import constants as C
 from . import inference
 from . import utils
@@ -35,11 +35,115 @@ from . import utils
 logger = logging.getLogger(__name__)
 
 
-def main():
+def parse_translation_arguments(args=None):
     params = arguments.ConfigArgumentParser(description='Translate CLI')
     arguments.add_translate_cli_args(params)
-    args = params.parse_args()
+    return params.parse_args(args)
+
+
+def main():
+    args = parse_translation_arguments()
     run_translate(args)
+
+
+def load_models_from_args(args: argparse.Namespace):
+    device = utils.init_device(args)
+
+    models, source_vocabs, target_vocabs = load_models(device=device,
+                                                       model_folders=args.models,
+                                                       checkpoints=args.checkpoints,
+                                                       dtype=args.dtype,
+                                                       clamp_to_dtype=args.clamp_to_dtype,
+                                                       inference_only=True,
+                                                       knn_index=args.knn_index)
+
+    for model in models:
+        model.eval()
+
+    return models, source_vocabs, target_vocabs
+
+
+def restrict_lexicon_from_args(args: argparse.Namespace,
+                               source_vocabs: List[vocab.Vocab],
+                               target_vocabs: List[vocab.Vocab]):
+    restrict_lexicon = None  # type: Optional[Union[RestrictLexicon, Dict[str, RestrictLexicon]]]
+    if args.restrict_lexicon is not None:
+        logger.info(str(args.restrict_lexicon))
+        if len(args.restrict_lexicon) == 1:
+            # Single lexicon used for all inputs.
+            # Handle a single arg of key:path or path (parsed as path:path)
+            restrict_lexicon = load_restrict_lexicon(args.restrict_lexicon[0][1], source_vocabs[0], target_vocabs[0],
+                                                     k=args.restrict_lexicon_topk)
+            logger.info(f"Loaded a single lexicon ({args.restrict_lexicon[0][0]}) that will be applied to all inputs.")
+        else:
+            check_condition(args.json_input,
+                            "JSON input is required when using multiple lexicons for vocabulary restriction")
+            # Multiple lexicons with specified names
+            restrict_lexicon = dict()
+            for key, path in args.restrict_lexicon:
+                lexicon = load_restrict_lexicon(path, source_vocabs[0], target_vocabs[0], k=args.restrict_lexicon_topk)
+                restrict_lexicon[key] = lexicon
+
+    return restrict_lexicon
+
+
+def load_scorer_from_args(args: argparse.Namespace, models: List[SockeyeModel]):
+    brevity_penalty_weight = args.brevity_penalty_weight
+    if args.brevity_penalty_type == C.BREVITY_PENALTY_CONSTANT:
+        if args.brevity_penalty_constant_length_ratio > 0.0:
+            constant_length_ratio = args.brevity_penalty_constant_length_ratio
+        else:
+            constant_length_ratio = sum(model.length_ratio_mean for model in models) / len(models)
+            logger.info("Using average of constant length ratios saved in the model configs: %f",
+                        constant_length_ratio)
+    elif args.brevity_penalty_type == C.BREVITY_PENALTY_LEARNED:
+        constant_length_ratio = -1.0
+    elif args.brevity_penalty_type == C.BREVITY_PENALTY_NONE:
+        brevity_penalty_weight = 0.0
+        constant_length_ratio = -1.0
+    else:
+        raise ValueError("Unknown brevity penalty type %s" % args.brevity_penalty_type)
+
+    scorer = inference.CandidateScorer(
+        length_penalty_alpha=args.length_penalty_alpha,
+        length_penalty_beta=args.length_penalty_beta,
+        brevity_penalty_weight=brevity_penalty_weight)
+    scorer.to(models[0].dtype)
+
+    return scorer, constant_length_ratio
+
+
+def load_translator_from_args(args: argparse.Namespace, output_scores: bool):
+    device = utils.init_device(args)
+    logger.info(f"Translate Device: {device}")
+
+    models, source_vocabs, target_vocabs = load_models_from_args(args)
+    restrict_lexicon = restrict_lexicon_from_args(args, source_vocabs, target_vocabs)
+    scorer, constant_length_ratio = load_scorer_from_args(args, models)
+
+    return inference.Translator(device=device,
+                                ensemble_mode=args.ensemble_mode,
+                                scorer=scorer,
+                                batch_size=args.batch_size,
+                                beam_size=args.beam_size,
+                                beam_search_stop=args.beam_search_stop,
+                                nbest_size=args.nbest_size,
+                                models=models,
+                                source_vocabs=source_vocabs,
+                                target_vocabs=target_vocabs,
+                                restrict_lexicon=restrict_lexicon,
+                                strip_unknown_words=args.strip_unknown_words,
+                                sample=args.sample,
+                                output_scores=output_scores,
+                                constant_length_ratio=constant_length_ratio,
+                                knn_lambda=args.knn_lambda,
+                                max_output_length_num_stds=args.max_output_length_num_stds,
+                                max_input_length=args.max_input_length,
+                                max_output_length=args.max_output_length,
+                                prevent_unk=args.prevent_unk,
+                                greedy=args.greedy,
+                                skip_nvs=args.skip_nvs,
+                                nvs_thresh=args.nvs_thresh)
 
 
 def run_translate(args: argparse.Namespace):
@@ -65,83 +169,7 @@ def run_translate(args: argparse.Namespace):
     output_handler = get_output_handler(args.output_type,
                                         args.output)
 
-    device = utils.init_device(args)
-    logger.info(f"Translate Device: {device}")
-
-    models, source_vocabs, target_vocabs = load_models(device=device,
-                                                       model_folders=args.models,
-                                                       checkpoints=args.checkpoints,
-                                                       dtype=args.dtype,
-                                                       clamp_to_dtype=args.clamp_to_dtype,
-                                                       inference_only=True,
-                                                       knn_index=args.knn_index)
-
-    restrict_lexicon = None  # type: Optional[Union[RestrictLexicon, Dict[str, RestrictLexicon]]]
-    if args.restrict_lexicon is not None:
-        logger.info(str(args.restrict_lexicon))
-        if len(args.restrict_lexicon) == 1:
-            # Single lexicon used for all inputs.
-            # Handle a single arg of key:path or path (parsed as path:path)
-            restrict_lexicon = load_restrict_lexicon(args.restrict_lexicon[0][1], source_vocabs[0], target_vocabs[0],
-                                                     k=args.restrict_lexicon_topk)
-            logger.info(f"Loaded a single lexicon ({args.restrict_lexicon[0][0]}) that will be applied to all inputs.")
-        else:
-            check_condition(args.json_input,
-                            "JSON input is required when using multiple lexicons for vocabulary restriction")
-            # Multiple lexicons with specified names
-            restrict_lexicon = dict()
-            for key, path in args.restrict_lexicon:
-                lexicon = load_restrict_lexicon(path, source_vocabs[0], target_vocabs[0], k=args.restrict_lexicon_topk)
-                restrict_lexicon[key] = lexicon
-
-    brevity_penalty_weight = args.brevity_penalty_weight
-    if args.brevity_penalty_type == C.BREVITY_PENALTY_CONSTANT:
-        if args.brevity_penalty_constant_length_ratio > 0.0:
-            constant_length_ratio = args.brevity_penalty_constant_length_ratio
-        else:
-            constant_length_ratio = sum(model.length_ratio_mean for model in models) / len(models)
-            logger.info("Using average of constant length ratios saved in the model configs: %f",
-                        constant_length_ratio)
-    elif args.brevity_penalty_type == C.BREVITY_PENALTY_LEARNED:
-        constant_length_ratio = -1.0
-    elif args.brevity_penalty_type == C.BREVITY_PENALTY_NONE:
-        brevity_penalty_weight = 0.0
-        constant_length_ratio = -1.0
-    else:
-        raise ValueError("Unknown brevity penalty type %s" % args.brevity_penalty_type)
-
-    for model in models:
-        model.eval()
-
-    scorer = inference.CandidateScorer(
-        length_penalty_alpha=args.length_penalty_alpha,
-        length_penalty_beta=args.length_penalty_beta,
-        brevity_penalty_weight=brevity_penalty_weight)
-    scorer.to(models[0].dtype)
-
-    translator = inference.Translator(device=device,
-                                      ensemble_mode=args.ensemble_mode,
-                                      scorer=scorer,
-                                      batch_size=args.batch_size,
-                                      beam_size=args.beam_size,
-                                      beam_search_stop=args.beam_search_stop,
-                                      nbest_size=args.nbest_size,
-                                      models=models,
-                                      source_vocabs=source_vocabs,
-                                      target_vocabs=target_vocabs,
-                                      restrict_lexicon=restrict_lexicon,
-                                      strip_unknown_words=args.strip_unknown_words,
-                                      sample=args.sample,
-                                      output_scores=output_handler.reports_score(),
-                                      constant_length_ratio=constant_length_ratio,
-                                      knn_lambda=args.knn_lambda,
-                                      max_output_length_num_stds=args.max_output_length_num_stds,
-                                      max_input_length=args.max_input_length,
-                                      max_output_length=args.max_output_length,
-                                      prevent_unk=args.prevent_unk,
-                                      greedy=args.greedy,
-                                      skip_nvs=args.skip_nvs,
-                                      nvs_thresh=args.nvs_thresh)
+    translator = load_translator_from_args(args, output_handler.reports_score())
 
     read_and_translate(translator=translator,
                        output_handler=output_handler,


### PR DESCRIPTION
Running sockeye models programmatically is desired (serving models) but is difficult.

You have to know what you are doing, and how to initialize the inference `Translator` class, among all other classes.
This was done by you already in `translate.py`, the CLI tool you made for translation, and so I was thinking to extract the code from the `translate.py` functionality and allow programatic access.

This PR makes it possible to run sockeye code by using the same arguments as the CLI tool, thus allowing easy use and reuse of the translator.
```py
from sockeye.translate import parse_translation_arguments, load_translator_from_args
from sockeye.inference import make_input_from_factored_string

args = parse_translation_arguments(["-m", model_path])
translator = load_translator_from_args(args, True)
strings = ["my|PRP name|NN is|VBZ John|NN"]
inputs = [inference.make_input_from_factored_string(sentence_id=i,
                                                    factored_string=s,
                                                    translator=translator)
          for i, s in enumerate(strings)]
outputs = translator.translate(inputs)
```


#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [ ] Unit tests pass (`pytest`)
```txt
no, but i suspect it is because i am using a mac
```
- [ ] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
```txt
************* Module sockeye.layers
sockeye/layers.py:766:28: E1136: Value 'self.weight.unsqueeze(0)' is unsubscriptable (unsubscriptable-object)
pylint: Command line or configuration file:1: UserWarning: 'Exception' is not a proper value for the 'overgeneral-exceptions' option. Use fully qualified name (maybe 'builtins.Exception' ?) instead. This will cease to be checked at runtime when the configuration upgrader is released.
************* Module test.unit.test_deepspeed
test/unit/test_deepspeed.py:27:4: E0401: Unable to import 'deepspeed' (import-error)
./style-check.sh: line 14: mypy: command not found
```
- [x] You have considered writing a test
- [ ] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [ ] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

