### PR TITLE
Use `weights_only=True` when loading SockeyeModel parameters.

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8]
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-12]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/torch_nightly.yml
+++ b/.github/workflows/torch_nightly.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8]
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-12]
       
     # The type of runner that the job will run on
     runs-on: ${{ matrix.platform }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Note that Sockeye has checks in place to not translate with an old model that wa
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [3.1.38]
+
+### Fixed
+
+- Set `weights_only=True` when loading `SockeyeModel` parameters.
+
 ## [3.1.37]
 
 ### Fixed

--- a/sockeye/__init__.py
+++ b/sockeye/__init__.py
@@ -11,4 +11,4 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-__version__ = '3.1.37'
+__version__ = '3.1.38'

--- a/sockeye/model.py
+++ b/sockeye/model.py
@@ -449,7 +449,7 @@ class SockeyeModel(pt.nn.Module):
         utils.check_condition(os.path.exists(filename), "No model parameter file found under %s. "
                                                         "This is either not a model directory or the first training "
                                                         "checkpoint has not happened yet." % filename)
-        state_dict = pt.load(filename, map_location=device)
+        state_dict = pt.load(filename, weights_only=True, map_location=device)
         missing, unexpected = self.load_state_dict(state_dict, strict=False)
         # Earlier versions of Sockeye may have saved parameters for traced
         # modules. These parameters can be safely ignored.


### PR DESCRIPTION
Use `weights_only=True` when loading SockeyeModel parameters. From [torch.load documentation](https://pytorch.org/docs/stable/generated/torch.load.html):
> [torch.load()](https://pytorch.org/docs/stable/generated/torch.load.html#torch.load) unless weights_only parameter is set to True, uses pickle module implicitly, which is known to be insecure.

#### Pull Request Checklist ##
- [x] Changes are complete (if posting work-in-progress code, prefix your pull request title with '[WIP]'
until you can check this box.
- [x] Unit tests pass (`pytest`)
- [x] System tests pass (`pytest test/system`)
- [x] Passed code style checking (`./style-check.sh`)
- [x] Updated major/minor version in `sockeye/__init__.py`. Major version bump if this is a backwards incompatible change.
- [x] Updated CHANGELOG.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

